### PR TITLE
Bootcamp/first-layout-angelina #451

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,6 +21,7 @@ Table of contents:
 ## Development
 
 ### Setup local dev environment
+
 To run and develop the module NodeJS 16 is required. In this section 2 ways of configuring a development environment are described.
 
 ### Installing the dependencies
@@ -34,8 +35,8 @@ The following dependencies are required in order to be able to run the project:
 
 If you wish to keep your host clean, it is also possible to develop the module in a Docker container. You can do that by using the [Visual Studio Code](https://code.visualstudio.com/download)'s [Remote Containers extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) and read [how to initialize your dev container](https://code.visualstudio.com/docs/remote/containers).
 
-
 ### Cloning and initializing the repo
+
 ```shell
 git clone https://github.com/podkrepi-bg/frontend
 cd frontend

--- a/src/common/api-endpoints.ts
+++ b/src/common/api-endpoints.ts
@@ -29,4 +29,11 @@ export const endpoints = {
     recurringPrices: <Endpoint>{ url: '/donation/prices/recurring', method: 'GET' },
     createCheckoutSession: <Endpoint>{ url: '/donation/create-checkout-session', method: 'POST' },
   },
+  bootcamp: {
+    bootcampList: <Endpoint>{ url: '/bootcamp', method: 'GET' },
+    bootcampSingle: (id: string) => <Endpoint>{ url: `/bootcamp/${id}`, method: 'GET' },
+    createBootcamp: <Endpoint>{ url: '/bootcamp', method: 'POST' },
+    updateBootcamp: (id: string) => <Endpoint>{ url: `/bootcamp/${id}`, method: 'PATCH' },
+    deleteBootcamp: (id: string) => <Endpoint>{ url: `/bootcamp/${id}`, method: 'DELETE' },
+  },
 }

--- a/src/common/bootcampRest.ts
+++ b/src/common/bootcampRest.ts
@@ -1,0 +1,38 @@
+import { MutationFunction } from 'react-query'
+import { AxiosResponse } from 'axios'
+
+import { axios } from './api-client'
+import { endpoints } from './api-endpoints'
+import { BootcampEdit, BootcampInput, BootcampResponse } from 'gql/bootcamp'
+
+export const createBootcamp: MutationFunction<AxiosResponse<BootcampResponse>, BootcampInput> =
+  async (data: BootcampInput) => {
+    return await axios.post<BootcampInput, AxiosResponse<BootcampResponse>>(
+      endpoints.bootcamp.createBootcamp.url,
+      data,
+    )
+  }
+
+export const getBootcamp: MutationFunction<AxiosResponse<BootcampResponse>, string> = async (
+  id: string,
+) => {
+  return await axios.get<string, AxiosResponse<BootcampResponse>>(
+    endpoints.bootcamp.bootcampSingle(id).url,
+  )
+}
+
+export const updateBootcampREST: MutationFunction<AxiosResponse<BootcampResponse>, BootcampEdit> =
+  async (data: BootcampEdit) => {
+    return await axios.patch<BootcampInput, AxiosResponse<BootcampResponse>>(
+      endpoints.bootcamp.updateBootcamp(data.id).url,
+      data,
+    )
+  }
+
+export const deleteBootcampREST: MutationFunction<AxiosResponse<BootcampResponse>, string> = async (
+  id: string,
+) => {
+  return await axios.delete<BootcampInput, AxiosResponse<BootcampResponse>>(
+    endpoints.bootcamp.deleteBootcamp(id).url,
+  )
+}

--- a/src/common/hooks/bootcamp.ts
+++ b/src/common/hooks/bootcamp.ts
@@ -1,0 +1,35 @@
+import { KeycloakInstance } from 'keycloak-js'
+import { useKeycloak } from '@react-keycloak/ssr'
+import { QueryClient, useQuery } from 'react-query'
+
+import { endpoints } from 'common/api-endpoints'
+import { authQueryFnFactory } from 'common/rest'
+
+type Bootcamp = {
+  id: string
+  firstName: string
+  lastName: string
+}
+
+export function useBootcampList() {
+  const { keycloak } = useKeycloak<KeycloakInstance>()
+  return useQuery<Bootcamp[]>(
+    endpoints.bootcamp.bootcampList.url,
+    // authQueryFnFactory<Bootcamp[]>(keycloak?.token),
+  )
+}
+
+export async function prefetchBootcampList(client: QueryClient, token?: string) {
+  await client.prefetchQuery<Bootcamp[]>(
+    endpoints.bootcamp.bootcampList.url,
+    // authQueryFnFactory<Bootcamp[]>(token),
+  )
+}
+
+export function useBootcampSingle(id: string) {
+  const { keycloak } = useKeycloak<KeycloakInstance>()
+  return useQuery<Bootcamp>(
+    endpoints.bootcamp.bootcampSingle(id).url,
+    // authQueryFnFactory<Bootcamp[]>(keycloak?.token),
+  )
+}

--- a/src/common/routes.ts
+++ b/src/common/routes.ts
@@ -49,4 +49,10 @@ export const routes = {
     infoRequests: '/admin/info-requests',
     supporters: '/admin/supporters',
   },
+  bootcamp: {
+    index: '/bootcamp',
+    create: '/bootcamp/create',
+    edit: (id: string) => `/bootcamp/edit/${id}`,
+    view: (id: string) => `/bootcamp/${id}`,
+  },
 }

--- a/src/components/bootcamp/BootcampCreatePage.tsx
+++ b/src/components/bootcamp/BootcampCreatePage.tsx
@@ -1,0 +1,68 @@
+import { useMutation } from 'react-query'
+import { useRouter } from 'next/router'
+import { AxiosError, AxiosResponse } from 'axios'
+import { FormikHelpers } from 'formik'
+import { Grid } from '@mui/material'
+
+import { AlertStore } from 'stores/AlertStore'
+import { ApiErrors, isAxiosError, matchValidator } from 'common/api-errors'
+import { useTranslation } from 'next-i18next'
+import { routes } from 'common/routes'
+
+import GenericForm from 'components/common/form/GenericForm'
+import FormTextField from 'components/common/form/FormTextField'
+import SubmitButton from 'components/common/form/SubmitButton'
+import { createBootcamp } from 'common/bootcampRest'
+import { BootcampFormData, BootcampInput, BootcampResponse } from 'gql/bootcamp'
+import Layout from './Layout'
+
+export default function BootcampPage() {
+  const router = useRouter()
+  const { t } = useTranslation()
+
+  const mutation = useMutation<
+    AxiosResponse<BootcampResponse>,
+    AxiosError<ApiErrors>,
+    BootcampInput
+  >({
+    mutationFn: createBootcamp,
+    onError: () => AlertStore.show(t('common:alerts.error'), 'error'),
+    onSuccess: () => AlertStore.show(t('common:alerts.message-sent'), 'success'),
+  })
+
+  const onSubmit = async (
+    values: BootcampFormData,
+    { setFieldError, resetForm }: FormikHelpers<BootcampFormData>,
+  ) => {
+    try {
+      await mutation.mutateAsync(values)
+      resetForm()
+      router.push(routes.bootcamp.index)
+    } catch (error) {
+      if (isAxiosError(error)) {
+        const { response } = error as AxiosError<ApiErrors>
+        response?.data.message.map(({ property, constraints }) => {
+          setFieldError(property, t(matchValidator(constraints)))
+        })
+      }
+    }
+  }
+
+  return (
+    <Layout>
+      <GenericForm onSubmit={onSubmit} initialValues={{ firstName: ' ', lastName: ' ' }}>
+        <Grid container spacing={3} sx={{ m: 10 }}>
+          <Grid item xs={10}>
+            <FormTextField type="text" label="First Name" name="firstName" />
+          </Grid>
+          <Grid item xs={10}>
+            <FormTextField type="text" label="Last Name" name="lastName" />
+          </Grid>
+          <Grid item xs={4}>
+            <SubmitButton fullWidth label="Add" />
+          </Grid>
+        </Grid>
+      </GenericForm>
+    </Layout>
+  )
+}

--- a/src/components/bootcamp/BootcampDetailsPage.tsx
+++ b/src/components/bootcamp/BootcampDetailsPage.tsx
@@ -1,0 +1,22 @@
+import React from 'react'
+import { Card, CardContent, Typography } from '@mui/material'
+
+import Layout from 'components/layout/Layout'
+import { useBootcampSingle } from 'common/hooks/bootcamp'
+
+type Props = { id: string }
+export default function BootcampPage({ id }: Props) {
+  const { data } = useBootcampSingle(id)
+
+  return (
+    <Layout>
+      <Card sx={{ minWidth: 275 }}>
+        <CardContent>
+          <Typography variant="h5" component="div">
+            {data?.firstName} {data?.lastName}
+          </Typography>
+        </CardContent>
+      </Card>
+    </Layout>
+  )
+}

--- a/src/components/bootcamp/BootcampEditPage.tsx
+++ b/src/components/bootcamp/BootcampEditPage.tsx
@@ -1,0 +1,85 @@
+import { useMutation } from 'react-query'
+import { useRouter } from 'next/router'
+import { FormikHelpers } from 'formik'
+import { Button, Grid } from '@mui/material'
+
+import { AxiosError, AxiosResponse } from 'axios'
+import { ApiErrors, isAxiosError, matchValidator } from 'common/api-errors'
+import { useTranslation } from 'next-i18next'
+import { AlertStore } from 'stores/AlertStore'
+
+import GenericForm from 'components/common/form/GenericForm'
+import FormTextField from 'components/common/form/FormTextField'
+import SubmitButton from 'components/common/form/SubmitButton'
+import { useBootcampSingle } from 'common/hooks/bootcamp'
+import { BootcampEdit, BootcampFormData, BootcampResponse } from 'gql/bootcamp'
+import { updateBootcampREST } from 'common/bootcampRest'
+import { routes } from 'common/routes'
+import Layout from './Layout'
+
+type Props = { id: string }
+
+export default function BootcampEditPage({ id }: Props) {
+  const router = useRouter()
+  const { t } = useTranslation()
+
+  const { data } = useBootcampSingle(id)
+
+  const updateMutation = useMutation<
+    AxiosResponse<BootcampResponse>,
+    AxiosError<ApiErrors>,
+    BootcampEdit
+  >({
+    mutationFn: updateBootcampREST,
+    onError: () => AlertStore.show(t('common:alerts.error'), 'error'),
+    onSuccess: () => AlertStore.show(t('common:alerts.message-sent'), 'success'),
+  })
+
+  const onSubmit = async (
+    values: BootcampFormData,
+    { setFieldError, resetForm }: FormikHelpers<BootcampFormData>,
+  ) => {
+    try {
+      await updateMutation.mutateAsync({ id, ...values })
+      resetForm()
+      router.push(routes.bootcamp.index)
+    } catch (error) {
+      if (isAxiosError(error)) {
+        const { response } = error as AxiosError<ApiErrors>
+        response?.data.message.map(({ property, constraints }) => {
+          setFieldError(property, t(matchValidator(constraints)))
+        })
+      }
+    }
+  }
+
+  return (
+    <Layout>
+      <GenericForm
+        onSubmit={onSubmit}
+        initialValues={{ firstName: data?.firstName || '', lastName: data?.lastName || '' }}>
+        <Grid container spacing={3} sx={{ m: 10 }}>
+          <Grid item xs={10}>
+            <FormTextField type="text" label="First Name" name="firstName" />
+          </Grid>
+          <Grid item xs={10}>
+            <FormTextField type="text" label="Last Name" name="lastName" />
+          </Grid>
+          <Grid item xs={4}>
+            <SubmitButton fullWidth label="Save" />
+          </Grid>
+          <Grid item xs={4}>
+            <Button
+              fullWidth
+              variant="outlined"
+              onClick={() => {
+                ;('')
+              }}>
+              Cancel
+            </Button>
+          </Grid>
+        </Grid>
+      </GenericForm>
+    </Layout>
+  )
+}

--- a/src/components/bootcamp/BootcampGrid.tsx
+++ b/src/components/bootcamp/BootcampGrid.tsx
@@ -1,0 +1,159 @@
+import React from 'react'
+import { useMutation } from 'react-query'
+import Link from 'next/link'
+import { useRouter } from 'next/router'
+import { AxiosError, AxiosResponse } from 'axios'
+import { GridColumns, DataGrid } from '@mui/x-data-grid'
+import { Box, IconButton, Modal, Typography } from '@mui/material'
+import { DeleteOutline, ModeEditOutline, InfoOutlined } from '@mui/icons-material'
+
+import { useTranslation } from 'next-i18next'
+import { AlertStore } from '../../stores/AlertStore'
+import { routes } from '../../common/routes'
+
+import { useBootcampList } from '../../common/hooks/bootcamp'
+import { BootcampResponse } from 'gql/bootcamp'
+import { ApiErrors } from 'common/api-errors'
+import { deleteBootcampREST, getBootcamp } from 'common/bootcampRest'
+
+const style = {
+  position: 'absolute' as const,
+  top: '50%',
+  left: '50%',
+  transform: 'translate(-50%, -50%)',
+  width: 400,
+  bgcolor: 'background.paper',
+  border: '2px solid #000',
+  boxShadow: 24,
+  p: 4,
+}
+
+const initialValues: BootcampResponse = {
+  id: '',
+  firstName: '',
+  lastName: '',
+}
+
+export default function BootcampGrid() {
+  const [intern, setIntern] = React.useState<BootcampResponse>(initialValues)
+  const [openInfo, setOpenInfo] = React.useState(false)
+  const { data } = useBootcampList()
+
+  const router = useRouter()
+  const { t } = useTranslation()
+
+  const handleOpen = () => setOpenInfo(true)
+  const handleClose = () => setOpenInfo(false)
+
+  const deleteMutation = useMutation<
+    AxiosResponse<BootcampResponse>,
+    AxiosError<ApiErrors>,
+    string
+  >({
+    mutationFn: deleteBootcampREST,
+    onError: () => AlertStore.show(t('common:alerts.error'), 'error'),
+    onSuccess: () => AlertStore.show(t('common:alerts.message-sent'), 'success'),
+  })
+
+  const deleteRow = async (id: string) => {
+    await deleteMutation.mutateAsync(id)
+    router.push(routes.bootcamp.index)
+  }
+
+  const infoMutation = useMutation<AxiosResponse<BootcampResponse>, AxiosError<ApiErrors>, string>({
+    mutationFn: getBootcamp,
+    onError: () => AlertStore.show(t('bootcamp:alerts.load-intern.error'), 'error'),
+    onSuccess: ({ data }) => {
+      setIntern(data)
+      handleOpen()
+    },
+  })
+
+  const loadInternInfo = async (id: string) => {
+    try {
+      await infoMutation.mutateAsync(id)
+    } catch (error) {
+      console.error(error)
+    }
+  }
+
+  const renderButtons = (params: any) => {
+    return (
+      <>
+        <IconButton onClick={() => loadInternInfo(params.id)}>
+          <InfoOutlined />
+        </IconButton>
+        <Link href={routes.bootcamp.edit(params.id)}>
+          <IconButton>
+            <ModeEditOutline />
+          </IconButton>
+        </Link>
+        <IconButton onClick={() => deleteRow(params.id)}>
+          <DeleteOutline />
+        </IconButton>
+      </>
+    )
+  }
+
+  const columns: GridColumns = [
+    { field: 'id', headerName: 'ID', hide: true },
+    {
+      field: 'firstName',
+      headerName: 'First Name',
+      width: 200,
+    },
+    {
+      field: 'lastName',
+      headerName: 'Last Name',
+      width: 760,
+    },
+    {
+      field: 'buttons',
+      headerName: '',
+      width: 140,
+      align: 'right',
+      renderCell: renderButtons,
+    },
+  ]
+
+  return (
+    <>
+      <Modal
+        open={openInfo}
+        onClose={handleClose}
+        aria-labelledby="modal-m)odal-title"
+        aria-describedby="modal-modal-description">
+        <Box sx={style}>
+          <Typography id="modal-modal-title" variant="h6" component="h2">
+            Info
+          </Typography>
+          <Typography id="modal-modal-description" sx={{ mt: 2 }}>
+            <p>
+              <b>Id:</b> {intern.id}
+            </p>
+            <p>
+              <b>{t('auth:fields.first-name')}:</b> {intern.firstName}
+            </p>
+            <p>
+              <b>{t('auth:fields.last-name')}:</b> {intern.lastName}
+            </p>
+          </Typography>
+        </Box>
+      </Modal>
+      <DataGrid
+        rows={data || []}
+        columns={columns}
+        pageSize={5}
+        autoHeight
+        autoPageSize
+        checkboxSelection
+        disableSelectionOnClick
+        onRowClick={(row) => {
+          const id = row.getValue(row.id, 'id')
+          if (typeof id !== 'string') return
+          // router.push(routes.bootcamp.view(id))
+        }}
+      />
+    </>
+  )
+}

--- a/src/components/bootcamp/BootcampPage.tsx
+++ b/src/components/bootcamp/BootcampPage.tsx
@@ -2,7 +2,6 @@ import React from 'react'
 import Link from 'next/link'
 import { IconButton, Typography } from '@mui/material'
 import AddCircleOutlinedIcon from '@mui/icons-material/AddCircleOutlined'
-import DeleteSweepOutlinedIcon from '@mui/icons-material/DeleteSweepOutlined'
 
 import { routes } from '../../common/routes'
 
@@ -20,9 +19,7 @@ export default function BootcampPage() {
           <AddCircleOutlinedIcon />
         </IconButton>
       </Link>
-      <IconButton>
-        <DeleteSweepOutlinedIcon />
-      </IconButton>
+
       <BootcampGrid />
     </Layout>
   )

--- a/src/components/bootcamp/BootcampPage.tsx
+++ b/src/components/bootcamp/BootcampPage.tsx
@@ -1,0 +1,29 @@
+import React from 'react'
+import Link from 'next/link'
+import { IconButton, Typography } from '@mui/material'
+import AddCircleOutlinedIcon from '@mui/icons-material/AddCircleOutlined'
+import DeleteSweepOutlinedIcon from '@mui/icons-material/DeleteSweepOutlined'
+
+import { routes } from '../../common/routes'
+
+import BootcampGrid from './BootcampGrid'
+import Layout from './Layout'
+
+export default function BootcampPage() {
+  return (
+    <Layout>
+      <Typography variant="h4" sx={{ p: 1 }}>
+        Bootcampers
+      </Typography>
+      <Link href={routes.bootcamp.create}>
+        <IconButton>
+          <AddCircleOutlinedIcon />
+        </IconButton>
+      </Link>
+      <IconButton>
+        <DeleteSweepOutlinedIcon />
+      </IconButton>
+      <BootcampGrid />
+    </Layout>
+  )
+}

--- a/src/components/bootcamp/DeleteModal.tsx
+++ b/src/components/bootcamp/DeleteModal.tsx
@@ -1,0 +1,50 @@
+import { Modal, Box, Typography, Button } from '@mui/material'
+import makeStyles from '@mui/styles/makeStyles'
+
+const useStyles = makeStyles(() => {
+  return {
+    modal: {
+      position: 'absolute',
+      top: '30%',
+      left: '50%',
+      transform: 'translate(-50%, -50%)',
+      width: 400,
+      backgroundColor: '#fff',
+      border: '2px solid #000',
+      padding: 16,
+      textAlign: 'center',
+    },
+  }
+})
+
+type Props = {
+  open: boolean
+  closeModal: () => void
+  confirmHandler: () => void
+}
+
+export default function DeleteModal({ open, closeModal, confirmHandler }: Props) {
+  const classes = useStyles()
+
+  return (
+    <Modal open={open} onClose={closeModal}>
+      <Box className={classes.modal}>
+        <Typography id="modal-modal-title" variant="h6" component="h2">
+          Are you sure you want to delete this Bootcamper/s?
+        </Typography>
+
+        <Button
+          variant="contained"
+          color="error"
+          size="small"
+          sx={{ m: 1 }}
+          onClick={confirmHandler}>
+          Delete
+        </Button>
+        <Button variant="contained" size="small" sx={{ m: 1 }} onClick={closeModal}>
+          Cancel
+        </Button>
+      </Box>
+    </Modal>
+  )
+}

--- a/src/components/bootcamp/Layout.tsx
+++ b/src/components/bootcamp/Layout.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import Link from 'next/link'
-// import { styled, useTheme } from '@mui/material/styles'
+import { observer } from 'mobx-react'
 import {
   Box,
   Container,
@@ -19,7 +19,7 @@ import {
   ContainerProps,
   AppBar,
 } from '@mui/material'
-// import MuiAppBar, { AppBarProps as MuiAppBarProps } from '@mui/material/AppBar'
+import { makeStyles } from '@mui/styles'
 import MenuIcon from '@mui/icons-material/Menu'
 import ChevronLeftIcon from '@mui/icons-material/ChevronLeft'
 import ChevronRightIcon from '@mui/icons-material/ChevronRight'
@@ -30,56 +30,45 @@ import ExpandMore from '@mui/icons-material/ExpandMore'
 import StarBorder from '@mui/icons-material/StarBorder'
 import { AccountCircle } from '@mui/icons-material'
 
-import { routes } from 'common/routes'
+import { routes } from '../../common/routes'
 import PodkrepiIcon from 'components/brand/PodkrepiIcon'
+import { DrawerStore } from '../../stores/DrawerStore'
 
 const drawerWidth = 240
 
-// interface AppBarProps extends MuiAppBarProps {
-//     open?: boolean
-// }
+const useStyles = makeStyles({
+  appBar: {
+    backgroundColor: '#fff',
+  },
+  logo: {
+    height: 40,
+    width: 'auto',
+    marginRight: 10,
+  },
+  closeNavBtn: {
+    display: 'flex',
+    justifyContent: 'flex-end',
+    padding: '8px 0',
+  },
+  submenu: {},
+})
 
-// const AppBar = styled(MuiAppBar, {
-//     shouldForwardProp: (prop: any) => prop !== 'open',
-// })<AppBarProps>(({ theme, open }) => ({
-//     transition: theme.transitions.create(['margin', 'width'], {
-//         easing: theme.transitions.easing.sharp,
-//         duration: theme.transitions.duration.leavingScreen,
-//     }),
-//     ...(open && {
-//         width: `calc(100% - ${drawerWidth}px)`,
-//         marginLeft: `${drawerWidth}px`,
-//         transition: theme.transitions.create(['margin', 'width'], {
-//             easing: theme.transitions.easing.easeOut,
-//             duration: theme.transitions.duration.enteringScreen,
-//         }),
-//     }),
-// }))
-
-// const DrawerHeader = styled('div')(({ theme }) => ({
-//     display: 'flex',
-//     alignItems: 'center',
-//     padding: theme.spacing(0, 1),
-//     ...theme.mixins.toolbar,
-//     justifyContent: 'flex-end',
-// }))
-
-export default function Layout({ children }: ContainerProps) {
-  // const theme = useTheme()
+export default observer(function Layout({ children }: ContainerProps) {
+  const classes = useStyles()
   const [anchorEl, setAnchorEl] = React.useState(null)
-  const [open, setOpen] = React.useState(false)
   const [openCol, setOpenCol] = React.useState(true)
+  const { isOpen, toggle } = DrawerStore
 
   const handleClick = () => {
     setOpenCol(!openCol)
   }
 
   const handleDrawerOpen = () => {
-    setOpen(true)
+    toggle()
   }
 
   const handleDrawerClose = () => {
-    setOpen(false)
+    toggle()
   }
 
   const isMenuOpen = Boolean(anchorEl)
@@ -114,14 +103,14 @@ export default function Layout({ children }: ContainerProps) {
   return (
     <Container maxWidth={false} disableGutters>
       <Box>
-        <AppBar>
+        <AppBar className={classes.appBar}>
           <Toolbar>
             <IconButton
               size="large"
               edge="start"
               color="inherit"
               aria-label="open drawer"
-              sx={{ mr: 2 }}
+              sx={{ mr: 2, ...(isOpen && { display: 'none' }) }}
               onClick={handleDrawerOpen}>
               <MenuIcon />
             </IconButton>
@@ -166,12 +155,12 @@ export default function Layout({ children }: ContainerProps) {
         }}
         variant="persistent"
         anchor="left"
-        open={open}>
-        <div>
+        open={isOpen}>
+        <div className={classes.closeNavBtn}>
           <IconButton onClick={handleDrawerClose}>{<ChevronLeftIcon />}</IconButton>
         </div>
         <Divider />
-        <List>
+        <List className={classes.submenu}>
           <Link href={routes.bootcamp.index}>
             <ListItem button key="All Bootcampers">
               <ListItemText primary="All Bootcampers" />
@@ -231,4 +220,4 @@ export default function Layout({ children }: ContainerProps) {
       </footer>
     </Container>
   )
-}
+})

--- a/src/components/bootcamp/Layout.tsx
+++ b/src/components/bootcamp/Layout.tsx
@@ -1,0 +1,234 @@
+import React from 'react'
+import Link from 'next/link'
+// import { styled, useTheme } from '@mui/material/styles'
+import {
+  Box,
+  Container,
+  Divider,
+  Drawer,
+  IconButton,
+  List,
+  ListItem,
+  ListItemButton,
+  ListItemIcon,
+  Collapse,
+  Menu,
+  MenuItem,
+  Toolbar,
+  Typography,
+  ContainerProps,
+  AppBar,
+} from '@mui/material'
+// import MuiAppBar, { AppBarProps as MuiAppBarProps } from '@mui/material/AppBar'
+import MenuIcon from '@mui/icons-material/Menu'
+import ChevronLeftIcon from '@mui/icons-material/ChevronLeft'
+import ChevronRightIcon from '@mui/icons-material/ChevronRight'
+import ListItemText from '@mui/material/ListItemText'
+import InboxIcon from '@mui/icons-material/MoveToInbox'
+import ExpandLess from '@mui/icons-material/ExpandLess'
+import ExpandMore from '@mui/icons-material/ExpandMore'
+import StarBorder from '@mui/icons-material/StarBorder'
+import { AccountCircle } from '@mui/icons-material'
+
+import { routes } from 'common/routes'
+import PodkrepiIcon from 'components/brand/PodkrepiIcon'
+
+const drawerWidth = 240
+
+// interface AppBarProps extends MuiAppBarProps {
+//     open?: boolean
+// }
+
+// const AppBar = styled(MuiAppBar, {
+//     shouldForwardProp: (prop: any) => prop !== 'open',
+// })<AppBarProps>(({ theme, open }) => ({
+//     transition: theme.transitions.create(['margin', 'width'], {
+//         easing: theme.transitions.easing.sharp,
+//         duration: theme.transitions.duration.leavingScreen,
+//     }),
+//     ...(open && {
+//         width: `calc(100% - ${drawerWidth}px)`,
+//         marginLeft: `${drawerWidth}px`,
+//         transition: theme.transitions.create(['margin', 'width'], {
+//             easing: theme.transitions.easing.easeOut,
+//             duration: theme.transitions.duration.enteringScreen,
+//         }),
+//     }),
+// }))
+
+// const DrawerHeader = styled('div')(({ theme }) => ({
+//     display: 'flex',
+//     alignItems: 'center',
+//     padding: theme.spacing(0, 1),
+//     ...theme.mixins.toolbar,
+//     justifyContent: 'flex-end',
+// }))
+
+export default function Layout({ children }: ContainerProps) {
+  // const theme = useTheme()
+  const [anchorEl, setAnchorEl] = React.useState(null)
+  const [open, setOpen] = React.useState(false)
+  const [openCol, setOpenCol] = React.useState(true)
+
+  const handleClick = () => {
+    setOpenCol(!openCol)
+  }
+
+  const handleDrawerOpen = () => {
+    setOpen(true)
+  }
+
+  const handleDrawerClose = () => {
+    setOpen(false)
+  }
+
+  const isMenuOpen = Boolean(anchorEl)
+  const handleProfileMenuOpen = (event: any) => {
+    setAnchorEl(event.currentTarget)
+  }
+  const handleMenuClose = () => {
+    setAnchorEl(null)
+  }
+
+  const menuId = 'primary-search-account-menu'
+  const renderMenu = (
+    <Menu
+      anchorEl={anchorEl}
+      anchorOrigin={{
+        vertical: 'top',
+        horizontal: 'right',
+      }}
+      id={menuId}
+      keepMounted
+      transformOrigin={{
+        vertical: 'top',
+        horizontal: 'right',
+      }}
+      open={isMenuOpen}
+      onClose={handleMenuClose}>
+      <MenuItem onClick={handleMenuClose}>Profile</MenuItem>
+      <MenuItem onClick={handleMenuClose}>My account</MenuItem>
+    </Menu>
+  )
+
+  return (
+    <Container maxWidth={false} disableGutters>
+      <Box>
+        <AppBar>
+          <Toolbar>
+            <IconButton
+              size="large"
+              edge="start"
+              color="inherit"
+              aria-label="open drawer"
+              sx={{ mr: 2 }}
+              onClick={handleDrawerOpen}>
+              <MenuIcon />
+            </IconButton>
+            <Link href={routes.index}>
+              <a>
+                <PodkrepiIcon />
+              </a>
+            </Link>
+            <Typography
+              variant="h6"
+              noWrap
+              component="div"
+              sx={{ display: { xs: 'none', sm: 'block' } }}>
+              Admin panel
+            </Typography>
+
+            <Box sx={{ flexGrow: 1 }} />
+            <Box sx={{ display: { xs: 'none', md: 'flex' } }}>
+              <IconButton
+                size="large"
+                edge="end"
+                aria-label="account of current user"
+                aria-controls={menuId}
+                aria-haspopup="true"
+                onClick={handleProfileMenuOpen}
+                color="inherit">
+                <AccountCircle />
+              </IconButton>
+            </Box>
+          </Toolbar>
+        </AppBar>
+        {renderMenu}
+      </Box>
+      <Drawer
+        sx={{
+          width: drawerWidth,
+          flexShrink: 0,
+          '& .MuiDrawer-paper': {
+            width: drawerWidth,
+            boxSizing: 'border-box',
+          },
+        }}
+        variant="persistent"
+        anchor="left"
+        open={open}>
+        <div>
+          <IconButton onClick={handleDrawerClose}>{<ChevronLeftIcon />}</IconButton>
+        </div>
+        <Divider />
+        <List>
+          <Link href={routes.bootcamp.index}>
+            <ListItem button key="All Bootcampers">
+              <ListItemText primary="All Bootcampers" />
+            </ListItem>
+          </Link>
+          <Divider />
+          <Link href={routes.bootcamp.create}>
+            <ListItem button key="Create">
+              <ListItemText primary="Create" />
+            </ListItem>
+          </Link>
+          <Divider />
+          {['Somth', 'Somth'].map((text, index) => (
+            <>
+              <ListItem button key={text}>
+                <ListItemText primary={text} />
+              </ListItem>
+              <Divider />
+            </>
+          ))}
+
+          <ListItemButton onClick={handleClick}>
+            <ListItemIcon>
+              <InboxIcon />
+            </ListItemIcon>
+            <ListItemText primary="ColapseItem" />
+            {openCol ? <ExpandLess /> : <ExpandMore />}
+          </ListItemButton>
+        </List>
+        <Collapse in={openCol} timeout="auto" unmountOnExit>
+          <List component="div" disablePadding>
+            <ListItemButton sx={{ pl: 4 }}>
+              <ListItemIcon>
+                <StarBorder />
+              </ListItemIcon>
+              <ListItemText primary="Nested" />
+            </ListItemButton>
+          </List>
+        </Collapse>
+      </Drawer>
+
+      <Container maxWidth="lg" sx={{ mt: 10 }}>
+        {children}
+      </Container>
+
+      <footer
+        style={{
+          position: 'fixed',
+          left: '0',
+          bottom: '0',
+          width: '100%',
+          backgroundColor: '#32a9fe',
+          textAlign: 'center',
+          height: '6.8%',
+        }}>
+        <Typography variant="inherit">&copy; All Rights Reserved</Typography>
+      </footer>
+    </Container>
+  )
+}

--- a/src/gql/bootcamp.d.ts
+++ b/src/gql/bootcamp.d.ts
@@ -1,0 +1,21 @@
+export type BootcampResponse = {
+  id: string
+  firstName: string
+  lastName: string
+}
+
+export type BootcampInput = {
+  firstName: string
+  lastName: string
+}
+
+export type BootcampEdit = {
+  id: string
+  firstName: string
+  lastName: string
+}
+
+export type BootcampFormData = {
+  firstName: string
+  lastName: string
+}

--- a/src/pages/bootcamp/[id].tsx
+++ b/src/pages/bootcamp/[id].tsx
@@ -1,0 +1,26 @@
+import { GetServerSideProps } from 'next'
+import { dehydrate, QueryClient } from 'react-query'
+import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
+
+import { queryFn } from 'common/rest'
+import BootcampDetailsPage from 'components/bootcamp/BootcampDetailsPage'
+
+export const getServerSideProps: GetServerSideProps = async ({ query, locale }) => {
+  const { id } = query
+  const client = new QueryClient()
+  await client.prefetchQuery(`/bootcamp/${id}`, queryFn)
+  return {
+    props: {
+      id,
+      ...(await serverSideTranslations(locale ?? 'bg', [
+        'common',
+        'auth',
+        'validation',
+        'campaigns',
+      ])),
+      dehydratedState: dehydrate(client),
+    },
+  }
+}
+
+export default BootcampDetailsPage

--- a/src/pages/bootcamp/create.tsx
+++ b/src/pages/bootcamp/create.tsx
@@ -1,0 +1,24 @@
+import { GetServerSideProps } from 'next'
+import { dehydrate, QueryClient } from 'react-query'
+import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
+
+import { queryFn } from 'common/rest'
+import BootcampCreatePage from '../../components/bootcamp/BootcampCreatePage'
+
+export const getServerSideProps: GetServerSideProps = async ({ locale }) => {
+  const client = new QueryClient()
+  await client.prefetchQuery(`/bootcamp`, queryFn)
+  return {
+    props: {
+      ...(await serverSideTranslations(locale ?? 'bg', [
+        'common',
+        'auth',
+        'validation',
+        'campaigns',
+      ])),
+      dehydratedState: dehydrate(client),
+    },
+  }
+}
+
+export default BootcampCreatePage

--- a/src/pages/bootcamp/edit/[id].tsx
+++ b/src/pages/bootcamp/edit/[id].tsx
@@ -1,0 +1,26 @@
+import { GetServerSideProps } from 'next'
+import { dehydrate, QueryClient } from 'react-query'
+import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
+
+import { queryFn } from 'common/rest'
+import BootcampEditPage from 'components/bootcamp/BootcampEditPage'
+
+export const getServerSideProps: GetServerSideProps = async ({ query, locale }) => {
+  const { id } = query
+  const client = new QueryClient()
+  await client.prefetchQuery(`/bootcamp/${id}`, queryFn)
+  return {
+    props: {
+      id,
+      ...(await serverSideTranslations(locale ?? 'bg', [
+        'common',
+        'auth',
+        'validation',
+        'campaigns',
+      ])),
+      dehydratedState: dehydrate(client),
+    },
+  }
+}
+
+export default BootcampEditPage

--- a/src/pages/bootcamp/index.tsx
+++ b/src/pages/bootcamp/index.tsx
@@ -1,0 +1,24 @@
+import { GetServerSideProps } from 'next'
+import { dehydrate, QueryClient } from 'react-query'
+import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
+
+import { queryFn } from 'common/rest'
+import BootcampPage from '../../components/bootcamp/BootcampPage'
+
+export const getServerSideProps: GetServerSideProps = async ({ locale }) => {
+  const client = new QueryClient()
+  await client.prefetchQuery(`/bootcamp`, queryFn)
+  return {
+    props: {
+      ...(await serverSideTranslations(locale ?? 'bg', [
+        'common',
+        'auth',
+        'validation',
+        'campaigns',
+      ])),
+      dehydratedState: dehydrate(client),
+    },
+  }
+}
+
+export default BootcampPage

--- a/src/stores/DrawerStore.ts
+++ b/src/stores/DrawerStore.ts
@@ -1,0 +1,27 @@
+import { action, makeObservable, observable } from 'mobx'
+import { enableStaticRendering } from 'mobx-react'
+
+enableStaticRendering(typeof window === 'undefined')
+
+export class DrawerStoreImpl {
+  isOpen = false
+  subMenuIsOpen = false
+
+  constructor() {
+    makeObservable(this, {
+      isOpen: observable,
+      subMenuIsOpen: observable,
+      toggle: action,
+    })
+  }
+
+  toggle = () => {
+    this.isOpen = !this.isOpen
+  }
+
+  toggleSubMenu = () => {
+    this.subMenuIsOpen = !this.subMenuIsOpen
+  }
+}
+
+export const DrawerStore = new DrawerStoreImpl()


### PR DESCRIPTION
## First  Layout

1.Appbar

 - [x] hamburger menu
 - [x] logo
 - [x] heading(Admin panel)
 - [x] profile button(icon) to the most right side with a dropdown menu with few options
 
2.Drawer

 - [x] menu items
 - [x] submenu items when clicked on main menu items
 - [x] should keep open state across pages

3.Footer - should be part of the whole layout

- [x] maybe some copyright text

4.Datagrid

 - [x] Should have a title above it to say what we display in it
 - [x] Should display our entity loaded from the back-end
 - [x] Should have a + button/icon at the top which leads to a new page displaying the create form
 - [x] Should have a delete button/icon which opens a confirmation modal & deletes all selected items by the checkbox column
 - [x] checkbox column
 - [x] Should have a last column with 3 icons aligned to the right :
-view icon (opens a modal that shows all the values of the entity clicked)
-edit icon (opens a new page with form in which you can edit all the form values, also on this form we should have 2 buttons -save/cancel)
-delete icon (a normal confirmation pop-up asking "Are you sure" and 2 answers yes/no)

5.Notifications

 - [x] Should show success/error notification after create/edit/delete


## Screenshots:
![Screenshot 2022-02-16 001116](https://user-images.githubusercontent.com/62725741/154158712-7277437a-f52d-4eab-a451-99b0ed649d3b.png)
![Screenshot 2022-02-16 001329](https://user-images.githubusercontent.com/62725741/154158755-98c8ac53-e257-4cab-9309-cd0475b368ff.png)
![Screenshot 2022-02-16 001154](https://user-images.githubusercontent.com/62725741/154158778-769e08c8-f81e-4785-94de-df75a1898779.png)
![Screenshot 2022-02-16 001507](https://user-images.githubusercontent.com/62725741/154158795-5522ce6d-9ac1-41b5-b6c3-3a955cc4f427.png)

