### PR TITLE
[FIX] Change GDRP text to lower case

### DIFF
--- a/public/locales/en/validation.json
+++ b/public/locales/en/validation.json
@@ -14,7 +14,7 @@
   "agree-terms": "Agree to the Terms and Conditions",
   "agree-with": "I agree to the",
   "informed-agree-with": "I understand and I agree to the",
-  "terms-and-conditions": "terms and conditions",
-  "gdpr": "general Data Protection Regulation (GDPR)",
+  "terms-and-conditions": "Terms and Conditions",
+  "gdpr": "General Data Protection Regulation (GDPR)",
   "legal-entity": "Legal entity"
 }


### PR DESCRIPTION
Fixed the text of the links "Terms and conditions" and "GDPR" to begin with lower case on BG translations:

![image](https://user-images.githubusercontent.com/14351733/154668134-efff088c-fadf-4587-8c56-2f0b38349c4f.png)
