### PR TITLE
Add button hover states in the theme to correspond to the UI theme

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -25,6 +25,6 @@ FEATURE_CAMPAIGN=true
 ## Keycloak ##
 ##############
 
-KEYCLOAK_URL=https://keycloak.podkrepi.bg/auth/
+KEYCLOAK_URL=http://localhost:8080/auth/
 KEYCLOAK_REALM=webapp-dev
 KEYCLOAK_CLIENT_ID=account

--- a/src/common/theme.ts
+++ b/src/common/theme.ts
@@ -46,6 +46,11 @@ export const themeOptions: ThemeOptions = {
     background: {
       default: colors.white.main,
     },
+    info: {
+      main: colors.blue.dark,
+      light: colors.blue.mainDark,
+      dark: darken(colors.blue.dark, 0.2),
+    },
   },
   shape: {
     borderRadius: 3,
@@ -92,14 +97,14 @@ export const themeOptions: ThemeOptions = {
             borderColor: darken(colors.yellow.main, 0.15),
           },
         },
-        containedSecondary: {
-          backgroundColor: colors.yellow.dark,
-        },
         containedPrimary: {
           backgroundColor: colors.blue.main,
           '&:hover': {
             backgroundColor: darken(colors.blue.main, 0.2),
           },
+        },
+        containedSecondary: {
+          backgroundColor: colors.yellow.dark,
         },
       },
     },

--- a/src/common/theme.ts
+++ b/src/common/theme.ts
@@ -1,4 +1,10 @@
-import { createTheme, darken, responsiveFontSizes, ThemeOptions } from '@mui/material/styles'
+import {
+  createTheme,
+  darken,
+  lighten,
+  responsiveFontSizes,
+  ThemeOptions,
+} from '@mui/material/styles'
 
 const fontFamily = 'Montserrat'
 
