### PR TITLE
Fix 'How everything begin' hyperlink on About Us page

### DIFF
--- a/src/components/about/sections/HowEverythingBegin.tsx
+++ b/src/components/about/sections/HowEverythingBegin.tsx
@@ -27,7 +27,7 @@ export default function HowEverythingBegin() {
     <StyledGrid container alignItems="center" spacing={4}>
       <Grid xs={12} item>
         <Heading
-          id="principles-that-unite-us"
+          id="how-everyting-begin"
           variant="h4"
           component="h1"
           align="center"


### PR DESCRIPTION
The issue was caused by the incorrect id of the title.