### PR TITLE
Change background color of Principles section in About Us page

### DIFF
--- a/src/components/about/sections/PrincipleCard.tsx
+++ b/src/components/about/sections/PrincipleCard.tsx
@@ -3,11 +3,9 @@ import { Theme } from '@mui/material/styles'
 import makeStyles from '@mui/styles/makeStyles'
 import createStyles from '@mui/styles/createStyles'
 import { Typography, CardContent, CardHeader, Card, SvgIconProps } from '@mui/material'
-import { grey } from '@mui/material/colors'
 
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
-    container: { backgroundColor: grey[50] },
     contentContainer: {
       padding: theme.spacing(0),
       margin: theme.spacing(2, 0),
@@ -50,7 +48,7 @@ type PrincipleCardProps = {
 export default function PrincipleCard({ Icon, heading, content }: PrincipleCardProps) {
   const classes = useStyles()
   return (
-    <Card elevation={0} className={classes.container}>
+    <Card elevation={0}>
       <CardHeader
         className={classes.cardHeader}
         avatar={<Icon className={classes.icon} />}


### PR DESCRIPTION
Since we changed the background color of the website from light grey to white, the background had to be changed here too:

| Before              | After              |
| ------------------- | ------------------ |
| ![Screenshot 2022-01-13 230509](https://user-images.githubusercontent.com/14351733/149409031-81188627-f1d2-4c8f-a6df-b5e1e0fca713.png) | ![Screenshot 2022-01-13 230406](https://user-images.githubusercontent.com/14351733/149409063-3c1d96c9-6fd1-4b73-96f4-783dc611c299.png) |