@@ -14,6 +20,7 @@ const colors = {
   },
   yellow: {
     main: '#FFCB57',
+    dark: '#F6992B',
   },
   gray: {
     main: '#F5F5F5',
@@ -57,6 +64,10 @@ export const themeOptions: ThemeOptions = {
         root: {
           lineHeight: 2,
           borderRadius: '25px',
+          borderWidth: 2,
+          '&:hover': {
+            borderWidth: 2,
+          },
         },
         textPrimary: {
           color: colors.blue.dark,
@@ -65,23 +76,29 @@ export const themeOptions: ThemeOptions = {
           },
         },
         outlined: {
-          '&:hover': {
-            backgroundColor: colors.blue.dark,
-            color: colors.blue.light,
-          },
+          backgroundColor: colors.white.main,
         },
         outlinedPrimary: {
           color: colors.blue.dark,
           '&:hover': {
-            color: colors.blue.light,
-            borderColor: colors.blue.mainDark,
+            backgroundColor: lighten(colors.blue.main, 0.85),
           },
         },
-        containedPrimary: {
-          backgroundColor: colors.blue.dark,
-          color: colors.blue.light,
+        outlinedSecondary: {
+          color: darken(colors.yellow.dark, 0.4),
+          borderColor: colors.yellow.main,
           '&:hover': {
-            backgroundColor: darken(colors.blue.dark, 0.2),
+            backgroundColor: lighten(colors.yellow.main, 0.85),
+            borderColor: darken(colors.yellow.main, 0.15),
+          },
+        },
+        containedSecondary: {
+          backgroundColor: colors.yellow.dark,
+        },
+        containedPrimary: {
+          backgroundColor: colors.blue.main,
+          '&:hover': {
+            backgroundColor: darken(colors.blue.main, 0.2),
           },
         },
       },

--- a/src/components/campaigns/CampaignCard.tsx
+++ b/src/components/campaigns/CampaignCard.tsx
@@ -92,14 +92,6 @@ const useStyles = makeStyles((theme) => ({
   supportNowButton: {
     padding: theme.spacing(1, 4),
   },
-  seeMoreButton: {
-    backgroundColor: theme.palette.common.white,
-    padding: theme.spacing(1, 4),
-    border: `2px solid ${theme.palette.primary.main}`,
-    '&:hover': {
-      border: `2px solid ${theme.palette.primary.dark}`,
-    },
-  },
   progressBar: {
     margin: theme.spacing(2.5),
     textAlign: 'left',
@@ -178,7 +170,6 @@ export default function CampaignCard({ campaign }: Props) {
                 href={routes.campaigns.viewCampaignBySlug(campaign.slug)}
                 variant="contained"
                 color="secondary"
-                className={classes.supportNowButton}
                 endIcon={<Favorite color="error" />}>
                 {t('campaigns:cta.support-now')}
               </LinkButton>
@@ -188,8 +179,6 @@ export default function CampaignCard({ campaign }: Props) {
                 fullWidth
                 href={routes.campaigns.viewCampaignBySlug(campaign.slug)}
                 variant="outlined"
-                size="small"
-                className={classes.seeMoreButton}
                 endIcon={<ArrowForwardIosIcon />}>
                 {t('campaigns:cta.see-more')}
               </LinkButton>

--- a/src/components/campaigns/CampaignForm.tsx
+++ b/src/components/campaigns/CampaignForm.tsx
@@ -283,7 +283,12 @@ export default function CampaignForm({ initialValues = defaults }: CampaignFormP
             <AcceptPrivacyPolicyField name="gdpr" />
           </Grid>
           <Grid item xs={12}>
-            <SubmitButton fullWidth label="campaigns:cta.submit" loading={mutation.isLoading} />
+            <SubmitButton
+              fullWidth
+              label="campaigns:cta.submit"
+              loading={mutation.isLoading}
+              color="info"
+            />
           </Grid>
         </Grid>
       </GenericForm>

--- a/src/components/campaigns/DonorsAndDonations.tsx
+++ b/src/components/campaigns/DonorsAndDonations.tsx
@@ -32,9 +32,6 @@ const useStyles = makeStyles((theme: Theme) =>
       fontSize: theme.spacing(1),
       alignSelf: 'center',
     },
-    seeAllButton: {
-      border: `1px solid ${theme.palette.primary.main}`,
-    },
   }),
 )
 
@@ -89,7 +86,7 @@ export default function DonorsAndDonations({
       </Grid>
       <Grid>
         {donations && donations.length > shownDonationsNumber && (
-          <Button onClick={() => setAll((prev) => !prev)} className={classes.seeAllButton}>
+          <Button onClick={() => setAll((prev) => !prev)} variant="outlined">
             {all ? t('campaigns:cta.see-less') : t('campaigns:cta.see-all')}
           </Button>
         )}

--- a/src/components/campaigns/InlineDonation.tsx
+++ b/src/components/campaigns/InlineDonation.tsx
@@ -42,17 +42,9 @@ const useStyles = makeStyles((theme: Theme) =>
       fontWeight: 'bold',
       fontSize: theme.spacing(2),
     },
-    shareButton: {
-      padding: theme.spacing(0.75, 0),
-      borderColor: theme.palette.warning.main,
-      color: 'black',
-    },
     donationPriceList: {
       display: 'contents',
       textAlignLast: 'center',
-    },
-    supportButton: {
-      background: theme.palette.warning.light,
     },
   }),
 )
@@ -130,10 +122,8 @@ export default function InlineDonation({ campaign }: Props) {
           fullWidth
           href="#"
           variant="outlined"
-          size="small"
           startIcon={<ShareIcon />}
-          color="secondary"
-          className={classes.shareButton}>
+          color="secondary">
           {t('campaigns:cta.share')}
         </LinkButton>
         <LinkButton
@@ -142,7 +132,6 @@ export default function InlineDonation({ campaign }: Props) {
           onClick={onClick}
           variant="contained"
           color="secondary"
-          className={classes.supportButton}
           startIcon={<Favorite color="action" />}>
           {t('common:support')}
         </LinkButton>

--- a/src/components/index/sections/CampaignsSection.tsx
+++ b/src/components/index/sections/CampaignsSection.tsx
@@ -50,7 +50,8 @@ export default function CampaignsSection() {
           ))}
           <LinkButton
             href={routes.campaigns.index}
-            variant="outlined"
+            variant="contained"
+            color="info"
             endIcon={<ChevronRightIcon />}
             sx={{ marginTop: '2rem' }}>
             {t('index:campaign.see-all')}

--- a/src/components/index/sections/FaqSection.tsx
+++ b/src/components/index/sections/FaqSection.tsx
@@ -2,6 +2,7 @@ import { Container, Grid, Theme } from '@mui/material'
 import { createStyles, makeStyles } from '@mui/styles'
 import ChevronRightIcon from '@mui/icons-material/ChevronRight'
 import { useTranslation } from 'next-i18next'
+import theme from 'common/theme'
 import LinkButton from 'components/common/LinkButton'
 import { routes } from 'common/routes'
 import * as data from '../../faq/contents'
@@ -47,7 +48,7 @@ export default function FaqSection() {
           href={routes.faq}
           variant="outlined"
           endIcon={<ChevronRightIcon />}
-          sx={{ marginTop: '1rem', marginBottom: '1rem' }}>
+          sx={{ marginY: theme.spacing(2) }}>
           {t('index:campaign.see-all')}
         </LinkButton>
       </Grid>

--- a/src/components/index/sections/ReadyToStartCampaignSection.tsx
+++ b/src/components/index/sections/ReadyToStartCampaignSection.tsx
@@ -16,10 +16,8 @@ const useStyles = makeStyles(() =>
       textAlign: 'center',
     },
     button: {
-      background: theme.palette.primary.main,
-      borderRadius: '61px',
-      color: 'black',
       margin: 'auto',
+      color: 'black',
     },
     content: {
       display: 'flex',
@@ -50,7 +48,8 @@ export default function ReadyToStartCampaignSection() {
       <Grid item>
         <LinkButton
           href={routes.campaigns.create}
-          variant="outlined"
+          variant="contained"
+          color="primary"
           endIcon={<ChevronRightIcon />}
           className={classes.button}>
           {t('index:ready-to-start-campaign-section.button')}

--- a/src/components/index/sections/WantToHelpPodkrepiBg.tsx
+++ b/src/components/index/sections/WantToHelpPodkrepiBg.tsx
@@ -27,9 +27,6 @@ const useStyles = makeStyles(() =>
       fontFamily: 'Montserrat',
     },
     button: {
-      background: theme.palette.primary.main,
-      border: `2px solid ${theme.palette.primary.main}`,
-      borderRadius: '61px',
       color: 'black',
       margin: 'auto',
     },
@@ -63,6 +60,7 @@ export default function WantToHelpPodkrepiBgSection() {
         </Grid>
         <Grid item>
           <LinkButton
+            variant="contained"
             href={routes.support}
             className={classes.button}
             endIcon={<ChevronRightIcon />}>

--- a/src/components/layout/nav/PrivateMenu.tsx
+++ b/src/components/layout/nav/PrivateMenu.tsx
@@ -8,6 +8,7 @@ import { routes } from 'common/routes'
 import { isAdmin } from 'common/util/roles'
 import { useSession } from 'common/util/useSession'
 import LinkMenuItem from 'components/common/LinkMenuItem'
+import theme from 'common/theme'
 
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
@@ -46,7 +47,7 @@ export default function PrivateMenu() {
         {session.picture ? (
           <Avatar title={title} alt={title} src={session.picture} />
         ) : (
-          <AccountCircle color="info" />
+          <AccountCircle sx={{ fill: theme.palette.info.light }} />
         )}
       </IconButton>
       <Menu

--- a/src/components/layout/nav/PublicMenu.tsx
+++ b/src/components/layout/nav/PublicMenu.tsx
@@ -9,6 +9,7 @@ import LinkMenuItem from 'components/common/LinkMenuItem'
 
 import makeStyles from '@mui/styles/makeStyles'
 import createStyles from '@mui/styles/createStyles'
+import theme from 'common/theme'
 
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
@@ -43,7 +44,7 @@ export default function PublicMenu() {
   return (
     <Grid item>
       <IconButton onClick={handleMenu} size="large">
-        <AccountCircle color="info" />
+        <AccountCircle sx={{ fill: theme.palette.info.light }} />
       </IconButton>
       <Menu
         open={Boolean(anchorEl)}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and context

The current state of the buttons was pretty random and there were styling on top of the default button stylings. 



I have now changevdthe styles to be in tact with the UI Kit and in my opinion this way they look better.
This is the reference design:
<img width="1069" alt="image" src="https://user-images.githubusercontent.com/61479393/167727397-96ac5cc3-f000-4398-8577-e5c4a3d4b337.png">
https://www.figma.com/file/MmvFKzUv6yE5U2wrOpWtwS/Podkrepi.bg?node-id=38%3A3937

There are quite a bit of changes to the theme though and everything has to be looked at by QA if possible since there might be problems that arise from that.

## Screenshots:

| Before              | After              |
| ------------------- | ------------------ |
|<img width="1109" alt="image" src="https://user-images.githubusercontent.com/61479393/167727719-4a8ef5ae-a986-4a18-ad65-dbca2f68d43f.png">|<img width="1176" alt="image" src="https://user-images.githubusercontent.com/61479393/167727646-82ceb61f-d257-400f-85ed-11e2d41ba870.png">|

## Testing

Went through most of the pages and didn't see any blatant problems
