### PR TITLE
Update pie chart

### DIFF
--- a/frontend/src/components/common/Heading.tsx
+++ b/frontend/src/components/common/Heading.tsx
@@ -28,7 +28,9 @@ type Linkable =
     }
   | { linkable?: false }
 
-type HeadingParams = PropsWithChildren<TypographyProps & Linkable> & { component?: string }
+type HeadingParams = PropsWithChildren<TypographyProps & Linkable> & {
+  component?: React.ElementType
+}
 
 export default function Heading({ children, id, linkable, ...props }: HeadingParams) {
   const [linkIconIsShown, setlinkIconIsShown] = useState(false)

--- a/frontend/src/components/index/helpers/chart/TeamPie.tsx
+++ b/frontend/src/components/index/helpers/chart/TeamPie.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useEffect, useState } from 'react'
 import Highcharts from 'highcharts'
 import HighchartsReact from 'highcharts-react-official'
 import { teamPieData, teamPieOptions, TeamPieItem } from 'components/index/helpers/chart/pieData'
@@ -16,7 +16,22 @@ const TeamPie = ({ inViewport, forwardedRef, enterCount }: TeamPieProps) => {
   teamPieData.forEach((item: TeamPieItem): void => {
     item.name = t(`index:team-chart-section.data.${item.id}`)
   })
-  const runAnimation: boolean = inViewport || enterCount > 0
+
+  const [runAnimation, setRunAnimation] = useState(inViewport || enterCount > 0)
+
+  useEffect(() => {
+    setRunAnimation(inViewport || enterCount > 0)
+
+    function handleResize(): void {
+      setRunAnimation(false)
+      setRunAnimation(inViewport || enterCount > 0)
+    }
+    window.addEventListener('resize', handleResize)
+
+    return () => {
+      window.removeEventListener('resize', handleResize)
+    }
+  })
 
   return (
     <div ref={forwardedRef}>


### PR DESCRIPTION
Using lifecycle method  and state for running the animation to re-render the pie chart on window resize.
Also we have on little change that we forgot to push with previous PR, discussed here: https://github.com/podkrepi-bg/frontend/pull/278#discussion_r656027096

## Motivation and context
We need this change introduced because we need responsive website.
Fixes known bug: #255 
