### PR TITLE
Add spacing in thank you form for the successful message

### DIFF
--- a/src/components/support-form/steps/ThankYou.tsx
+++ b/src/components/support-form/steps/ThankYou.tsx
@@ -17,6 +17,7 @@ const useStyles = makeStyles((theme: Theme) =>
     },
     instructions: {
       marginTop: theme.spacing(5),
+      marginLeft: theme.spacing(6),
     },
   }),
 )


### PR DESCRIPTION
## Add spacing in thank you form for the successful message

Fix issue 630
[https://github.com/podkrepi-bg/frontend/issues/630](https://github.com/podkrepi-bg/frontend/issues/630)

Add margin left to the instructions container

## Screenshots:

| Before              | After              |
| ------------------- | ------------------ |
| ![image](https://user-images.githubusercontent.com/69143/159154763-4ee40677-e5fd-4bbd-9c41-35839f3ed083.png) | ![image](https://user-images.githubusercontent.com/69143/159154835-abf3d3f5-a0de-4f8e-a958-d8a4047074aa.png) |

