### PR TITLE
Send person authentication to the backend on campaign creation

### DIFF
--- a/src/components/campaigns/CampaignForm.tsx
+++ b/src/components/campaigns/CampaignForm.tsx
@@ -12,7 +12,7 @@ import createStyles from '@mui/styles/createStyles'
 
 import { routes } from 'common/routes'
 import { PersonFormData } from 'gql/person'
-import { createCampaign } from 'service/restRequests'
+import { useCreateCampaign } from 'service/restRequests'
 import { AlertStore } from 'stores/AlertStore'
 import { createSlug } from 'common/util/createSlug'
 import PersonDialog from 'components/person/PersonDialog'
@@ -96,7 +96,7 @@ export default function CampaignForm({ initialValues = defaults }: CampaignFormP
     AxiosError<ApiErrors>,
     CampaignInput
   >({
-    mutationFn: createCampaign,
+    mutationFn: useCreateCampaign(),
     onError: () => AlertStore.show(t('common:alerts.error'), 'error'),
     onSuccess: () => AlertStore.show(t('common:alerts.message-sent'), 'success'),
   })

--- a/src/components/contact/ContactForm.tsx
+++ b/src/components/contact/ContactForm.tsx
@@ -9,7 +9,7 @@ import makeStyles from '@mui/styles/makeStyles'
 import createStyles from '@mui/styles/createStyles'
 
 import { AlertStore } from 'stores/AlertStore'
-import { createContactRequest } from 'service/restRequests'
+import { useCreateContactRequest } from 'service/restRequests'
 import { isAxiosError, ApiErrors, matchValidator } from 'service/apiErrors'
 import { ContactFormData, ContactRequestResponse, ContactRequestInput } from 'gql/contact'
 import GenericForm from 'components/common/form/GenericForm'
@@ -62,12 +62,13 @@ export type ContactFormProps = { initialValues?: ContactFormData }
 export default function ContactForm({ initialValues = defaults }: ContactFormProps) {
   const classes = useStyles()
   const { t } = useTranslation()
+  const mutationFn = useCreateContactRequest()
   const mutation = useMutation<
     AxiosResponse<ContactRequestResponse>,
     AxiosError<ApiErrors>,
     ContactRequestInput
   >({
-    mutationFn: createContactRequest,
+    mutationFn,
     onError: () => AlertStore.show(t('common:alerts.error'), 'error'),
     onSuccess: () => AlertStore.show(t('common:alerts.message-sent'), 'success'),
   })

--- a/src/components/contact/ContactForm.tsx
+++ b/src/components/contact/ContactForm.tsx
@@ -9,7 +9,7 @@ import makeStyles from '@mui/styles/makeStyles'
 import createStyles from '@mui/styles/createStyles'
 
 import { AlertStore } from 'stores/AlertStore'
-import { useCreateContactRequest } from 'service/restRequests'
+import { createContactRequest } from 'service/restRequests'
 import { isAxiosError, ApiErrors, matchValidator } from 'service/apiErrors'
 import { ContactFormData, ContactRequestResponse, ContactRequestInput } from 'gql/contact'
 import GenericForm from 'components/common/form/GenericForm'
@@ -62,7 +62,7 @@ export type ContactFormProps = { initialValues?: ContactFormData }
 export default function ContactForm({ initialValues = defaults }: ContactFormProps) {
   const classes = useStyles()
   const { t } = useTranslation()
-  const mutationFn = useCreateContactRequest()
+  const mutationFn = createContactRequest
   const mutation = useMutation<
     AxiosResponse<ContactRequestResponse>,
     AxiosError<ApiErrors>,

--- a/src/service/restRequests.ts
+++ b/src/service/restRequests.ts
@@ -1,17 +1,19 @@
+import { QueryFunction } from 'react-query'
+import { KeycloakInstance } from 'keycloak-js'
+import { useKeycloak } from '@react-keycloak/ssr'
 import { AxiosRequestConfig, AxiosResponse } from 'axios'
-import { MutationFunction, QueryFunction } from 'react-query'
 
 import { apiClient } from 'service/apiClient'
 import {
   SupportRequestResponse,
   SupportRequestInput,
 } from 'components/support-form/helpers/support-form.types'
-import { ContactRequestResponse, ContactRequestInput } from 'gql/contact'
 import { CampaignResponse, CampaignInput } from 'gql/campaigns'
+import { CreateBeneficiaryInput, PersonResponse } from 'gql/person'
+import { ContactRequestResponse, ContactRequestInput } from 'gql/contact'
+import { CheckoutSessionInput, CheckoutSessionResponse } from 'gql/donations'
 
 import { endpoints } from './apiEndpoints'
-import { CheckoutSessionInput, CheckoutSessionResponse } from 'gql/donations'
-import { CreateBeneficiaryInput, PersonResponse } from 'gql/person'
 
 export const queryFn: QueryFunction = async function ({ queryKey }) {
   const response = await apiClient.get(queryKey.join('/'))
@@ -25,52 +27,46 @@ export const queryFnFactory = <T>(config?: AxiosRequestConfig): QueryFunction<T>
   }
 
 export const authQueryFnFactory = <T>(token?: string): QueryFunction<T> => {
-  const headers = token ? { Authorization: `Bearer ${token}` } : {}
-  return queryFnFactory<T>({ headers })
+  return queryFnFactory<T>(authConfig(token))
 }
 
-export const createBeneficiary: MutationFunction<
-  AxiosResponse<PersonResponse>,
-  CreateBeneficiaryInput
-> = async (data: CreateBeneficiaryInput) => {
+export const authConfig = (token?: string): AxiosRequestConfig => {
+  const headers = token ? { Authorization: `Bearer ${token}` } : {}
+  return { headers }
+}
+
+export const createBeneficiary = async (data: CreateBeneficiaryInput) => {
   return await apiClient.post<CreateBeneficiaryInput, AxiosResponse<PersonResponse>>(
     endpoints.person.createBeneficiary.url,
     data,
   )
 }
 
-export const createContactRequest: MutationFunction<
-  AxiosResponse<ContactRequestResponse>,
-  ContactRequestInput
-> = async (data: ContactRequestInput) => {
+export const createContactRequest = async (data: ContactRequestInput) => {
   return await apiClient.post<ContactRequestInput, AxiosResponse<ContactRequestResponse>>(
     endpoints.support.createInfoRequest.url,
     data,
   )
 }
 
-export const createSupportRequest: MutationFunction<
-  AxiosResponse<SupportRequestResponse>,
-  SupportRequestInput
-> = async (data: SupportRequestInput) => {
+export const createSupportRequest = async (data: SupportRequestInput) => {
   return await apiClient.post<SupportRequestInput, AxiosResponse<SupportRequestResponse>>(
     endpoints.support.createSupportRequest.url,
     data,
   )
 }
 
-export const createCampaign: MutationFunction<AxiosResponse<CampaignResponse>, CampaignInput> =
-  async (data: CampaignInput) => {
-    return await apiClient.post<CampaignInput, AxiosResponse<CampaignResponse>>(
+export const useCreateCampaign = () => {
+  const { keycloak } = useKeycloak<KeycloakInstance>()
+  return async (data: CampaignInput) =>
+    await apiClient.post<CampaignInput, AxiosResponse<CampaignResponse>>(
       endpoints.campaign.createCampaign.url,
       data,
+      authConfig(keycloak?.token),
     )
-  }
+}
 
-export const createCheckoutSession: MutationFunction<
-  AxiosResponse<CheckoutSessionResponse>,
-  CheckoutSessionInput
-> = async (data: CheckoutSessionInput) => {
+export const createCheckoutSession = async (data: CheckoutSessionInput) => {
   return await apiClient.post<CheckoutSessionInput, AxiosResponse<CheckoutSessionResponse>>(
     endpoints.donation.createCheckoutSession.url,
     data,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and context

<!--- Why is this change required? -->

We need to authenticate the people when we want them to submit their campaign

<!--- If it fixes an open issue, please link to the issue here. -->

With this PR we introduce a simple way of adding keycloak token to the mutation requests.

Until now the mutation functions were constants and now we are defining them as hooks so we can use keycloak instance inside their body.


### Before

```tsx
const mutation = useMutation<AxiosResponse<CampaignResponse>, AxiosError<ApiErrors>, CampaignInput>({
  mutationFn: createCampaign
})
```

```tsx
export const createCampaign: MutationFunction<AxiosResponse<CampaignResponse>, CampaignInput> =
  async (data: CampaignInput) => {
    return await apiClient.post<CampaignInput, AxiosResponse<CampaignResponse>>(
      endpoints.campaign.createCampaign.url,
      data,
    )
  }
```

### After

```tsx
const mutation = useMutation<AxiosResponse<CampaignResponse>, AxiosError<ApiErrors>, CampaignInput>({
  mutationFn: useCreateCampaign()
})
```

```tsx
export const useCreateCampaign = () => {
  const { keycloak } = useKeycloak<KeycloakInstance>() // <-- NEW
  return async (data: CampaignInput) =>
    await apiClient.post<CampaignInput, AxiosResponse<CampaignResponse>>(
      endpoints.campaign.createCampaign.url,
      data,
      authConfig(keycloak?.token),
    )
}
```

<!--- Any links to external sources of documentation -->
<!--- Any links to internal designs -->
<!--- What problem are you trying to solve? -->
<!--- How did you solve the problem? -->
<!--- Provide link to ora.pm task if any -->

Additionally we can skip the double typing of the mutation functions as their return type is the same as the constant expected type.
