### PR TITLE
fix: Inputlabel error color from formik

### DIFF
--- a/src/common/theme.ts
+++ b/src/common/theme.ts
@@ -100,9 +100,6 @@ export const themeOptions: ThemeOptions = {
         root: {
           fontSize: '1rem',
         },
-        filled: {
-          transform: 'translate(14px, 9px) scale(1)',
-        },
       },
     },
 

--- a/src/components/campaigns/CampaignTypeSelect.tsx
+++ b/src/components/campaigns/CampaignTypeSelect.tsx
@@ -13,14 +13,10 @@ export default function CampaignTypeSelect({ name = 'campaignTypeId' }) {
 
   return (
     <FormControl variant="outlined" fullWidth size="small">
-      <InputLabel variant="filled" margin="dense">
-        {t('campaigns:campaign.type')}
-      </InputLabel>
+      <InputLabel>{t('campaigns:campaign.type')}</InputLabel>
       <Select
         fullWidth
         defaultValue=""
-        margin="dense"
-        variant="outlined"
         label={t('campaigns:campaign.type')}
         error={Boolean(meta.error) && Boolean(meta.touched)}
         {...field}>

--- a/src/components/campaigns/CampaignTypeSelect.tsx
+++ b/src/components/campaigns/CampaignTypeSelect.tsx
@@ -8,12 +8,12 @@ export default function CampaignTypeSelect({ name = 'campaignTypeId' }) {
   const { t } = useTranslation()
   const { data } = useCampaignTypesList()
   const [field, meta] = useField(name)
-  console.log(meta)
   const helperText = meta.touched ? translateError(meta.error as TranslatableField, t) : ''
-
   return (
     <FormControl variant="outlined" fullWidth size="small">
-      <InputLabel>{t('campaigns:campaign.type')}</InputLabel>
+      <InputLabel color={meta.touched && meta.error ? 'error' : 'primary'}>
+        {t('campaigns:campaign.type')}
+      </InputLabel>
       <Select
         fullWidth
         defaultValue=""


### PR DESCRIPTION
InputLabel does not change color to error when a field has formi errors

## Motivation and context
Visit the Create Campaign form and then tab through the Campaign Type Select without entering any data, the label will keep a blue color, even though the Campaign field is required bu empty 

## Screenshots:

| Before              | After              |
| ------------------- | ------------------ |
| ![grab202](https://user-images.githubusercontent.com/6075606/139633082-25c4897d-1f2c-465c-83fc-c463835e3ad2.jpg)|![grab205](https://user-images.githubusercontent.com/6075606/139632974-cc965b19-b705-494e-8d37-3840fe48e806.jpg)|


