### PR TITLE
720 feature add button to load more campaigns and set intially shown campaigns to 6.

### DIFF
--- a/src/components/campaigns/CampaignsList.tsx
+++ b/src/components/campaigns/CampaignsList.tsx
@@ -1,33 +1,67 @@
 import Image from 'next/image'
-import { Box, CircularProgress, Grid } from '@mui/material'
-
+import { Box, Button, CircularProgress, Grid, Theme } from '@mui/material'
+import makeStyles from '@mui/styles/makeStyles'
+import createStyles from '@mui/styles/createStyles'
 import { CampaignResponse } from 'gql/campaigns'
 import useMobile from 'common/hooks/useMobile'
 
 import CampaignCard from './CampaignCard'
+import { useEffect, useState } from 'react'
+import { useTranslation } from 'next-i18next'
+
+const useStyles = makeStyles((theme: Theme) =>
+  createStyles({
+    seeAllButton: {
+      border: `1px solid ${theme.palette.primary.main}`,
+      margin: `1em`,
+    },
+  }),
+)
 
 type Props = { campaignToShow: CampaignResponse[] }
 export default function CampaignsList({ campaignToShow }: Props) {
+  const { t } = useTranslation()
+  const classes = useStyles()
   const { mobile } = useMobile()
-
+  const numberOfMinimalShownCampaings = 6
+  const [campaignsToShow, setCampaignsToShow] = useState<CampaignResponse[] | undefined>()
+  const [all, setAll] = useState<boolean>(false)
+  useEffect(() => {
+    all
+      ? setCampaignsToShow(campaignToShow)
+      : setCampaignsToShow(campaignToShow?.slice(0, numberOfMinimalShownCampaings))
+  }, [campaignToShow, all])
   return (
     <Grid container justifyContent="center" spacing={2}>
-      {/* <pre>{JSON.stringify(data, null, 2)}</pre> */}
-      {<CircularProgress size="large" />}
-      {campaignToShow?.map((campaign, index) => (
-        <Grid key={index} item xs={12} sm={6} lg={4}>
-          <Box textAlign="center">
-            <CampaignCard campaign={campaign} />
-          </Box>
+      <Grid container justifyContent="center" spacing={2}>
+        {/* <pre>{JSON.stringify(data, null, 2)}</pre> */}
+        {<CircularProgress size="large" />}
+        {campaignsToShow?.map((campaign, index) => (
+          <Grid key={index} item xs={12} sm={6} lg={4}>
+            <Box textAlign="center">
+              <CampaignCard campaign={campaign} />
+            </Box>
+          </Grid>
+        ))}
+      </Grid>
+      {campaignsToShow && campaignsToShow?.length >= numberOfMinimalShownCampaings ? (
+        <Grid container justifyContent="center" spacing={-10}>
+          <Button onClick={() => setAll((prev) => !prev)} className={classes.seeAllButton}>
+            {all ? t('campaigns:cta.see-less') : t('campaigns:cta.see-all')}
+          </Button>
         </Grid>
-      ))}
-      <Box sx={{ my: 10 }}>
-        {mobile ? (
-          <Image src="/img/ArtboardRotate.png" width={250} height={400} />
-        ) : (
-          <Image src="/img/Artboard.png" width={813} height={358} />
-        )}
-      </Box>
+      ) : (
+        ''
+      )}
+      <Grid>
+        <Box sx={{ my: 10 }}>
+          {mobile ? (
+            <Image src="/img/ArtboardRotate.png" width={250} height={400} />
+          ) : (
+            <Image src="/img/Artboard.png" width={813} height={358} />
+          )}
+        </Box>
+      </Grid>
     </Grid>
   )
 }

--- a/src/components/campaigns/CampaignsList.tsx
+++ b/src/components/campaigns/CampaignsList.tsx
@@ -9,14 +9,6 @@ import CampaignCard from './CampaignCard'
 import { useEffect, useState } from 'react'
 import { useTranslation } from 'next-i18next'
 
