### PR TITLE
fix: mui-5 select props fix

### DIFF
--- a/src/common/theme.ts
+++ b/src/common/theme.ts
@@ -100,9 +100,6 @@ export const themeOptions: ThemeOptions = {
         root: {
           fontSize: '1rem',
         },
-        filled: {
-          transform: 'translate(14px, 9px) scale(1)',
-        },
       },
     },
 

--- a/src/components/campaigns/CampaignTypeSelect.tsx
+++ b/src/components/campaigns/CampaignTypeSelect.tsx
@@ -13,14 +13,10 @@ export default function CampaignTypeSelect({ name = 'campaignTypeId' }) {
 
   return (
     <FormControl variant="outlined" fullWidth size="small">
-      <InputLabel variant="filled" margin="dense">
-        {t('campaigns:campaign.type')}
-      </InputLabel>
+      <InputLabel>{t('campaigns:campaign.type')}</InputLabel>
       <Select
         fullWidth
         defaultValue=""
-        margin="dense"
-        variant="outlined"
         label={t('campaigns:campaign.type')}
         error={Boolean(meta.error) && Boolean(meta.touched)}
         {...field}>


### PR DESCRIPTION
Closes #394
## Motivation and context

The Select component within a FormControl behavior has changed in mui5 and the initial conversion used a small hack to correct the vertical alignment of the Label. However this lead to an issue when the Select is focused.
This new fix played with the prop of the Select and it seems removing `variant="filled"` from the Label and the margin="dense" achieves behavior like in mui-4

## Screenshots:

| Before              | After              |
| ------------------- | ------------------ |
|  ![grab199](https://user-images.githubusercontent.com/6075606/139522770-d292e0e6-1064-4ec1-99c0-556ed2779642.jpg) | ![grab200](https://user-images.githubusercontent.com/6075606/139522779-10a58b8e-bc70-4e75-8584-5e8f9ecbd8b5.jpg)  |




