### PR TITLE
Update copyright text, change profile dropdown color links

### DIFF
--- a/public/locales/bg/common.json
+++ b/public/locales/bg/common.json
@@ -60,7 +60,7 @@
       "privacy-policy": "Защита на лични данни",
       "terms-of-service": "Общи условия",
       "hosting-partner": "Хостинг партньор:",
-      "copyrights": "Podkrepi.bg ©2021 Всички права запазени.",
+      "copyrights": "Podkrepi.bg ©2022 Всички права запазени.",
       "version": "Версия"
     }
   },

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -59,7 +59,7 @@
       "privacy-policy": "Privacy Policy",
       "terms-of-service": "Terms of service",
       "hosting-partner": "Hosting partner:",
-      "copyrights": "Podkrepi.bg ©2021 All rights reserved.",
+      "copyrights": "Podkrepi.bg ©2022 All rights reserved.",
       "version": "Version"
     }
   },

--- a/src/components/layout/nav/PublicMenu.tsx
+++ b/src/components/layout/nav/PublicMenu.tsx
@@ -1,16 +1,37 @@
 import React, { useState } from 'react'
 import { useTranslation } from 'next-i18next'
 import { AccountCircle } from '@mui/icons-material'
-import { Grid, IconButton, Menu, Typography } from '@mui/material'
+import { Grid, IconButton, Menu, Typography, Theme, lighten } from '@mui/material'
 
 import { routes } from 'common/routes'
 import { useSession } from 'common/util/useSession'
 import LinkMenuItem from 'components/common/LinkMenuItem'
 
+import makeStyles from '@mui/styles/makeStyles'
+import createStyles from '@mui/styles/createStyles'
+
+const useStyles = makeStyles((theme: Theme) =>
+  createStyles({
+    dropdownLinkButton: {
+      '&:hover': {
+        backgroundColor: lighten(theme.palette.primary.main, 0.9),
+      },
+    },
+    dropdownLinkText: {
+      color: theme.palette.primary.dark,
+      width: '100%',
+      '&:hover': {
+        color: theme.palette.primary.main,
+      },
+    },
+  }),
+)
+
 export default function PublicMenu() {
   const { t } = useTranslation()
   const { session } = useSession()
   const [anchorEl, setAnchorEl] = useState<Element | null>(null)
+  const classes = useStyles()
 
   const handleMenu = (event: React.MouseEvent) => setAnchorEl(event.currentTarget)
   const handleClose = () => setAnchorEl(null)
@@ -32,11 +53,15 @@ export default function PublicMenu() {
         onClose={handleClose}
         anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
         transformOrigin={{ vertical: 'top', horizontal: 'right' }}>
-        <LinkMenuItem href={routes.login}>
-          <Typography variant="button">{t('nav.login')}</Typography>
+        <LinkMenuItem href={routes.login} className={classes.dropdownLinkButton}>
+          <Typography variant="button" className={classes.dropdownLinkText}>
+            {t('nav.login')}
+          </Typography>
         </LinkMenuItem>
-        <LinkMenuItem href={routes.register}>
-          <Typography variant="button">{t('nav.register')}</Typography>
+        <LinkMenuItem href={routes.register} className={classes.dropdownLinkButton}>
+          <Typography variant="button" className={classes.dropdownLinkText}>
+            {t('nav.register')}
+          </Typography>
         </LinkMenuItem>
       </Menu>
     </Grid>


### PR DESCRIPTION
- Updated copyright text from ©2021 to ©2022:

![image](https://user-images.githubusercontent.com/14351733/155812884-ce6d3a66-c60d-4bab-b59d-59b6aded8799.png)

- Change profile dropdown color links and hover effect:

![image](https://user-images.githubusercontent.com/14351733/155812939-99505638-354f-42ae-9ef5-fa9a13372c01.png)