### PR TITLE
Fix borderRadius styles

### DIFF
--- a/src/common/theme.ts
+++ b/src/common/theme.ts
@@ -61,7 +61,7 @@ export const themeOptions: ThemeOptions = {
     },
   },
   shape: {
-    borderRadius: 3,
+    borderRadius: '25px',
   },
   components: {
     MuiLink: {

--- a/src/components/about-project/sections/TimelineItem.tsx
+++ b/src/components/about-project/sections/TimelineItem.tsx
@@ -35,9 +35,7 @@ const StyledTimelineItemMaterial = styled(TimelineItemMaterial)(({ theme }) => (
 
   [`& .${classes.icon}`]: {
     fontSize: theme.typography.pxToRem(40),
-    // backgroundColor: theme.palette.primary.dark,
     padding: '.5rem',
-    // borderRadius: '50%',
     boxSizing: 'content-box',
   },
 

--- a/src/components/admin/navigation/AdminContainer.tsx
+++ b/src/components/admin/navigation/AdminContainer.tsx
@@ -11,7 +11,7 @@ export default function AdminContainer({ title, children }: Props) {
     <Container
       maxWidth={false}
       sx={{
-        borderRadius: '13px',
+        borderRadius: '25px',
         minHeight: 'calc(100vh - 64px)',
         position: 'relative',
         background: '#e9f6ff',
@@ -23,7 +23,7 @@ export default function AdminContainer({ title, children }: Props) {
             background: 'white',
             minHeight: '20rem',
             flexDirection: 'column',
-            borderRadius: '13px',
+            borderRadius: '25px',
           }}>
           <AppBarMenu title={title} />
           {children}

--- a/src/components/admin/navigation/AppBarMenu.tsx
+++ b/src/components/admin/navigation/AppBarMenu.tsx
@@ -27,7 +27,7 @@ export default function AppBarMenu({ title }: Props) {
         <Typography fontSize={'18px'} sx={{ px: 0.5, height: '20px' }}>
           /
         </Typography>
-        <IconButton sx={{ borderRadius: '10px' }}>
+        <IconButton sx={{ borderRadius: '25px' }}>
           <Typography>{title}</Typography>
         </IconButton>
       </Box>

--- a/src/components/admin/navigation/HoverMenu.tsx
+++ b/src/components/admin/navigation/HoverMenu.tsx
@@ -55,7 +55,7 @@ export default function HoverMenu({ menu, items, icon: Icon, isOpen }: Props) {
       <ListItemButton
         selected={isSelected}
         onClick={handleOpenMenu}
-        sx={{ borderRadius: '0 20px 20px 0' }}>
+        sx={{ borderRadius: '0 25px 25px 0' }}>
         <ListItemIcon
           title={menu}
           sx={(theme) => ({

--- a/src/components/auth/profile/ProfilePage.tsx
+++ b/src/components/auth/profile/ProfilePage.tsx
@@ -76,7 +76,7 @@ export default function ProfilePage() {
         <Box
           sx={{
             backgroundColor: 'white',
-            borderRadius: '10px 10px 0px 0px',
+            borderRadius: '25px 25px 0px 0px',
             padding: '10px 30px',
           }}>
           <h1 className={classes.h1}>Дарителски профил</h1>

--- a/src/components/layout/nav/DonationMenuMobile.tsx
+++ b/src/components/layout/nav/DonationMenuMobile.tsx
@@ -20,7 +20,7 @@ const StyledAccordion = styled(Accordion)(({ theme }) => ({
   [`&.${classes.accordionWrapper}`]: {
     boxShadow: 'none',
     border: '1px solid rgba(50, 169, 254, 0.5)',
-    borderRadius: '25px !important',
+    borderRadius: `${theme.shape.borderRadius} !important`,
     color: theme.palette.primary.dark,
     textAlign: 'center',
   },


### PR DESCRIPTION
- Inherited the borderRadius styles from the theme - theme.shape.borderRadius (25px).
- Removed the style where it is not used.
- borderRadius is still inlined in Admin panel where it is not inherited from the theme, but has the default value of 25px.
- borderRadius: '50%' is saved, it makes the icons round.