### PR TITLE
Enable static pages with dynamic header

### DIFF
--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -9,8 +9,10 @@ import makeStyles from '@mui/styles/makeStyles'
 import Footer from 'components/layout/Footer'
 import { defaultOgImage } from 'common/routes'
 import Snackbar from 'components/layout/Snackbar'
-import AppNavBar from 'components/layout/AppNavBar'
 import DetailsModal from 'components/modal/DetailsModal'
+
+import dynamic from 'next/dynamic'
+const AppNavBarWithNoSSR = dynamic(() => import('components/layout/AppNavBar'), { ssr: false })
 
 import MobileNav from './nav/MobileNav'
 import ImproveThisPageTag from './ImproveThisPageTag'
@@ -75,7 +77,7 @@ export default function Layout({
           <meta key="og:image:height" property="og:image:height" content="1000" />
         </Head>
         <Box pt={4} pb={disableOffset ? 0 : 10} {...boxProps}>
-          <AppNavBar navMenuToggle={navMenuToggle} />
+          <AppNavBarWithNoSSR navMenuToggle={navMenuToggle} />
           <MobileNav mobileOpen={mobileOpen} setMobileOpen={setMobileOpen} />
           {!disableOffset && <div className={classes.offset} />}
           {title && (

--- a/src/pages/about-project.tsx
+++ b/src/pages/about-project.tsx
@@ -1,8 +1,8 @@
-import { GetServerSideProps } from 'next'
+import { GetStaticProps } from 'next'
 import AboutProjectPage from 'components/about-project/AboutProjectPage'
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
 
-export const getServerSideProps: GetServerSideProps = async ({ locale }) => ({
+export const getStaticProps: GetStaticProps = async ({ locale }) => ({
   props: {
     ...(await serverSideTranslations(locale ?? 'bg', ['common', 'about-project'])),
   },

--- a/src/pages/about.tsx
+++ b/src/pages/about.tsx
@@ -1,9 +1,9 @@
-import { GetServerSideProps } from 'next'
+import { GetStaticProps } from 'next'
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
 
 import AboutPage from 'components/about/AboutPage'
 
-export const getServerSideProps: GetServerSideProps = async ({ locale }) => ({
+export const getStaticProps: GetStaticProps = async ({ locale }) => ({
   props: {
     ...(await serverSideTranslations(locale ?? 'bg', ['common', 'about'])),
   },

--- a/src/pages/contact.tsx
+++ b/src/pages/contact.tsx
@@ -1,9 +1,9 @@
-import { GetServerSideProps } from 'next'
+import { GetStaticProps } from 'next'
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
 
 import ContactPage from 'components/contact/ContactPage'
 
-export const getServerSideProps: GetServerSideProps = async ({ locale }) => ({
+export const getStaticProps: GetStaticProps = async ({ locale }) => ({
   props: {
     ...(await serverSideTranslations(locale ?? 'bg', ['common', 'auth', 'validation', 'contact'])),
   },

--- a/src/pages/faq.tsx
+++ b/src/pages/faq.tsx
@@ -1,8 +1,8 @@
 import FaqPage from '../components/faq/FaqPage'
-import { GetServerSideProps } from 'next'
+import { GetStaticProps } from 'next'
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
 
-export const getServerSideProps: GetServerSideProps = async ({ locale }) => ({
+export const getStaticProps: GetStaticProps = async ({ locale }) => ({
   props: {
     ...(await serverSideTranslations(locale ?? 'bg', ['common'])),
   },

--- a/src/pages/privacy-policy.tsx
+++ b/src/pages/privacy-policy.tsx
@@ -1,8 +1,8 @@
-import { GetServerSideProps } from 'next'
+import { GetStaticProps } from 'next'
 import PrivacyPolicyPage from 'components/privacy-policy/PrivacyPolicyPage'
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
 
-export const getServerSideProps: GetServerSideProps = async ({ locale }) => ({
+export const getStaticProps: GetStaticProps = async ({ locale }) => ({
   props: {
     ...(await serverSideTranslations(locale ?? 'bg', ['common', 'privacy-policy'])),
   },

--- a/src/pages/support.tsx
+++ b/src/pages/support.tsx
@@ -1,9 +1,9 @@
-import { GetServerSideProps } from 'next'
+import { GetStaticProps } from 'next'
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
 
 import SupportFormPage from 'components/support-form/SupportPage'
 
-export const getServerSideProps: GetServerSideProps = async ({ locale }) => ({
+export const getStaticProps: GetStaticProps = async ({ locale }) => ({
   props: {
     ...(await serverSideTranslations(locale ?? 'bg', [
       'common',

--- a/src/pages/terms-of-service.tsx
+++ b/src/pages/terms-of-service.tsx
@@ -1,8 +1,8 @@
-import { GetServerSideProps } from 'next'
+import { GetStaticProps } from 'next'
 import TermsOfServicePage from 'components/terms-of-service/TermsOfServicePage'
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
 
-export const getServerSideProps: GetServerSideProps = async ({ locale }) => ({
+export const getStaticProps: GetStaticProps = async ({ locale }) => ({
   props: {
     ...(await serverSideTranslations(locale ?? 'bg', ['common'])),
   },


### PR DESCRIPTION
This change enables static pages generation at build time, while the header is still loaded dynamically at runtime. 
 - The dynamic header is imported as per the With No SSR section here: https://nextjs.org/docs/advanced-features/dynamic-import
 - The static pages are marked with full dots on the below screenshots. 

## Screenshots:
<img width="636" alt="Screenshot 2022-02-06 at 16 00 29" src="https://user-images.githubusercontent.com/91589884/152684443-4d9df0ba-6dff-4c61-816a-76266f4e772f.png">

## Testing
manual on localhost only
