### PR TITLE
Feature/770 google provider login

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -27,5 +27,5 @@ FEATURE_CAMPAIGN=true
 ##############
 NEXTAUTH_URL=http://localhost:3040
 NEXTAUTH_SECRET=super-dev-secret
-GOOGLE_ID=333154281816-5rfm87qo5s98ubslj44fo9o2h2636sdd.apps.googleusercontent.com
-GOOGLE_SECRET=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
+GOOGLE_ID=
+GOOGLE_SECRET=

--- a/.env.local.example
+++ b/.env.local.example
@@ -27,5 +27,5 @@ FEATURE_CAMPAIGN=true
 ##############
 NEXTAUTH_URL=http://localhost:3040
 NEXTAUTH_SECRET=super-dev-secret
-GOOGLE_ID=
-GOOGLE_SECRET=
+GOOGLE_ID=333154281816-5rfm87qo5s98ubslj44fo9o2h2636sdd.apps.googleusercontent.com
+GOOGLE_SECRET=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

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "formik": "2.2.9",
     "highcharts": "9.1.0",
     "highcharts-react-official": "3.0.0",
+    "jwt-decode": "^3.1.2",
     "lodash": "^4.17.21",
     "mobx": "6.3.2",
     "mobx-react": "7.2.0",

--- a/src/common/util/parseJWT.ts
+++ b/src/common/util/parseJWT.ts
@@ -1,7 +1,0 @@
-export function parseJWT<T>(token: string): T | null {
-  try {
-    return JSON.parse(atob(token.split('.')[1]))
-  } catch (e) {
-    return null
-  }
-}

--- a/src/common/util/roles.ts
+++ b/src/common/util/roles.ts
@@ -58,10 +58,7 @@ export const isAdmin = (session: Session | JWT | null): boolean => {
       realmRoles: session.user?.realm_access.roles ?? [],
       resourceRoles: session.user?.resource_access.account.roles ?? [],
     }
-    return (
-      canViewContactRequests(sessionRoles) &&
-      canViewSupporters(sessionRoles)
-    )
+    return canViewContactRequests(sessionRoles) && canViewSupporters(sessionRoles)
   }
   return false
 }

--- a/src/components/auth/login/LoginForm.tsx
+++ b/src/components/auth/login/LoginForm.tsx
@@ -1,5 +1,5 @@
 import * as yup from 'yup'
-import { Grid } from '@mui/material'
+import { Button, Grid } from '@mui/material'
 import React, { useState } from 'react'
 import { useRouter } from 'next/router'
 import { signIn } from 'next-auth/react'
@@ -12,6 +12,7 @@ import FormInput from 'components/common/form/FormInput'
 import GenericForm from 'components/common/form/GenericForm'
 import SubmitButton from 'components/common/form/SubmitButton'
 import FormTextField from 'components/common/form/FormTextField'
+import Google from 'common/icons/Google'
 
 export type LoginFormData = {
   email: string
@@ -64,7 +65,10 @@ export default function LoginForm({ initialValues = defaults }: LoginFormProps) 
       setLoading(false)
     }
   }
