### PR TITLE
Add rounded corners to inputs on the theme

### DIFF
--- a/src/common/theme.ts
+++ b/src/common/theme.ts
@@ -95,6 +95,30 @@ export const themeOptions: ThemeOptions = {
       styleOverrides: {
         root: {
           fontSize: '1rem',
+          borderRadius: 60,
+        },
+        multiline: {
+          borderRadius: 20,
+        },
+      },
+    },
+    MuiFilledInput: {
+      styleOverrides: {
+        root: {
+          borderRadius: 60,
+        },
+        multiline: {
+          borderRadius: 20,
+        },
+      },
+    },
+    MuiOutlinedInput: {
+      styleOverrides: {
+        root: {
+          borderRadius: 60,
+        },
+        multiline: {
+          borderRadius: 20,
         },
       },
     },
@@ -105,7 +129,6 @@ export const themeOptions: ThemeOptions = {
         },
       },
     },
-
     MuiAppBar: {
       styleOverrides: {
         root: {

--- a/src/components/common/FormFieldButton.tsx
+++ b/src/components/common/FormFieldButton.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Button, Typography, Box } from '@mui/material'
+import { Button, Typography, Box, ButtonBase } from '@mui/material'
 import makeStyles from '@mui/styles/makeStyles'
 import theme from 'common/theme'
 
@@ -18,7 +18,8 @@ const useStyles = makeStyles({
     alignItems: 'center',
     justifyContent: 'space-between',
     border: `1px solid rgba(0, 0, 0, 0.23)`,
-    borderRadius: '3px',
+    borderRadius: 60,
+    width: '100%',
     padding: '8.5px 14px',
     cursor: 'pointer',
     '&:hover': {
@@ -65,16 +66,8 @@ function FormFieldButton({ error, onClick, value, placeholder, button, label }: 
   const classes = useStyles()
   return (
     <>
-      <Box
+      <ButtonBase
         aria-label={label}
-        component="div"
-        role="button"
-        tabIndex={0}
-        onKeyDown={(e: React.KeyboardEvent<HTMLDivElement>) => {
-          if (e.keyCode === 32 || e.keyCode === 13) {
-            onClick ? onClick() : null
-          }
-        }}
         onClick={onClick}
         className={
           error ? classes.imitateInputBox + ' ' + classes.errorInputBox : classes.imitateInputBox
@@ -87,7 +80,7 @@ function FormFieldButton({ error, onClick, value, placeholder, button, label }: 
             {button.label}
           </Button>
         ) : null}
-      </Box>
+      </ButtonBase>
       {error ? <p className={classes.errorText}>{error}</p> : null}
     </>
   )


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and context

Changed the styling of the inputs in the `muiTheme` we are using. 

The corners of the oneline input fields are now fully round and the corners of the mulitline input are more round than they were before

## Screenshots:

| Before              | After              |
| ------------------- | ------------------ |
|![image](https://user-images.githubusercontent.com/61479393/166110842-0c83031b-6b12-46ae-bec7-440427ce6c59.png)|![image](https://user-images.githubusercontent.com/61479393/166110834-2208050c-6e10-4e89-b629-cc1cd28833b7.png)|

## Testing

Went through many of the pages and didn't find any bugs whatsoever 🚀!
