### PR TITLE
Replace using of appseting.json with env variables for BE campaigns

### DIFF
--- a/backend/module-campaigns/src/Podkrepibg.Campaigns.Infrastructure/Configuration/DbConfiguration.cs
+++ b/backend/module-campaigns/src/Podkrepibg.Campaigns.Infrastructure/Configuration/DbConfiguration.cs
@@ -1,0 +1,15 @@
+namespace Podkrepibg.Campaigns.Infrastructure.Configuration
+{
+    using System;
+
+    public class DbConfiguration
+    {
+        private static string DbHost = Environment.GetEnvironmentVariable("DB_HOST");
+        private static string DbPort = Environment.GetEnvironmentVariable("DB_PORT");
+
+        public static string GetConnectionString()
+        {
+            return $"Host={DbHost};Port={DbPort};Database=app;Username=root;Password=1234";
+        }
+    }
+}

--- a/backend/module-campaigns/src/Podkrepibg.Campaigns.Infrastructure/Configuration/DependencyInjection.cs
+++ b/backend/module-campaigns/src/Podkrepibg.Campaigns.Infrastructure/Configuration/DependencyInjection.cs
@@ -1,20 +1,19 @@
 namespace Podkrepibg.Campaigns.Infrastructure.Configuration
 {
     using Microsoft.EntityFrameworkCore;
-    using Microsoft.Extensions.Configuration;
     using Microsoft.Extensions.DependencyInjection;
     using Podkrepibg.Campaigns.Application.Data;
     using Podkrepibg.Campaigns.Infrastructure.Persistence;
 
     public static class DependencyInjection
     {
-        public static IServiceCollection AddInfrastructure(this IServiceCollection services, IConfiguration configuration)
+        public static IServiceCollection AddInfrastructure(this IServiceCollection services)
         {
             services.AddScoped<IApplicationDbContext>(provider => provider.GetService<CampaignsContext>());
             services.AddScoped<IApplicationReadOnlyDbContext>(provider => provider.GetService<CampaignsContext>());
 
             services.AddDbContext<CampaignsContext>(
-                options => options.UseNpgsql(configuration.GetConnectionString("CampaignDb")));
+                options => options.UseNpgsql(DbConfiguration.GetConnectionString()));
 
             return services;
         }

--- a/backend/module-campaigns/src/Podkrepibg.Campaigns/Startup.cs
+++ b/backend/module-campaigns/src/Podkrepibg.Campaigns/Startup.cs
@@ -30,7 +30,7 @@ namespace Podkrepibg.Campaigns
             services.AddOptions();
 
             services.AddApplication(Configuration);
-            services.AddInfrastructure(Configuration);
+            services.AddInfrastructure();
         }
 
         public void Configure(IApplicationBuilder app, IWebHostEnvironment env)

--- a/backend/module-campaigns/tests/Podkrepibg.Campaigns.IntegrationTests/CampaignsServiceTests/CampaignsServiceTestsBase.cs
+++ b/backend/module-campaigns/tests/Podkrepibg.Campaigns.IntegrationTests/CampaignsServiceTests/CampaignsServiceTestsBase.cs
@@ -33,11 +33,10 @@ namespace Podkrepibg.Campaigns.IntegrationTests.CampaignsServiceTests
             _services = new ServiceCollection()
                 .AddOptions()
                 .AddApplication(configuration)
-                .AddInfrastructure(configuration)
+                .AddInfrastructure()
                 .AddScoped<CampaignsService>();
 
-            _postgresDataHelper = new PostgresDataHelper(
-                configuration.GetConnectionString("CampaignDb"));
+            _postgresDataHelper = new PostgresDataHelper(DbConfiguration.GetConnectionString());
         }
 
         [SetUp]


### PR DESCRIPTION
Replace using of appseting.json for getting db connection string with environment variables. 

Currently module campaign in BE reading db connection string from configuration which read it from appsetings.json. The PR replace reading of this JSON with reading env variables and build the string.