-
+  const onGoogleLogin = () => {
+    const resp = signIn('google')
+    console.log(resp)
+  }
   return (
     <GenericForm
       onSubmit={onSubmit}
@@ -85,6 +89,11 @@ export default function LoginForm({ initialValues = defaults }: LoginFormProps) 
         </Grid>
         <Grid item xs={12}>
           <SubmitButton fullWidth label="auth:cta.login" loading={loading} />
+        </Grid>
+        <Grid item xs={12}>
+          <Button fullWidth onClick={onGoogleLogin}>
+            <Google /> {t('auth:cta.login')}
+          </Button>
         </Grid>
       </Grid>
     </GenericForm>

--- a/src/components/common/form/RadioButtonGroup.tsx
+++ b/src/components/common/form/RadioButtonGroup.tsx
@@ -53,15 +53,17 @@ export default function RadioButtonGroup({
         {...muiRadioGroupProps}>
         <Grid rowSpacing={2} columnSpacing={2} container>
           {options ? (
-            options.map(({ label: optionLabel, value: optionValue }, index) => (
-              <Grid key={index} item xs={12} sm={6} {...muiRadioButtonGridProps}>
-                <PriceRadioButton
-                  value={optionValue}
-                  checked={optionValue == field.value}
-                  label={optionLabel}
-                />
-              </Grid>
-            ))
+            <>
+              {options.map(({ label: optionLabel, value: optionValue }, index) => (
+                <Grid key={index} item xs={12} sm={6} {...muiRadioButtonGridProps}>
+                  <PriceRadioButton
+                    value={optionValue}
+                    checked={optionValue == field.value}
+                    label={optionLabel}
+                  />
+                </Grid>
+              ))}
+            </>
           ) : (
             <Typography>There are no avaliable choices you can make :(</Typography>
           )}

--- a/src/components/index/sections/Jumbotron.tsx
+++ b/src/components/index/sections/Jumbotron.tsx
@@ -3,8 +3,6 @@ import { useTranslation } from 'next-i18next'
 import { Container, Grid, Theme, Typography } from '@mui/material'
 import useMediaQuery from '@mui/material/useMediaQuery'
 import Image from 'next/image'
-
-import Typewriter from '../helpers/Typewriter'
 import LinkButton from 'components/common/LinkButton'
 import theme from 'common/theme'
 import { routes } from 'common/routes'

--- a/src/components/index/sections/Jumbotron.tsx
+++ b/src/components/index/sections/Jumbotron.tsx
@@ -45,7 +45,7 @@ export default function Jumbotron() {
         objectPosition="70% 50%"
         style={{ zIndex: -1 }}
       />
-      <Container maxWidth="xl">
+      <Container maxWidth="lg">
         <Grid item textAlign="left" sx={{ xs: { mb: 4 }, mb: 8 }}>
           <Typography
             maxWidth="lg"

--- a/src/components/one-time-donation/steps/FirstStep.tsx
+++ b/src/components/one-time-donation/steps/FirstStep.tsx
@@ -120,7 +120,8 @@ export default function FirstStep() {
                 .map((v) => ({
                   label: money(Number(v.unit_amount)),
                   value: v.id,
-                })) || []
+                }))
+                .concat({ label: 'Other', value: 'other' }) || []
             }
           />
         </Box>

--- a/src/pages/api/auth/[...nextauth].ts
+++ b/src/pages/api/auth/[...nextauth].ts
@@ -122,8 +122,13 @@ export const options: NextAuthOptions = {
       return session
     },
     async jwt({ token, user, account }) {
-      // Initial sign in
       if (account && user) {
+        // Initial sign in only triggered when a provider is logging
+        // Since when there are credentials the `user` and `account` are undefined
+        // With credentials the token is already with this structure since that is what is returned from the `authorize` function:
+        // accessToken: keycloakToken.accessToken,
+        // accessTokenExpires: Date.now() + Number(keycloakToken.expires) * 1000,
+        // refreshToken: keycloakToken.refreshToken,
         const keycloakToken = await getAccessTokenFromProvider(
           account.access_token,
           account.provider,

--- a/src/pages/api/auth/[...nextauth].ts
+++ b/src/pages/api/auth/[...nextauth].ts
@@ -1,70 +1,17 @@
 import { AxiosResponse } from 'axios'
-import { parseJWT } from 'common/util/parseJWT'
-import { RealmRole, ResourceRole } from 'common/util/roles'
+import jwtDecode from 'jwt-decode'
 import NextAuth, { EventCallbacks, NextAuthOptions, Session } from 'next-auth'
-import { JWT } from 'next-auth/jwt'
 import CredentialsProvider from 'next-auth/providers/credentials'
 import GoogleProvider from 'next-auth/providers/google'
 import { apiClient } from 'service/apiClient'
 import { endpoints } from 'service/apiEndpoints'
-
-interface KeycloakTokenParsed {
-  // keycloak-js
-  exp?: number
-  iat?: number
-  nonce?: string
-  sub?: string
-  session_state?: string
-  realm_access?: KeycloakRoles
-  resource_access?: KeycloakResourceAccess
-}
-interface KeycloakResourceAccess {
-  [key: string]: KeycloakRoles
-}
-
-interface KeycloakRoles {
-  roles: string[]
-}
-
-export type ParsedToken = KeycloakTokenParsed & {
-  name?: string
-  email?: string
-  given_name?: string
-  family_name?: string
-  preferred_username?: string
-  email_verified?: boolean
-  picture?: string
-  'allowed-origins'?: string[]
-}
-
-export type ServerUser = ParsedToken & {
-  scope: string
-  theme: string
-  locale: string
-  name: string
-  email: string
-  email_verified: boolean
-  given_name: string
-  family_name: string
-  preferred_username: string
-  picture?: string
-  session_state: string
-  'allowed-origins': string[]
-  // access
-  realm_access: { roles: RealmRole[] }
-  resource_access: { account: { roles: ResourceRole[] } }
-  // system
-  exp: number
-  iat: number
-  jti: string
-  iss: string
-  aud: string
-  sub: string
-  typ: string
-  azp: string
-  acr: string
-  sid: string
-}
+import {
+  AuthResponse,
+  getAccessTokenFromProvider,
+  LoginInput,
+  refreshAccessToken,
+  ServerUser,
+} from 'service/auth'
 
 declare module 'next-auth/jwt' {
   /**
@@ -75,6 +22,7 @@ declare module 'next-auth/jwt' {
     accessTokenExpires: number
     refreshToken: string
     user: ServerUser | null
+    expires?: number
   }
 }
 declare module 'next-auth' {
@@ -96,17 +44,8 @@ declare module 'next-auth' {
     expires: number
     accessToken: string
     refreshToken: string
+    picture: string
   }
-}
-
-type AuthResponse = {
-  accessToken: string
-  refreshToken: string
-  expires: number
-}
-type LoginInput = {
-  email: string
-  password: string
 }
 
 const onCreate: EventCallbacks['createUser'] = async ({ user }) => {
@@ -116,35 +55,6 @@ const onCreate: EventCallbacks['createUser'] = async ({ user }) => {
     console.log(`Sent email`)
   } catch (error) {
     console.log(`❌ Unable to send welcome email to user (${email})`)
-  }
-}
-async function refreshAccessToken(token: string): Promise<JWT> {
-  try {
-    const response = await apiClient.post<AuthResponse>(
-      endpoints.auth.refresh.url,
-      { refreshToken: token },
-      {
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        method: 'POST',
-      },
-    )
-
-    if (response.status !== 201) {
-      throw new Error()
-    }
-
-    const authRes = response.data
-    console.log('refreshed')
-    return {
-      ...authRes,
-      user: parseJWT<ServerUser>(authRes.accessToken),
-      accessTokenExpires: Date.now() + authRes.expires * 1000,
-    }
-  } catch (error) {
-    console.log(error)
-    throw new Error('RefreshAccessTokenError')
   }
 }
 export const options: NextAuthOptions = {
@@ -201,13 +111,12 @@ export const options: NextAuthOptions = {
     }),
   ],
   callbacks: {
-    async signIn({ user, account, profile, email, credentials }) {
-      console.log('SIGN IN CALLBACK', { user, account, profile, email, credentials })
-      console.log('signIn', user, account, profile)
+    async signIn({ user, account }) {
+      // Can be used to check if the user is allowed to log in or not
       return true
     },
     async session({ session, token }): Promise<Session> {
-      session.user = token.user
+      session.user = jwtDecode<ServerUser>(token.accessToken)
       session.accessToken = token.accessToken
 
       return session
@@ -215,11 +124,17 @@ export const options: NextAuthOptions = {
     async jwt({ token, user, account }) {
       // Initial sign in
       if (account && user) {
+        const keycloakToken = await getAccessTokenFromProvider(
+          account.access_token,
+          account.provider,
+          token.picture as string,
+        )
         return {
-          accessToken: user.accessToken,
-          accessTokenExpires: Date.now() + user.expires * 1000,
-          refreshToken: user.refreshToken,
-          user: parseJWT<ServerUser>(user.accessToken),
+          accessToken: keycloakToken.accessToken,
+          // This is called the first time only here expires always exists and that calculates the timestamp that the token would actually expire in
+          accessTokenExpires: Date.now() + Number(keycloakToken.expires) * 1000,
+          refreshToken: keycloakToken.refreshToken,
+          user: jwtDecode<ServerUser>(keycloakToken.accessToken),
         }
       }
 

--- a/src/service/apiEndpoints.ts
+++ b/src/service/apiEndpoints.ts
@@ -10,6 +10,7 @@ export const endpoints = {
     login: <Endpoint>{ url: '/login', method: 'POST' },
     register: <Endpoint>{ url: '/register', method: 'POST' },
     refresh: <Endpoint>{ url: '/refresh', method: 'POST' },
+    providerLogin: <Endpoint>{ url: '/provider-login', method: 'POST' },
   },
   campaign: {
     listCampaigns: <Endpoint>{ url: '/campaign/list', method: 'GET' },

--- a/src/service/auth.ts
+++ b/src/service/auth.ts
@@ -1,12 +1,82 @@
 import { AxiosResponse } from 'axios'
 import { useMutation } from 'react-query'
+import { JWT } from 'next-auth/jwt'
 
 import { apiClient } from 'service/apiClient'
 import { endpoints } from 'service/apiEndpoints'
 import { Person } from 'gql/person'
+import { RealmRole, ResourceRole } from 'common/util/roles'
+import jwtDecode from 'jwt-decode'
 
-type RegisterResponse = Person
-type RegisterInput = {
+export interface KeycloakTokenParsed {
+  // keycloak-js
+  exp?: number
+  iat?: number
+  nonce?: string
+  sub?: string
+  session_state?: string
+  realm_access?: KeycloakRoles
+  resource_access?: KeycloakResourceAccess
+}
+export interface KeycloakResourceAccess {
+  [key: string]: KeycloakRoles
+}
+
+export interface KeycloakRoles {
+  roles: string[]
+}
+
+export type ParsedToken = KeycloakTokenParsed & {
+  name?: string
+  email?: string
+  given_name?: string
+  family_name?: string
+  preferred_username?: string
+  email_verified?: boolean
+  picture?: string
+  'allowed-origins'?: string[]
+}
+
+export type ServerUser = ParsedToken & {
+  scope: string
+  theme: string
+  locale: string
+  name: string
+  email: string
+  email_verified: boolean
+  given_name: string
+  family_name: string
+  preferred_username: string
+  picture?: string
+  session_state: string
+  'allowed-origins': string[]
+  // access
+  realm_access: { roles: RealmRole[] }
+  resource_access: { account: { roles: ResourceRole[] } }
+  // system
+  exp: number
+  iat: number
+  jti: string
+  iss: string
+  aud: string
+  sub: string
+  typ: string
+  azp: string
+  acr: string
+  sid: string
+}
+export type RegisterResponse = Person
+export type RegisterInput = {
+  email: string
+  password: string
+}
+
+export type AuthResponse = {
+  accessToken: string
+  refreshToken: string
+  expires: number
+}
+export type LoginInput = {
   email: string
   password: string
 }
@@ -23,4 +93,68 @@ export function useRegister() {
     endpoints.auth.register.url,
     { mutationFn: register },
   )
+}
+
+export async function refreshAccessToken(token: string): Promise<JWT> {
+  console.log(token)
+  try {
+    const response = await apiClient.post<AuthResponse>(
+      endpoints.auth.refresh.url,
+      { refreshToken: token },
+      {
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        method: 'POST',
+      },
+    )
+
+    if (response.status !== 201) {
+      throw new Error()
+    }
+
+    const authRes = response.data
+    console.log('refreshed')
+    return {
+      ...authRes,
+      user: jwtDecode<ServerUser>(authRes.accessToken),
+      accessTokenExpires: Date.now() + authRes.expires * 1000,
+    }
+  } catch (error) {
+    console.log(error)
+    throw new Error('RefreshAccessTokenError')
+  }
+}
+
+export async function getAccessTokenFromProvider(
+  token: string | undefined,
+  provider: string,
+  picture: string,
+): Promise<JWT> {
+  try {
+    const response = await apiClient.post<AuthResponse>(
+      endpoints.auth.providerLogin.url,
+      { providerToken: token, provider, picture },
+      {
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        method: 'POST',
+      },
+    )
+
+    if (response.status !== 201) {
+      throw new Error()
+    }
+
+    const authRes = response.data
+    return {
+      ...authRes,
+      user: jwtDecode<ServerUser>(authRes.accessToken),
+      accessTokenExpires: Date.now() + authRes.expires * 1000,
+    }
+  } catch (error) {
+    console.log(error)
+    throw new Error('FetchAccessTokenError')
+  }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5224,6 +5224,11 @@ jss@10.9.0, jss@^10.8.2:
     array-includes "^3.1.2"
     object.assign "^4.1.2"
 
+jwt-decode@^3.1.2:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/jwt-decode/-/jwt-decode-3.1.2.tgz#3fb319f3675a2df0c2895c8f5e9fa4b67b04ed59"
+  integrity sha512-UfpWE/VZn0iP50d8cz9NrZLM9lSWhcJ+0Gt/nm4by88UL+J1SiKN8/5dkjMmbEzwL2CAe+67GsegCbIKtbp75A==
+
 kind-of@^6.0.2, kind-of@^6.0.3:
   version "6.0.3"
   resolved "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and context

Add functionality to login with Google which sends a call to the API with the Google Access token from the NextAuth server layer. Then it takes the `keycloakAccess` token and passes it on to the frontend as a normal user with credentials would

## Testing

Tested all pages and the token refresh. Everything seems to work!

**New environment variables**:

You would now need to provide  and GOOGLE_SECRET in order to be able to
- `GOOGLE_ID` : Google ID from the Google console
- `GOOGLE_SECRET` : Google secret from the Google console

**New dependencies**:

- `jwtDecode` : An auth0 maintaned library to decode JWT's since the old way as blowing unexpectedly sometimes.

