### PR TITLE
removed cockroach-lb from env.dev

### DIFF
--- a/.env.dev
+++ b/.env.dev
@@ -56,7 +56,7 @@ CAMPAIGN_GRPC_PORT=4060
 ## Database ##
 ##############
 
-DB_HOST=roach-lb
+DB_HOST=roach-0
 DB_USER=root
 DB_PASS=
 DB_PORT=26257

--- a/.env.example
+++ b/.env.example
@@ -56,7 +56,7 @@ CAMPAIGN_GRPC_PORT=4060
 ## Database ##
 ##############
 
-DB_HOST=roach-lb
+DB_HOST=roach-0
 DB_USER=root
 DB_PASS=
 DB_PORT=26257

--- a/backend/contact/Dockerfile
+++ b/backend/contact/Dockerfile
@@ -1,5 +1,5 @@
 # Base Stage
-FROM golang:1.15-alpine as base
+FROM golang:1.16-alpine as base
 ARG APP_PATH=/app
 ARG DB_MIGRATIONS_PATH=/db/migrations
 WORKDIR $APP_PATH

--- a/backend/contact/api/config/config.go
+++ b/backend/contact/api/config/config.go
@@ -1,11 +1,7 @@
 package config
 
 import (
-	"fmt"
-	"os"
-
 	"github.com/spf13/viper"
-
 	"github.com/gofiber/fiber/v2"
 )
 
@@ -28,17 +24,11 @@ func New() *Config {
 	config.SetConfigType("dotenv")
 	config.AddConfigPath(".")
 
-	// Automatically refresh environment variables
+	// Automatically update environment variables
+	// Note: This will load the env variables from the container into the config. 
+	// Note: The .env file is passed to the ENV from the docker-compose env_file parameter
 	config.AutomaticEnv()
-
-	// Read configuration
-	if err := config.ReadInConfig(); err != nil {
-		if _, ok := err.(viper.ConfigFileNotFoundError); !ok {
-			fmt.Println("failed to read configuration:", err.Error())
-			os.Exit(1)
-		}
-	}
-
+	
 	return config
 }
 
