### PR TITLE
Changed -h flag Symlink to -n for better compitability.

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@ git clone git@github.com:podkrepi-bg/frontend.git
 cd frontend
 yarn
 
-# Symlink dev environment on unix
-ln -hfs .env.local.example .env.local
+# Symlink dev environment on Mac / Linux
+ln -nfs .env.local.example .env.local
 
 # Symlink dev environment on Windows
 mklink .env.local .env.local.example


### PR DESCRIPTION
 Changed a flag in the Symlink command for Unix systems

## Motivation and context

During initial setup the provided command with -h flag throws an error on Linux systems. The -n flag is more compatible with Linux systems and still works with Mac.

## Screenshots:
-------------------------------------------------------------------------------------------------------------------------------------------------------------------

**Before Screenshot**

![Screenshot from 2022-02-25 11-39-43](https://user-images.githubusercontent.com/53947134/155692658-5406999a-d4b0-4018-b05d-0e39f36f76c2.png)

-------------------------------------------------------------------------------------------------------------------------------------------------------------------

**After Screenshot**
![Screenshot from 2022-02-25 11-41-25](https://user-images.githubusercontent.com/53947134/155693066-44d45f9a-7572-4a8e-8fdd-baafd0b2472d.png)

