### PR TITLE
Login and register directly on Keycloak

### DIFF
--- a/src/components/auth/login/LoginPage.tsx
+++ b/src/components/auth/login/LoginPage.tsx
@@ -1,28 +1,17 @@
-import React from 'react'
-import { useTranslation } from 'next-i18next'
-import { Container, Grid, Box } from '@mui/material'
+import React, { useEffect } from 'react'
+import { KeycloakInstance } from 'keycloak-js'
+import { LinearProgress } from '@mui/material'
+import { useKeycloak } from '@react-keycloak/ssr'
 
-import { routes } from 'common/routes'
-import Link from 'components/common/Link'
-import { LoginPageProps } from 'pages/login'
-import Layout from 'components/layout/Layout'
-import LoginForm from 'components/auth/login/LoginForm'
+import { baseUrl, routes } from 'common/routes'
 
-export default function LoginPage({ csrfToken }: LoginPageProps) {
-  const { t } = useTranslation()
-  return (
-    <Layout
-      title={t('nav.login')}
-      githubUrl="https://github.com/podkrepi-bg/frontend/tree/master/src/components/auth/login/LoginPage.tsx"
-      figmaUrl="https://www.figma.com/file/MmvFKzUv6yE5U2wrOpWtwS/Podkrepi.bg?node-id=5055%3A21469">
-      <Container maxWidth="xs">
-        <LoginForm csrfToken={csrfToken || ''} />
-        <Grid container justifyContent="flex-end">
-          <Box mt={2}>
-            <Link href={routes.forgottenPassword}>{t('nav.forgottenPassword')}</Link>
-          </Box>
-        </Grid>
-      </Container>
-    </Layout>
-  )
+export default function LoginPage() {
+  const { keycloak } = useKeycloak<KeycloakInstance>()
+  useEffect(() => {
+    keycloak?.login({
+      redirectUri: `${baseUrl}${routes.profile}`,
+    })
+  }, [])
+
+  return <LinearProgress />
 }

--- a/src/components/auth/register/RegisterPage.tsx
+++ b/src/components/auth/register/RegisterPage.tsx
@@ -1,18 +1,17 @@
-import React from 'react'
-import { useTranslation } from 'next-i18next'
-import { Container } from '@mui/material'
+import React, { useEffect } from 'react'
+import { KeycloakInstance } from 'keycloak-js'
+import { LinearProgress } from '@mui/material'
+import { useKeycloak } from '@react-keycloak/ssr'
 
-import Layout from 'components/layout/Layout'
-import RegisterForm from 'components/auth/register/RegisterForm'
+import { baseUrl, routes } from 'common/routes'
 
-export default function RegisterPage() {
-  const { t } = useTranslation()
+export default function LoginPage() {
+  const { keycloak } = useKeycloak<KeycloakInstance>()
+  useEffect(() => {
+    keycloak?.register({
+      redirectUri: `${baseUrl}${routes.profile}`,
+    })
+  }, [])
 
-  return (
-    <Layout title={t('nav.register')}>
-      <Container maxWidth="xs">
-        <RegisterForm />
-      </Container>
-    </Layout>
-  )
+  return <LinearProgress />
 }


### PR DESCRIPTION
Skips our internal login and register forms and redirect the user straight away to Keycloak auth pages