### PR TITLE
Fix Jumbotron responsive styles

### DIFF
--- a/src/components/index/sections/Jumbotron.tsx
+++ b/src/components/index/sections/Jumbotron.tsx
@@ -27,7 +27,10 @@ export default function Jumbotron() {
           xl: theme.spacing(12, 1, 0, 1),
         },
         mb: 12,
-        mt: 10,
+        mt: {
+          xs: 6,
+          xl: 10,
+        },
         textAlign: 'center',
         color: theme.palette.common.white,
         position: 'relative',
@@ -84,7 +87,17 @@ export default function Jumbotron() {
               flexWrap: 'wrap',
             }}>
             <LinkButton
-              sx={{ minWidth: 320, marginRight: theme.spacing(4), marginBottom: theme.spacing(3) }}
+              sx={{
+                minWidth: {
+                  xs: 260,
+                  md: 320,
+                },
+                marginRight: theme.spacing(4),
+                marginBottom: {
+                  xs: theme.spacing(1.5),
+                  sm: 0,
+                },
+              }}
               size="large"
               variant="outlined"
               color="primary"
@@ -92,7 +105,12 @@ export default function Jumbotron() {
               {t('common:nav.about.support-us')}
             </LinkButton>
             <LinkButton
-              sx={{ minWidth: 320, marginBottom: theme.spacing(3) }}
+              sx={{
+                minWidth: {
+                  xs: 260,
+                  md: 320,
+                },
+              }}
               size="large"
               variant="contained"
               color="secondary"

--- a/src/components/index/sections/Jumbotron.tsx
+++ b/src/components/index/sections/Jumbotron.tsx
@@ -92,8 +92,8 @@ export default function Jumbotron() {
                   xs: 260,
                   md: 320,
                 },
-                marginRight: theme.spacing(4),
-                marginBottom: {
+                mr: theme.spacing(4),
+                mb: {
                   xs: theme.spacing(1.5),
                   sm: 0,
                 },


### PR DESCRIPTION
- Reduced the white space on the top of the section:

| Before              | After              |
| ------------------- | ------------------ |
| ![Screenshot 2022-06-02 223638](https://user-images.githubusercontent.com/14351733/171724789-a5369b77-41a1-41c6-bffd-56b889657dba.png) | ![Screenshot 2022-06-02 223753](https://user-images.githubusercontent.com/14351733/171724903-58ca07c1-eebf-41a2-bea5-1f7899dc19e7.png) | 

- Fixed buttons' styles:

| Before              | After              |
| ------------------- | ------------------ |
| ![Screenshot 2022-06-02 225021](https://user-images.githubusercontent.com/14351733/171726275-f74bf7b0-a4ff-490e-92e9-f53f3214d79b.png) |  ![Screenshot 2022-06-02 223828](https://user-images.githubusercontent.com/14351733/171725110-ff4916d2-1ae2-432e-b789-caa8caf39001.png)  | 