### PR TITLE
Add returnUrl to secured props and made the login to redirect to crea…

### DIFF
--- a/src/middleware/auth/securedProps.ts
+++ b/src/middleware/auth/securedProps.ts
@@ -12,13 +12,12 @@ export const securedProps: (
   returnUrl?: string,
 ) => Promise<GetServerSidePropsResult<Session>> = async (ctx, returnUrl?: string) => {
   const session = await getSession(ctx)
-
+  let url = returnUrl ?? ctx.req.url ?? ''
+  if (url.startsWith('_next') || url.startsWith('_error')) url = '/'
   if (!session) {
     return {
       redirect: {
-        destination: `${routes.login}?callbackUrl=${encodeURIComponent(
-          returnUrl ?? ctx.req.url ?? '',
-        )}`,
+        destination: `${routes.login}?callbackUrl=${encodeURIComponent(url)}`,
         permanent: false,
       },
     }

--- a/src/middleware/auth/securedProps.ts
+++ b/src/middleware/auth/securedProps.ts
@@ -13,7 +13,7 @@ export const securedProps: (
 ) => Promise<GetServerSidePropsResult<Session>> = async (ctx, returnUrl?: string) => {
   const session = await getSession(ctx)
   let url = returnUrl ?? ctx.req.url ?? ''
-  if (url.startsWith('_next') || url.startsWith('_error')) url = '/'
+  if (url.startsWith('/_next') || url.startsWith('/_error')) url = '/'
   if (!session) {
     return {
       redirect: {

--- a/src/middleware/auth/securedProps.ts
+++ b/src/middleware/auth/securedProps.ts
@@ -29,10 +29,13 @@ export const securedProps: (
   }
 }
 
-export const securedPropsWithTranslation: (namespaces?: string[]) => GetServerSideProps<Session> =
-  (namespaces = ['common', 'auth', 'validation']) =>
+export const securedPropsWithTranslation: (
+  namespaces?: string[],
+  returnUrl?: string,
+) => GetServerSideProps<Session> =
+  (namespaces = ['common', 'auth', 'validation'], returnUrl) =>
   async (ctx) => {
-    const response = await securedProps(ctx)
+    const response = await securedProps(ctx, returnUrl)
     if ('props' in response) {
       return {
         props: {

--- a/src/pages/campaigns/create.tsx
+++ b/src/pages/campaigns/create.tsx
@@ -1,17 +1,11 @@
 import { GetServerSideProps } from 'next'
-import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
-
 import CreateCampaignPage from 'components/campaigns/CreateCampaignPage'
+import { securedPropsWithTranslation } from 'middleware/auth/securedProps'
+import { routes } from 'common/routes'
 
-export const getServerSideProps: GetServerSideProps = async ({ locale }) => ({
-  props: {
-    ...(await serverSideTranslations(locale ?? 'bg', [
-      'common',
-      'auth',
-      'validation',
-      'campaigns',
-    ])),
-  },
-})
+export const getServerSideProps: GetServerSideProps = securedPropsWithTranslation(
+  ['common', 'auth', 'validation', 'campaigns'],
+  routes.campaigns.create,
+)
 
 export default CreateCampaignPage


### PR DESCRIPTION
## Motivation and context

Closes #363.

Added a returnUrl to the secured props with translation since when next return `ctx.req.url` as a callbackUrl it returns this
![image](https://user-images.githubusercontent.com/61479393/168469838-56572332-8369-4407-80be-9a192962ebb2.png)

Is redirecting like that with a returnUrl parameter ok or is there something more to it?