### PR TITLE
Fix borderRadius error

### DIFF
--- a/src/common/theme.ts
+++ b/src/common/theme.ts
@@ -61,7 +61,7 @@ export const themeOptions: ThemeOptions = {
     },
   },
   shape: {
-    borderRadius: '25px',
+    borderRadius: 3,
   },
   components: {
     MuiLink: {

--- a/src/components/layout/nav/DonationMenuMobile.tsx
+++ b/src/components/layout/nav/DonationMenuMobile.tsx
@@ -19,8 +19,8 @@ const classes = {
 const StyledAccordion = styled(Accordion)(({ theme }) => ({
   [`&.${classes.accordionWrapper}`]: {
     boxShadow: 'none',
-    border: '1px solid rgba(50, 169, 254, 0.5)',
-    borderRadius: `${theme.shape.borderRadius} !important`,
+    border: '2px solid rgba(50, 169, 254, 0.5)',
+    borderRadius: '25px !important',
     color: theme.palette.primary.dark,
     textAlign: 'center',
   },


### PR DESCRIPTION
- Fixed the following error related to borderRadius style:
"MUI: The `theme.shape.borderRadius` value (25px) is invalid.
It should be a number, an array or a function."

- Fixed minor UI change related to the mobile donation menu's border width:

| Before              | After              |
| ------------------- | ------------------ |
| ![Screenshot 2022-05-27 230648](https://user-images.githubusercontent.com/14351733/170782591-ae228c84-3bf1-4284-ac91-d4993384d14d.png) | ![Screenshot 2022-05-27 230549](https://user-images.githubusercontent.com/14351733/170782650-eb38a173-0580-491a-a228-86d2a79b5d48.png) |
