### PR TITLE
Job for posting production deployments in the #website channel

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -193,3 +193,16 @@ jobs:
 
           # Create new deploy for this Sentry release
           sentry-cli releases deploys $SENTRY_RELEASE new -e $SENTRY_DEPLOY_ENVIRONMENT
+
+  deploy-discord:
+    needs: [deploy-init, deploy-build, deploy-run]
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: sarisia/actions-status-discord@v1
+        if: always()
+        with:
+          webhook: ${{ secrets.APP_DISCORD_WEBHOOK }}
+          title: "deploy"
+          description: "A new version of the website is deployed: https://podkrepi.bg/"
+          color: 0x26A641


### PR DESCRIPTION
A job in the .github/workflows/deploy-prod.yml workflow which uses [Actions Status Discord](https://github.com/marketplace/actions/actions-status-discord) GitHub Action to update the #website channel in [our Discord server.](https://discord.com/invite/nZAeCb9YzP)


## Motivation and context

We need this change to follow the status of the deployment process in our Discord channel.
This PR addresses #220 

**New environment variables**:
- `APP_DISCORD_WEBHOOK` :  this is the URL of the webhook attached to the #website channel (I will send it privately to @kachar so he can add it in the settings of the repo)