-const useStyles = makeStyles((theme: Theme) =>
-  createStyles({
-    seeAllButton: {
-      border: `1px solid ${theme.palette.primary.main}`,
-      margin: `1em`,
-    },
-  }),
-)
 
 type Props = { campaignToShow: CampaignResponse[] }
 export default function CampaignsList({ campaignToShow }: Props) {

--- a/src/components/campaigns/CampaignsList.tsx
+++ b/src/components/campaigns/CampaignsList.tsx
@@ -38,7 +38,7 @@ export default function CampaignsList({ campaignToShow }: Props) {
       </Grid>
       {campaignToShow && campaignToShow?.length > numberOfMinimalShownCampaings ? (
         <Grid container justifyContent="center">
-          <Button onClick={() => setAll((prev) => !prev)} className={classes.seeAllButton}>
+          <Button onClick={() => setAll((prev) => !prev)} variant="outlined" sx={{ mt: 1 }}>
             {all ? t('campaigns:cta.see-less') : t('campaigns:cta.see-all')}
           </Button>
         </Grid>

--- a/src/components/campaigns/CampaignsList.tsx
+++ b/src/components/campaigns/CampaignsList.tsx
@@ -24,12 +24,12 @@ export default function CampaignsList({ campaignToShow }: Props) {
   const classes = useStyles()
   const { mobile } = useMobile()
   const numberOfMinimalShownCampaings = 6
-  const [campaignsToShow, setCampaignsToShow] = useState<CampaignResponse[] | undefined>()
   const [all, setAll] = useState<boolean>(false)
-  useEffect(() => {
-    all
-      ? setCampaignsToShow(campaignToShow)
-      : setCampaignsToShow(campaignToShow?.slice(0, numberOfMinimalShownCampaings))
+  const campaigns = useMemo<CampaignResponse[]>(() => {
+    if (all) {
+      return campaignToShow ?? []
+    }
+    return campaignToShow?.slice(0, numberOfMinimalShownCampaings) ?? []
   }, [campaignToShow, all])
   return (
     <Grid container justifyContent="center" spacing={2}>

--- a/src/components/campaigns/CampaignsList.tsx
+++ b/src/components/campaigns/CampaignsList.tsx
@@ -44,8 +44,8 @@ export default function CampaignsList({ campaignToShow }: Props) {
           </Grid>
         ))}
       </Grid>
-      {campaignsToShow && campaignsToShow?.length >= numberOfMinimalShownCampaings ? (
-        <Grid container justifyContent="center" spacing={-10}>
+      {campaignToShow && campaignToShow?.length > numberOfMinimalShownCampaings ? (
+        <Grid container justifyContent="center">
           <Button onClick={() => setAll((prev) => !prev)} className={classes.seeAllButton}>
             {all ? t('campaigns:cta.see-less') : t('campaigns:cta.see-all')}
           </Button>

--- a/src/components/campaigns/CampaignsList.tsx
+++ b/src/components/campaigns/CampaignsList.tsx
@@ -1,19 +1,16 @@
 import Image from 'next/image'
-import { Box, Button, CircularProgress, Grid, Theme } from '@mui/material'
-import makeStyles from '@mui/styles/makeStyles'
-import createStyles from '@mui/styles/createStyles'
+import { Box, Button, CircularProgress, Grid } from '@mui/material'
+
 import { CampaignResponse } from 'gql/campaigns'
 import useMobile from 'common/hooks/useMobile'
 
 import CampaignCard from './CampaignCard'
-import { useEffect, useState } from 'react'
+import { useMemo, useState } from 'react'
 import { useTranslation } from 'next-i18next'
-
 
 type Props = { campaignToShow: CampaignResponse[] }
 export default function CampaignsList({ campaignToShow }: Props) {
   const { t } = useTranslation()
-  const classes = useStyles()
   const { mobile } = useMobile()
   const numberOfMinimalShownCampaings = 6
   const [all, setAll] = useState<boolean>(false)
@@ -28,7 +25,7 @@ export default function CampaignsList({ campaignToShow }: Props) {
       <Grid container justifyContent="center" spacing={2}>
         {/* <pre>{JSON.stringify(data, null, 2)}</pre> */}
         {<CircularProgress size="large" />}
-        {campaignsToShow?.map((campaign, index) => (
+        {campaigns?.map((campaign, index) => (
           <Grid key={index} item xs={12} sm={6} lg={4}>
             <Box textAlign="center">
               <CampaignCard campaign={campaign} />


### PR DESCRIPTION
When campaigns are loaded initially only 6 campaigns should be shown.
A button should be added and when it is clicked it should show all of the campaigns. When it is clicked again it should show less campaings(6 campaigns).
When they are less than 6 campaigns there is no button.

![image](https://user-images.githubusercontent.com/101862171/165757715-531c4694-f91b-4862-9e65-3438b2ba40ce.png)

![image](https://user-images.githubusercontent.com/101862171/165757661-4dae10b7-aab8-403c-9e8e-e8d838e02399.png)
![image](https://user-images.githubusercontent.com/101862171/165757896-a919fe0e-2198-4637-88a9-7e70d748d829.png)

## Testing
<!--- Include links to the related pages -->
http://localhost:3040/campaigns