@@ -47,6 +37,9 @@ func (config *Config) SetErrorHandler(errorHandler fiber.ErrorHandler) {
 }
 
 func (config *Config) setDefaults() {
+	//Note: These are needed only for debug reasons
+	//Note: They will be updated by the call to config.AutomaticEnv()
+
 	// Set default App configuration
 	config.SetDefault("APP_ADDR", ":5000")
 	config.SetDefault("APP_ENV", "local")

--- a/backend/contact/database/database.go
+++ b/backend/contact/database/database.go
@@ -36,7 +36,7 @@ func New(config *DatabaseConfig) (*Database, error) {
 		" sslrootcert=" + config.RootCert +
 		" sslcert=" + config.Cert +
 		" sslkey=" + config.Key
-	println(dsn)
+
 	db, err = gorm.Open(postgres.Open(dsn), &gorm.Config{})
 	return &Database{db}, err
 }

--- a/backend/contact/main.go
+++ b/backend/contact/main.go
@@ -65,7 +65,7 @@ func (app *App) initDatabase() *database.Database {
 		panic("Failed to connect database")
 	}
 
-	fmt.Println("Connection Opened to Database")
+	fmt.Println("Connection Opened to Database host:", app.env.GetString("DB_HOST"), ", port:", app.env.GetInt("DB_PORT"))
 
 	// Add schema prefix to table
 	// db.Table("app.contacts").AutoMigrate(&contact.Contact{})

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -46,14 +46,3 @@ services:
       dockerfile: ./flyway/Dockerfile
     volumes:
       - ./db/migrations:/flyway/sql
-
-  roach-0:
-    image: cockroachdb/cockroach:latest
-    container_name: ${COMPOSE_PROJECT_NAME?}-roach-0
-    restart: always
-    hostname: roach-0
-    command: start-single-node --insecure --listen-addr=roach-0:${DB_PORT} 
-    volumes:
-      - roach-0-data:/cockroach/cockroach-data
-    networks:
-      - backend-net

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -40,15 +40,20 @@ services:
     ports:
       - "${CAMPAIGN_GRPC_PORT?}:5001"
 
-  roach-lb:
-    ports:
-      - "${DB_PORT?}:26257"
-      - "3080:8080"
-      - "3081:8081"
-
   flyway:
     build:
       context: .
       dockerfile: ./flyway/Dockerfile
     volumes:
       - ./db/migrations:/flyway/sql
+
+  roach-0:
+    image: cockroachdb/cockroach:latest
+    container_name: ${COMPOSE_PROJECT_NAME?}-roach-0
+    restart: always
+    hostname: roach-0
+    command: start-single-node --insecure --listen-addr=roach-0:${DB_PORT} 
+    volumes:
+      - roach-0-data:/cockroach/cockroach-data
+    networks:
+      - backend-net

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -24,8 +24,8 @@ services:
     container_name: ${COMPOSE_PROJECT_NAME?}-roach-0
     restart: always
     hostname: roach-0
-    command: start-single-node --insecure --listen-addr=roach-0:${DB_PORT} 
-    # command: start-single-node --cluster-name=dp-crdb-cluster --logtostderr=WARNING --log-file-verbosity=WARNING --listen-addr=roach-0:26257 --advertise-addr=roach-0:26257 --certs-dir=/certs
+    command: start --insecure --listen-addr=${DB_HOST?}:${DB_PORT?} 
+    # command: start --cluster-name=dp-crdb-cluster --logtostderr=WARNING --log-file-verbosity=WARNING --listen-addr=roach-0:26257 --advertise-addr=roach-0:26257 --certs-dir=/certs
     volumes:
       - roach-0-data:/cockroach/cockroach-data
     #   - certs-roach-0:/certs
@@ -34,31 +34,26 @@ services:
     networks:
       - backend-net
 
-  roach-lb:
-    # https://github.com/cockroachlabs-field/dynamic-haproxy
-    image: timveil/dynamic-haproxy:latest
-    container_name: ${COMPOSE_PROJECT_NAME?}-roach-lb
+  roach-1:
+    image: cockroachdb/cockroach:latest
+    container_name: ${COMPOSE_PROJECT_NAME?}-roach-1
     restart: always
-    hostname: roach-lb
-    environment:
-      - NODES=roach-0
-      # - NODES=roach-0 roach-1 roach-2
-    ports:
-        - "${DB_PORT?}:26257"
-        - "3080:8080"
-        - "3081:8081"
-    networks:
-      - backend-net
+    hostname: roach-1
+    command: start --insecure --join=roach-0
+    # command: start --cluster-name=dp-crdb-cluster --logtostderr=WARNING --log-file-verbosity=WARNING --certs-dir=/certs
+    volumes:
+      - roach-1-data:/cockroach/cockroach-data
+    #   - certs-roach-0:/certs
     depends_on:
       - roach-0
-    healthcheck:
-      test: /bin/true
-      interval: 3s
-      timeout: 10s
-      retries: 10
+    #   - roach-cert
+    networks:
+      - backend-net
+
+volumes:
+  roach-1-data:
 
 networks:
   pub1:
     external: true
-
 

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -11,6 +11,54 @@ services:
       pub1:
         ipv4_address: ${API_IPV4_ADDRESS?}
 
+# roach-cert:
+#   container_name: roach-cert
+#   hostname: roach-cert
+#   build: db/cert
+#   volumes:
+#     - certs-roach-0:/certs/roach-0
+#     - certs-client:/certs/client
+
+  roach-0:
+    image: cockroachdb/cockroach:latest
+    container_name: ${COMPOSE_PROJECT_NAME?}-roach-0
+    restart: always
+    hostname: roach-0
+    command: start-single-node --insecure --listen-addr=roach-0:${DB_PORT} 
+    # command: start-single-node --cluster-name=dp-crdb-cluster --logtostderr=WARNING --log-file-verbosity=WARNING --listen-addr=roach-0:26257 --advertise-addr=roach-0:26257 --certs-dir=/certs
+    volumes:
+      - roach-0-data:/cockroach/cockroach-data
+    #   - certs-roach-0:/certs
+    # depends_on:
+    #   - roach-cert
+    networks:
+      - backend-net
+
+  roach-lb:
+    # https://github.com/cockroachlabs-field/dynamic-haproxy
+    image: timveil/dynamic-haproxy:latest
+    container_name: ${COMPOSE_PROJECT_NAME?}-roach-lb
+    restart: always
+    hostname: roach-lb
+    environment:
+      - NODES=roach-0
+      # - NODES=roach-0 roach-1 roach-2
+    ports:
+        - "${DB_PORT?}:26257"
+        - "3080:8080"
+        - "3081:8081"
+    networks:
+      - backend-net
+    depends_on:
+      - roach-0
+    healthcheck:
+      test: /bin/true
+      interval: 3s
+      timeout: 10s
+      retries: 10
+
 networks:
   pub1:
     external: true
+
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -81,24 +81,12 @@ services:
     container_name: ${COMPOSE_PROJECT_NAME?}-roach-0
     restart: always
     hostname: roach-0
-    command: start-single-node --insecure --listen-addr=roach-0:${DB_PORT} 
-    # command: start-single-node --cluster-name=dp-crdb-cluster --logtostderr=WARNING --log-file-verbosity=WARNING --listen-addr=roach-0:26257 --advertise-addr=roach-0:26257 --certs-dir=/certs
+    command: start-single-node --insecure --listen-addr=${DB_HOST?}:${DB_PORT?} 
     volumes:
       - roach-0-data:/cockroach/cockroach-data
-    #   - certs-roach-0:/certs
-    # depends_on:
-    #   - roach-cert
     networks:
       - backend-net
-
-  # roach-cert:
-  #   container_name: roach-cert
-  #   hostname: roach-cert
-  #   build: db/cert
-  #   volumes:
-  #     - certs-roach-0:/certs/roach-0
-  #     - certs-client:/certs/client
-
+  
   roach-init:
     container_name: ${COMPOSE_PROJECT_NAME?}-roach-init
     hostname: roach-init
@@ -108,7 +96,7 @@ services:
       DATABASE_NAME: ${DB_NAME?}
       DATABASE_USER: ${DB_USER?}
       DATABASE_PASSWORD: ${DB_PASS?}
-      COCKROACH_HOST: roach-0
+      COCKROACH_HOST: ${DB_HOST?}
       COCKROACH_PORT: ${DB_PORT?}
       COCKROACH_DATABASE: ${DB_NAME?}
       COCKROACH_INSECURE: "true"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,6 +40,8 @@ services:
     image: ${API_DEPLOY_IMAGE}:${DEPLOY_TAG?}
     container_name: ${COMPOSE_PROJECT_NAME?}-api
     restart: always
+    env_file: 
+      - .env
     networks:
       backend-net:
         aliases:
@@ -79,7 +81,7 @@ services:
     container_name: ${COMPOSE_PROJECT_NAME?}-roach-0
     restart: always
     hostname: roach-0
-    command: start-single-node --cluster-name=dp-crdb-cluster --logtostderr=WARNING --log-file-verbosity=WARNING --listen-addr=roach-0:26257 --advertise-addr=roach-0:26257 --insecure
+    command: start-single-node --insecure --listen-addr=roach-0:${DB_PORT} 
     # command: start-single-node --cluster-name=dp-crdb-cluster --logtostderr=WARNING --log-file-verbosity=WARNING --listen-addr=roach-0:26257 --advertise-addr=roach-0:26257 --certs-dir=/certs
     volumes:
       - roach-0-data:/cockroach/cockroach-data
@@ -97,25 +99,6 @@ services:
   #     - certs-roach-0:/certs/roach-0
   #     - certs-client:/certs/client
 
-  roach-lb:
-    # https://github.com/cockroachlabs-field/dynamic-haproxy
-    image: timveil/dynamic-haproxy:latest
-    container_name: ${COMPOSE_PROJECT_NAME?}-roach-lb
-    restart: always
-    hostname: roach-lb
-    environment:
-      - NODES=roach-0
-      # - NODES=roach-0 roach-1 roach-2
-    networks:
-      - backend-net
-    depends_on:
-      - roach-0
-    healthcheck:
-      test: /bin/true
-      interval: 3s
-      timeout: 10s
-      retries: 10
-
   roach-init:
     container_name: ${COMPOSE_PROJECT_NAME?}-roach-init
     hostname: roach-init
@@ -125,7 +108,8 @@ services:
       DATABASE_NAME: ${DB_NAME?}
       DATABASE_USER: ${DB_USER?}
       DATABASE_PASSWORD: ${DB_PASS?}
-      COCKROACH_HOST: roach-0:${DB_PORT?}
+      COCKROACH_HOST: roach-0
+      COCKROACH_PORT: ${DB_PORT?}
       COCKROACH_DATABASE: ${DB_NAME?}
       COCKROACH_INSECURE: "true"
       # COCKROACH_INSECURE: 'false'
@@ -135,7 +119,7 @@ services:
     networks:
       - backend-net
     depends_on:
-      - roach-lb
+      - roach-0
 
   flyway:
     image: ${FLYWAY_DEPLOY_IMAGE}:${DEPLOY_TAG?}


### PR DESCRIPTION
Removed cockroach-lb from env.dev, now lb is used for staging and prod only.

## Motivation and context
The change was needed to because in dev mode lb is not needed and also used to clear some of the code that was passing through the LB while the rest was going directly to the node.

details: 
 - The golang contact service was not loading environment variables correctly, only the default hardcoded ones
 - golang reference updated from 1.15 to 1.16
 - not-fixed: campaign service (.Net) still uses hardcoded db host in appsettings

Tested:
Using 'docker compose up' on local machine and manual check the web site works.

