### PR TITLE
Add reports in About Project menu, fix reports link in FAQ

### DIFF
--- a/public/locales/bg/common.json
+++ b/public/locales/bg/common.json
@@ -5,6 +5,7 @@
       "about-project": "За проекта",
       "about-us": "За нас",
       "support-us": "Стани доброволец",
+      "reports": "Отчети",
       "contacts": "Контакти"
     },
     "campaigns": {

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -5,6 +5,7 @@
       "about-project": "The Project",
       "about-us": "About us",
       "support-us": "Support us",
+      "reports": "Reports",
       "contacts": "Contacts"
     },
     "campaigns": {

--- a/src/common/routes.ts
+++ b/src/common/routes.ts
@@ -17,6 +17,7 @@ export const staticUrls = {
   devDocs: 'https://docs.podkrepi.bg/development',
   blog: 'https://blog.podkrepi.bg/',
   hostingProvider: 'https://superhosting.bg?rel=podkrepi.bg',
+  eduspace: 'https://eduspace-bg.business.site/',
 }
 
 export const socialUrls = {

--- a/src/common/routes.ts
+++ b/src/common/routes.ts
@@ -36,6 +36,7 @@ export const routes = {
   logout: '/logout',
   contact: '/contact',
   support: '/support',
+  reports: '/npo/reports',
   campaigns: {
     index: '/campaigns',
     create: '/campaigns/create',

--- a/src/components/faq/contents/common.tsx
+++ b/src/components/faq/contents/common.tsx
@@ -158,7 +158,7 @@ export const COMMON_QUESTIONS: ContentType[] = [
         проследяването и отчетността на насочените дарения към Сдружението. Веднъж месечно
         Подкрепи.бг изготвя публичен отчет на приходящите дарения от изминалия месец, както и на
         основанията за разходваните суми за същия период. Всички отчети до момента можете да видите
-        <ExternalLink variant="subtitle1" href={undefined}>
+        <ExternalLink variant="subtitle1" href="/npo/reports">
           {' тук. '}
         </ExternalLink>
       </ContentTypography>

--- a/src/components/faq/contents/common.tsx
+++ b/src/components/faq/contents/common.tsx
@@ -1,7 +1,7 @@
 import { ContentType } from './content-type'
 import ExternalLink from 'components/common/ExternalLink'
 import ContentTypography from './ContentTypography'
-import { staticUrls } from 'common/routes'
+import { routes, staticUrls } from 'common/routes'
 
 export const COMMON_QUESTIONS: ContentType[] = [
   {
@@ -98,7 +98,7 @@ export const COMMON_QUESTIONS: ContentType[] = [
       <ContentTypography>
         Да, напълно. Сдружение Подкрепи.бг не е обвързано с влияния от политически и друг тип
         организации и субекти. Можете да видите повече в
-        <ExternalLink variant="subtitle1" href="/terms-of-service">
+        <ExternalLink variant="subtitle1" href={routes.termsOfService}>
           {' Условията за ползване на Подкрепи.бг.'}
         </ExternalLink>
       </ContentTypography>
@@ -158,7 +158,7 @@ export const COMMON_QUESTIONS: ContentType[] = [
         проследяването и отчетността на насочените дарения към Сдружението. Веднъж месечно
         Подкрепи.бг изготвя публичен отчет на приходящите дарения от изминалия месец, както и на
         основанията за разходваните суми за същия период. Всички отчети до момента можете да видите
-        <ExternalLink variant="subtitle1" href="/npo/reports">
+        <ExternalLink variant="subtitle1" href={routes.reports}>
           {' тук. '}
         </ExternalLink>
       </ContentTypography>
@@ -254,11 +254,11 @@ export const COMMON_QUESTIONS: ContentType[] = [
           Очаква се в бъдеще да имаме логистични/ куриерски, телекомуникационни и други извънредни
           разходи. Към момента част от разходите ни са покрити от партньори, като например:
           безплатен хостинг от{' '}
-          <ExternalLink variant="subtitle1" href={'https://www.superhosting.bg/'}>
+          <ExternalLink variant="subtitle1" href={staticUrls.hostingProvider}>
             {' SuperHosting '}
           </ExternalLink>{' '}
           или офис пространство от
-          <ExternalLink variant="subtitle1" href={'https://eduspace-bg.business.site/'}>
+          <ExternalLink variant="subtitle1" href={staticUrls.eduspace}>
             {' Eduspace.'}
           </ExternalLink>
         </p>
@@ -272,7 +272,7 @@ export const COMMON_QUESTIONS: ContentType[] = [
       <ContentTypography>
         <p>
           Да, намира се в жк. Белите Брези, бл. 13 и ни е любезно и безвъзмездно предоставен от{' '}
-          <ExternalLink variant="subtitle1" href={'https://eduspace-bg.business.site/'}>
+          <ExternalLink variant="subtitle1" href={staticUrls.eduspace}>
             {' Eduspace.'}
           </ExternalLink>
         </p>

--- a/src/components/layout/nav/ProjectMenu.tsx
+++ b/src/components/layout/nav/ProjectMenu.tsx
@@ -31,6 +31,10 @@ const allNavItems: NavItem[] = [
     label: 'nav.about.support-us',
   },
   {
+    href: routes.reports,
+    label: 'nav.about.reports',
+  },
+  {
     href: routes.contact,
     label: 'nav.about.contacts',
   },


### PR DESCRIPTION
- Added Reports link in About Project menu (leads to '/npo/reports') :
![image](https://user-images.githubusercontent.com/14351733/167010060-1981603b-5394-4c65-91c4-c88860e37627.png)

- Fixed Reports link in FAQ page:
![Screenshot 2022-05-05 215409](https://user-images.githubusercontent.com/14351733/167010341-f95bca21-5722-41b8-9ab0-4c06c06529a3.png)

- Removed hardcoded URLs from FAQ page.