### PR TITLE
Added sitemap generator for SEO

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -27,6 +27,7 @@ module.exports = {
     'next-i18next.config.js',
     'sentry.client.config.js',
     'sentry.server.config.js',
+    'next-sitemap.js',
   ],
   rules: {
     'react/display-name': 'off',

--- a/next-sitemap.js
+++ b/next-sitemap.js
@@ -1,0 +1,7 @@
+/** @type {import('next-sitemap').IConfig} */
+
+module.exports = {
+  siteUrl: process.env.SITE_URL || 'https://podkrepi.bg',
+  generateRobotsTxt: true, // (optional)
+  exclude: ['/admin*', '/test*'],
+}

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "predev": "shx test -e .env.local && exit 0 || shx echo 'You need to create .env.local file. Please check README.md!' && exit 1",
     "dev": "yarn && next dev -p 3040",
-    "build": "yarn format && next build",
+    "build": "yarn format && next build && next-sitemap",
     "start": "next start -p 3040",
     "test": "jest --env=jsdom",
     "test:debug": "node --inspect-brk ./node_modules/jest/bin/jest.js --runInBand",
@@ -20,7 +20,8 @@
     "release": "./manifests/release.sh",
     "release:patch": "./manifests/release.sh patch",
     "postversion": "./manifests/postrelease.sh v$npm_package_version",
-    "analyze": "ANALYZE=true next build"
+    "analyze": "ANALYZE=true next build",
+    "sitemap": "next-sitemap"
   },
   "dependencies": {
     "@emotion/cache": "^11.7.1",
@@ -87,6 +88,7 @@
     "husky": "7.0.1",
     "jest": "^27.3.1",
     "lint-staged": "11.0.0",
+    "next-sitemap": "^2.5.20",
     "prettier": "2.3.0",
     "shx": "^0.3.3",
     "stripe": "^8.184.0",

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,2 +1,9 @@
+# *
 User-agent: *
 Allow: /
+
+# Host
+Host: https://podkrepi.bg
+
+# Sitemaps
+Sitemap: https://podkrepi.bg/sitemap.xml

--- a/public/sitemap-0.xml
+++ b/public/sitemap-0.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:news="http://www.google.com/schemas/sitemap-news/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:mobile="http://www.google.com/schemas/sitemap-mobile/1.0" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" xmlns:video="http://www.google.com/schemas/sitemap-video/1.1">
+<url><loc>https://podkrepi.bg</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2022-04-21T08:49:28.836Z</lastmod></url>
+<url><loc>https://podkrepi.bg/about</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2022-04-21T08:49:28.836Z</lastmod></url>
+<url><loc>https://podkrepi.bg/about-project</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2022-04-21T08:49:28.836Z</lastmod></url>
+<url><loc>https://podkrepi.bg/campaigns</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2022-04-21T08:49:28.836Z</lastmod></url>
+<url><loc>https://podkrepi.bg/campaigns/create</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2022-04-21T08:49:28.836Z</lastmod></url>
+<url><loc>https://podkrepi.bg/change-password</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2022-04-21T08:49:28.836Z</lastmod></url>
+<url><loc>https://podkrepi.bg/chat</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2022-04-21T08:49:28.836Z</lastmod></url>
+<url><loc>https://podkrepi.bg/contact</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2022-04-21T08:49:28.836Z</lastmod></url>
+<url><loc>https://podkrepi.bg/faq</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2022-04-21T08:49:28.836Z</lastmod></url>
+<url><loc>https://podkrepi.bg/forgotten-password</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2022-04-21T08:49:28.836Z</lastmod></url>
+<url><loc>https://podkrepi.bg/login</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2022-04-21T08:49:28.836Z</lastmod></url>
+<url><loc>https://podkrepi.bg/logout</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2022-04-21T08:49:28.836Z</lastmod></url>
+<url><loc>https://podkrepi.bg/privacy-policy</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2022-04-21T08:49:28.836Z</lastmod></url>
+<url><loc>https://podkrepi.bg/profile</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2022-04-21T08:49:28.836Z</lastmod></url>
+<url><loc>https://podkrepi.bg/register</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2022-04-21T08:49:28.836Z</lastmod></url>
+<url><loc>https://podkrepi.bg/support</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2022-04-21T08:49:28.836Z</lastmod></url>
+<url><loc>https://podkrepi.bg/terms-of-service</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2022-04-21T08:49:28.836Z</lastmod></url>
+<url><loc>https://podkrepi.bg/404</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2022-04-21T08:49:28.836Z</lastmod></url>
+<url><loc>https://podkrepi.bg/en/404</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2022-04-21T08:49:28.836Z</lastmod></url>
+<url><loc>https://podkrepi.bg/en/about</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2022-04-21T08:49:28.836Z</lastmod></url>
+<url><loc>https://podkrepi.bg/en/privacy-policy</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2022-04-21T08:49:28.836Z</lastmod></url>
+<url><loc>https://podkrepi.bg/en/support</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2022-04-21T08:49:28.836Z</lastmod></url>
+<url><loc>https://podkrepi.bg/en/terms-of-service</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2022-04-21T08:49:28.836Z</lastmod></url>
+<url><loc>https://podkrepi.bg/en/contact</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2022-04-21T08:49:28.836Z</lastmod></url>
+<url><loc>https://podkrepi.bg/en/about-project</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2022-04-21T08:49:28.836Z</lastmod></url>
+<url><loc>https://podkrepi.bg/en/faq</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2022-04-21T08:49:28.836Z</lastmod></url>
+</urlset>

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+<sitemap><loc>https://podkrepi.bg/sitemap-0.xml</loc></sitemap>
+</sitemapindex>

--- a/src/pages/admin/documents/[id]/edit.tsx
+++ b/src/pages/admin/documents/[id]/edit.tsx
@@ -1,7 +1,3 @@
-import { GetServerSideProps } from 'next'
-import { dehydrate, QueryClient } from 'react-query'
-import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
-
 import EditPage from 'components/documents/EditPage'
 import { securedAdminProps } from 'middleware/auth/keycloak'
 import { endpoints } from 'service/apiEndpoints'

--- a/yarn.lock
+++ b/yarn.lock
@@ -496,6 +496,11 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
+"@corex/deepmerge@^2.6.148":
+  version "2.6.148"
+  resolved "https://registry.yarnpkg.com/@corex/deepmerge/-/deepmerge-2.6.148.tgz#8fa825d53ffd1cbcafce1b6a830eefd3dcc09dd5"
+  integrity sha512-6QMz0/2h5C3ua51iAnXMPWFbb1QOU1UvSM4bKBw5mzdT+WtLgjbETBBIQZ+Sh9WvEcGwlAt/DEdRpIC3XlDBMA==
+
 "@date-io/core@^2.13.1":
   version "2.13.1"
   resolved "https://registry.yarnpkg.com/@date-io/core/-/core-2.13.1.tgz#f041765aff5c55fbc7e37fdd75fc1792733426d6"
@@ -5133,7 +5138,7 @@ minimist-options@4.1.0:
     is-plain-obj "^1.1.0"
     kind-of "^6.0.3"
 
-minimist@^1.2.0, minimist@^1.2.3, minimist@^1.2.5, minimist@~1.2.5:
+minimist@^1.2.0, minimist@^1.2.3, minimist@^1.2.5, minimist@^1.2.6, minimist@~1.2.5:
   version "1.2.6"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.6.tgz#8637a5b759ea0d6e98702cfb3a9283323c93af44"
   integrity sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==
@@ -5256,6 +5261,14 @@ next-i18next@8.4.0:
     i18next "^20.1.0"
     i18next-fs-backend "^1.0.7"
     react-i18next "^11.8.13"
+
+next-sitemap@^2.5.20:
+  version "2.5.20"
+  resolved "https://registry.yarnpkg.com/next-sitemap/-/next-sitemap-2.5.20.tgz#7124e138506c2f10e460c3dc77907baf4d134478"
+  integrity sha512-Qbm4N2WGA6VHemFN0C9PNWQav9RKwMEbVrNgVvDQhG0sDBmNBgKii54WklOjCvVJVHgQPgtXLBhlNaJGS+RVQA==
+  dependencies:
+    "@corex/deepmerge" "^2.6.148"
+    minimist "^1.2.6"
 
 next@^12.1.0:
   version "12.1.0"


### PR DESCRIPTION
## Motivation and context
Having a sitemap is one of the requirements for good Search Engine Optimization mentioned in #46
Solved by adding next-sitemap package and configuring it accordingly. Admin and test pages will be skipped. Will generate the sitemap after each run of yarn build command.


## Screenshots:
Nothing visible for now.

## Testing
Sitemap appears in /public

**New dev dependencies**:

- `next-sitemap` : automated sitemap generator https://www.npmjs.com/package/next-sitemap
