### PR TITLE
Fixed jest tests by replacing babel-jest with the builtin nextjs jest

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,9 +10,9 @@ jobs:
     runs-on: ubuntu-latest
 
     strategy:
-      max-parallel: 2
+      max-parallel: 1
       matrix:
-        node-version: [12.x, 14.x]
+        node-version: [14.x]
 
     steps:
       - uses: actions/checkout@v2

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,20 @@
-module.exports = {
-  setupFilesAfterEnv: ['./src/test/setupTests.ts'],
-  moduleDirectories: ['node_modules', '<rootDir>/src'],
+//Setting jest as per https://nextjs.org/docs/testing#jest-and-react-testing-library
+
+// jest.config.js
+const nextJest = require('next/jest')
+
+const createJestConfig = nextJest({
+  // Provide the path to your Next.js app to load next.config.js and .env files in your test environment
+  dir: './',
+})
+
+// Add any custom config to be passed to Jest
+const customJestConfig = {
+  setupFilesAfterEnv: ['<rootDir>/src/test/setupTests.ts'],
+  // if using TypeScript with a baseUrl set to the root directory then you need the below for alias' to work
+  moduleDirectories: ['node_modules', '<rootDir>/src/'],
+  testEnvironment: 'jest-environment-jsdom',
 }
+
+// createJestConfig is exported this way to ensure that next/jest can load the Next.js config which is async
+module.exports = createJestConfig(customJestConfig)

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "yup": "0.32.9"
   },
   "devDependencies": {
-    "@testing-library/jest-dom": "^5.14.1",
+    "@testing-library/jest-dom": "^5.16.1",
     "@testing-library/react": "^12.1.2",
     "@types/cookie": "^0.4.1",
     "@types/lru-cache": "^5.1.1",
@@ -77,7 +77,6 @@
     "@types/yup": "0.29.11",
     "@typescript-eslint/eslint-plugin": "4.26.0",
     "@typescript-eslint/parser": "4.26.0",
-    "babel-jest": "^27.3.1",
     "eslint": "7.27.0",
     "eslint-config-next": "^11.0.1",
     "eslint-config-prettier": "8.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1439,14 +1439,14 @@
     lz-string "^1.4.4"
     pretty-format "^27.0.2"
 
-"@testing-library/jest-dom@^5.14.1":
-  version "5.14.1"
-  resolved "https://registry.yarnpkg.com/@testing-library/jest-dom/-/jest-dom-5.14.1.tgz#8501e16f1e55a55d675fe73eecee32cdaddb9766"
-  integrity sha512-dfB7HVIgTNCxH22M1+KU6viG5of2ldoA5ly8Ar8xkezKHKXjRvznCdbMbqjYGgO2xjRbwnR+rR8MLUIqF3kKbQ==
+"@testing-library/jest-dom@^5.16.1":
+  version "5.16.1"
+  resolved "https://registry.yarnpkg.com/@testing-library/jest-dom/-/jest-dom-5.16.1.tgz#3db7df5ae97596264a7da9696fe14695ba02e51f"
+  integrity sha512-ajUJdfDIuTCadB79ukO+0l8O+QwN0LiSxDaYUTI4LndbbUsGi6rWU1SCexXzBA2NSjlVB9/vbkasQIL3tmPBjw==
   dependencies:
     "@babel/runtime" "^7.9.2"
     "@types/testing-library__jest-dom" "^5.9.1"
-    aria-query "^4.2.2"
+    aria-query "^5.0.0"
     chalk "^3.0.0"
     css "^3.0.0"
     css.escape "^1.5.1"


### PR DESCRIPTION
## Motivation and context
This PR fixes the "yarn test" failure by replacing babel-jest with the builtin nextjs jest integration as per https://nextjs.org/docs/testing#jest-and-react-testing-library

## additional improvements
 - removed node12 from the test matrix in the testing git action
 - also reduced parallel job runs to 1, because the second job yarn step was failing when executed in parallel

## Testing
Currently there is only one test CopyTextButton.test.tsx which passes successfully after the fix
