### PR TITLE
Fixed permission checks when logging with default users for local-keycloak

### DIFF
--- a/src/common/util/roles.ts
+++ b/src/common/util/roles.ts
@@ -56,7 +56,7 @@ export const isAdmin = (session: Session | JWT | null): boolean => {
   if (session) {
     const sessionRoles: SessionRoles = {
       realmRoles: session.user?.realm_access.roles ?? [],
-      resourceRoles: session.user?.resource_access.account.roles ?? [],
+      resourceRoles: session.user?.resource_access?.account.roles ?? [],
     }
     return canViewContactRequests(sessionRoles) && canViewSupporters(sessionRoles)
   }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and context
The check for assigned roles was failing for users with Realm roles only. Fixed by checking for null object when collecting roles.
