### PR TITLE
Enable static pages generation at build time

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,6 +21,7 @@ Table of contents:
 ## Development
 
 ### Setup local dev environment
+
 To run and develop the module NodeJS 16 is required. In this section 2 ways of configuring a development environment are described.
 
 ### Installing the dependencies
@@ -34,8 +35,8 @@ The following dependencies are required in order to be able to run the project:
 
 If you wish to keep your host clean, it is also possible to develop the module in a Docker container. You can do that by using the [Visual Studio Code](https://code.visualstudio.com/download)'s [Remote Containers extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) and read [how to initialize your dev container](https://code.visualstudio.com/docs/remote/containers).
 
-
 ### Cloning and initializing the repo
+
 ```shell
 git clone https://github.com/podkrepi-bg/frontend
 cd frontend

--- a/src/pages/about-project.tsx
+++ b/src/pages/about-project.tsx
@@ -1,8 +1,8 @@
-import { GetServerSideProps } from 'next'
+import { GetStaticProps } from 'next'
 import AboutProjectPage from 'components/about-project/AboutProjectPage'
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
 
-export const getServerSideProps: GetServerSideProps = async ({ locale }) => ({
+export const getStaticProps: GetStaticProps = async ({ locale }) => ({
   props: {
     ...(await serverSideTranslations(locale ?? 'bg', ['common', 'about-project'])),
   },

--- a/src/pages/about.tsx
+++ b/src/pages/about.tsx
@@ -1,9 +1,9 @@
-import { GetServerSideProps } from 'next'
+import { GetStaticProps } from 'next'
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
 
 import AboutPage from 'components/about/AboutPage'
 
-export const getServerSideProps: GetServerSideProps = async ({ locale }) => ({
+export const getStaticProps: GetStaticProps = async ({ locale }) => ({
   props: {
     ...(await serverSideTranslations(locale ?? 'bg', ['common', 'about'])),
   },

--- a/src/pages/contact.tsx
+++ b/src/pages/contact.tsx
@@ -1,9 +1,9 @@
-import { GetServerSideProps } from 'next'
+import { GetStaticProps } from 'next'
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
 
 import ContactPage from 'components/contact/ContactPage'
 
-export const getServerSideProps: GetServerSideProps = async ({ locale }) => ({
+export const getStaticProps: GetStaticProps = async ({ locale }) => ({
   props: {
     ...(await serverSideTranslations(locale ?? 'bg', ['common', 'auth', 'validation', 'contact'])),
   },

--- a/src/pages/faq.tsx
+++ b/src/pages/faq.tsx
@@ -1,8 +1,8 @@
 import FaqPage from '../components/faq/FaqPage'
-import { GetServerSideProps } from 'next'
+import { GetStaticProps } from 'next'
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
 
-export const getServerSideProps: GetServerSideProps = async ({ locale }) => ({
+export const getStaticProps: GetStaticProps = async ({ locale }) => ({
   props: {
     ...(await serverSideTranslations(locale ?? 'bg', ['common'])),
   },

--- a/src/pages/privacy-policy.tsx
+++ b/src/pages/privacy-policy.tsx
@@ -1,8 +1,8 @@
-import { GetServerSideProps } from 'next'
+import { GetStaticProps } from 'next'
 import PrivacyPolicyPage from 'components/privacy-policy/PrivacyPolicyPage'
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
 
-export const getServerSideProps: GetServerSideProps = async ({ locale }) => ({
+export const getStaticProps: GetStaticProps = async ({ locale }) => ({
   props: {
     ...(await serverSideTranslations(locale ?? 'bg', ['common', 'privacy-policy'])),
   },

--- a/src/pages/support.tsx
+++ b/src/pages/support.tsx
@@ -1,9 +1,9 @@
-import { GetServerSideProps } from 'next'
+import { GetStaticProps } from 'next'
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
 
 import SupportFormPage from 'components/support-form/SupportPage'
 
-export const getServerSideProps: GetServerSideProps = async ({ locale }) => ({
+export const getStaticProps: GetStaticProps = async ({ locale }) => ({
   props: {
     ...(await serverSideTranslations(locale ?? 'bg', [
       'common',

--- a/src/pages/terms-of-service.tsx
+++ b/src/pages/terms-of-service.tsx
@@ -1,8 +1,8 @@
-import { GetServerSideProps } from 'next'
+import { GetStaticProps } from 'next'
 import TermsOfServicePage from 'components/terms-of-service/TermsOfServicePage'
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
 
-export const getServerSideProps: GetServerSideProps = async ({ locale }) => ({
+export const getStaticProps: GetStaticProps = async ({ locale }) => ({
   props: {
     ...(await serverSideTranslations(locale ?? 'bg', ['common'])),
   },


### PR DESCRIPTION
Еnabled static page generation by switching to getStaticProps for pages which don't load database content

## Motivation and context
The change is needed for enabling SEO for public pages and content which don't require login. Such pages are about us/about-project, faq, terms&conditions, etc. 
See the list of static pages marked with full circles on the build report below:

## Screenshots:
<img width="651" alt="Screenshot 2022-02-02 at 09 07 37" src="https://user-images.githubusercontent.com/7055304/152109686-31bd1b94-3ab8-4eaa-8c3c-32b0947ccb89.png">


## Testing
manual opening each affected page