### PR TITLE
Disable sentry reports for localhost

### DIFF
--- a/sentry.client.config.js
+++ b/sentry.client.config.js
@@ -8,6 +8,7 @@ const SENTRY_DSN = process.env.SENTRY_DSN || process.env.NEXT_PUBLIC_SENTRY_DSN
 
 Sentry.init({
   dsn: SENTRY_DSN || 'https://e25f62860a394934878c2e21306a6b66@o540074.ingest.sentry.io/5657969',
+  blacklistUrls: [/localhost/, /127.0.0.1/],
   // Note: if you want to override the automatic release value, do not set a
   // `release` value here - use the environment variable `SENTRY_RELEASE`, so
   // that it will also get attached to your source maps


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and context

At the moment all localhost errors are getting reported to Sentry and this burns up our limits. We need to enable Sentry only for staging/prod env.