### PR TITLE
Fix borderRadius styles

### DIFF
--- a/src/common/theme.ts
+++ b/src/common/theme.ts
@@ -61,7 +61,7 @@ export const themeOptions: ThemeOptions = {
     },
   },
   shape: {
-    borderRadius: 3,
+    borderRadius: '25px',
   },
   components: {
     MuiLink: {

--- a/src/components/about-project/sections/TimelineItem.tsx
+++ b/src/components/about-project/sections/TimelineItem.tsx
@@ -22,9 +22,7 @@ const useStyles = makeStyles((theme: Theme) =>
     },
     icon: {
       fontSize: theme.typography.pxToRem(40),
-      // backgroundColor: theme.palette.primary.dark,
       padding: '.5rem',
-      // borderRadius: '50%',
       boxSizing: 'content-box',
     },
     contentContainer: {},

--- a/src/components/admin/navigation/AdminContainer.tsx
+++ b/src/components/admin/navigation/AdminContainer.tsx
@@ -11,7 +11,7 @@ export default function AdminContainer({ title, children }: Props) {
     <Container
       maxWidth={false}
       sx={{
-        borderRadius: '13px',
+        borderRadius: '25px',
         minHeight: 'calc(100vh - 64px)',
         position: 'relative',
         background: '#e9f6ff',
@@ -23,7 +23,7 @@ export default function AdminContainer({ title, children }: Props) {
             background: 'white',
             minHeight: '20rem',
             flexDirection: 'column',
-            borderRadius: '13px',
+            borderRadius: '25px',
           }}>
           <AppBarMenu title={title} />
           {children}

--- a/src/components/admin/navigation/AppBarMenu.tsx
+++ b/src/components/admin/navigation/AppBarMenu.tsx
@@ -27,7 +27,7 @@ export default function AppBarMenu({ title }: Props) {
         <Typography fontSize={'18px'} sx={{ px: 0.5, height: '20px' }}>
           /
         </Typography>
-        <IconButton sx={{ borderRadius: '10px' }}>
+        <IconButton sx={{ borderRadius: '25px' }}>
           <Typography>{title}</Typography>
         </IconButton>
       </Box>

--- a/src/components/admin/navigation/HoverMenu.tsx
+++ b/src/components/admin/navigation/HoverMenu.tsx
@@ -46,7 +46,7 @@ export default function HoverMenu({ menu, items, icon: Icon, isOpen }: Props) {
       <ListItemButton
         selected={isSelected}
         onClick={handleOpenMenu}
-        sx={{ borderRadius: '0 20px 20px 0' }}>
+        sx={{ borderRadius: '0 25px 25px 0' }}>
         <ListItemIcon
           title={menu}
           sx={(theme) => ({

--- a/src/components/auth/profile/ProfilePage.tsx
+++ b/src/components/auth/profile/ProfilePage.tsx
@@ -65,7 +65,7 @@ export default function ProfilePage() {
         <Box
           sx={{
             backgroundColor: 'white',
-            borderRadius: '10px 10px 0px 0px',
+            borderRadius: '25px 25px 0px 0px',
             padding: '10px 30px',
           }}>
           <h1 className={classes.h1}>Дарителски профил</h1>

--- a/src/components/campaigns/CampaignProgress.tsx
+++ b/src/components/campaigns/CampaignProgress.tsx
@@ -7,13 +7,13 @@ import withStyles from '@mui/styles/withStyles'
 const BorderLinearProgress = withStyles((theme) => ({
   root: {
     height: theme.spacing(1.5),
-    borderRadius: 5,
+    borderRadius: '6px',
   },
   // colorPrimary: {
   //  backgroundColor: theme.palette.grey[theme.palette.mode === 'light' ? 200 : 700],
   // },
   bar: {
-    borderRadius: 5,
+    borderRadius: '6px',
     backgroundColor: '#1a90ff',
   },
 }))(LinearProgress)

--- a/src/components/index/sections/Jumbotron.tsx
+++ b/src/components/index/sections/Jumbotron.tsx
@@ -38,47 +38,11 @@ const useStyles = makeStyles((theme) =>
       marginTop: theme.spacing(2),
       fontWeight: 400,
     },
-    aboutProjectButton: {
-      color: darken(theme.palette.secondary.main, 0.8),
-      border: `none`,
-      borderRadius: '500px',
-      padding: theme.spacing(1.5, 4),
-      fontWeight: 500,
-      fontSize: theme.typography.pxToRem(15),
-      minWidth: theme.spacing(27),
-      height: theme.spacing(7),
-      margin: theme.spacing(2),
-      [theme.breakpoints.up('sm')]: {
-        margin: theme.spacing(3),
-      },
-    },
-    podkrepiButton: {
-      border: `none`,
-      borderRadius: '500px',
-      fontWeight: 500,
-      fontSize: theme.typography.pxToRem(15),
-      minWidth: theme.spacing(27),
-      height: theme.spacing(7),
-      margin: theme.spacing(2),
-      [theme.breakpoints.up('sm')]: {
-        margin: theme.spacing(3),
-      },
-    },
     scrollButton: {
       marginTop: theme.spacing(7),
       zIndex: 10,
       [theme.breakpoints.up(1600)]: {
         marginTop: theme.spacing(20),
-      },
-    },
-    scrollButtonIcon: {
-      border: `1px solid ${theme.palette.common.white}`,
-      borderRadius: '50%',
-      width: theme.spacing(5),
-      height: theme.spacing(5),
-      '&:hover': {
-        cursor: 'pointer',
-        color: theme.palette.secondary.main,
       },
     },
   }),

--- a/src/components/index/sections/ReadyToStartCampaignSection.tsx
+++ b/src/components/index/sections/ReadyToStartCampaignSection.tsx
@@ -17,6 +17,9 @@ const useStyles = makeStyles(() =>
     },
     button: {
       margin: 'auto',
+      background: theme.palette.primary.main,
+      border: `2px solid ${theme.palette.primary.main}`,
+      borderRadius: theme.shape.borderRadius,
       color: 'black',
     },
     content: {

--- a/src/components/index/sections/WantToHelpPodkrepiBg.tsx
+++ b/src/components/index/sections/WantToHelpPodkrepiBg.tsx
@@ -27,6 +27,9 @@ const useStyles = makeStyles(() =>
       fontFamily: 'Montserrat',
     },
     button: {
+      background: theme.palette.primary.main,
+      border: `2px solid ${theme.palette.primary.main}`,
+      borderRadius: theme.shape.borderRadius,
       color: 'black',
       margin: 'auto',
     },

--- a/src/components/layout/nav/DonationMenuMobile.tsx
+++ b/src/components/layout/nav/DonationMenuMobile.tsx
@@ -15,7 +15,7 @@ const useStyles = makeStyles((theme: Theme) =>
     accordionWrapper: {
       boxShadow: 'none',
       border: '1px solid rgba(50, 169, 254, 0.5)',
-      borderRadius: '25px !important',
+      borderRadius: `${theme.shape.borderRadius} !important`,
       color: theme.palette.primary.dark,
       textAlign: 'center',
     },

--- a/src/components/support-form/SupportForm.tsx
+++ b/src/components/support-form/SupportForm.tsx
@@ -45,7 +45,6 @@ const ColorlibConnector = withStyles({
     height: 3,
     border: 0,
     backgroundColor: '#eaeaf0',
-    borderRadius: 1,
   },
 })(StepConnector)
 


### PR DESCRIPTION
- Inherited the borderRadius styles from the theme - theme.shape.borderRadius (25px).
- Removed the style where it is not used.
- Removed unused styles on Homepage.

- borderRadius is still inlined in Admin panel where it is not inherited from the theme, but has the default value of 25px.
- borderRadius: '50%' is saved, it makes the icons round.