### PR TITLE
739.1 feature functionality for uploading a payment receipt and updating bank transactions 

### DIFF
--- a/public/locales/bg/donations.json
+++ b/public/locales/bg/donations.json
@@ -1,5 +1,6 @@
 {
   "form-heading": "Добави ново дарение",
+  "form-heading-bank-transactions-file": "Добави нов файл с банкови транзакции",
   "edit-form-heading": "Редактирай дарение",
   "all": "Всички дарения",
   "donations": "Дарения",
@@ -21,6 +22,8 @@
   "deleteAllContent": "Това действие ще изтрие избраните елементи завинаги!",
   "actions": "Действия",
   "createdAt": "Направено на",
+  "bankTransactionsFileId": "Номер на файла с банкови транзакции",
+  "addFiles": "Добави файлове",
   "alerts": {
     "selectRow": "Моля изберете ред",
     "create": "Дарението беше създадено успешно!",

--- a/public/locales/en/donations.json
+++ b/public/locales/en/donations.json
@@ -3,7 +3,7 @@
   "form-heading-bank-transactions-file": "Add new file with bank transactions",
   "edit-form-heading": "Edit donation",
   "all": "All donations",
-  "donations": "Doantions",
+  "donations": "Donations",
   "type": "Type",
   "status": "Status",
   "provider": "Payment system",

--- a/public/locales/en/donations.json
+++ b/public/locales/en/donations.json
@@ -1,5 +1,6 @@
 {
   "form-heading": "Add new donation",
+  "form-heading-bank-transactions-file": "Add new file with bank transactions",
   "edit-form-heading": "Edit donation",
   "all": "All donations",
   "donations": "Doantions",
@@ -19,6 +20,8 @@
   "deleteTitle": "Are you sure?",
   "deleteContent": "This action will delete this item permanently!",
   "deleteAllContent": "This action will delete selected items permanently!",
+  "bankTransactionsFileId": "Number of bank transactions file",
+  "addFiles": "Add files",
   "actions": "Actions",
   "createdAt": "Created at",
   "alerts": {

--- a/src/common/routes.ts
+++ b/src/common/routes.ts
@@ -100,6 +100,7 @@ export const routes = {
       index: '/admin/donations',
       create: '/admin/donations/create',
       edit: (id: string) => `/admin/donations/${id}/edit`,
+      addBankTransactionsFile: '/admin/donations/add-bank-transactions-file',
     },
     beneficiary: {
       index: '/admin/beneficiary',

--- a/src/components/bank-transactions-file/roles.ts
+++ b/src/components/bank-transactions-file/roles.ts
@@ -1,0 +1,15 @@
+export enum BankTransactionsFileRole {
+  xml = 'xml',
+  other = 'other',
+}
+
+export type FileRole = {
+  file: string
+  role: BankTransactionsFileRole
+}
+
+export type UploadBankTransactionFiles = {
+  bankTransactionsFileId: string
+  files: File[]
+  roles: FileRole[]
+}

--- a/src/components/bank-transactions-file/types.ts
+++ b/src/components/bank-transactions-file/types.ts
@@ -1,15 +1,15 @@
-export enum BankTransactionsFileRole {
+export enum BankTransactionsFileType {
   xml = 'xml',
   other = 'other',
 }
 
-export type FileRole = {
+export type FileType = {
   file: string
-  role: BankTransactionsFileRole
+  type: BankTransactionsFileType
 }
 
 export type UploadBankTransactionFiles = {
   bankTransactionsFileId: string
   files: File[]
-  roles: FileRole[]
+  types: FileType[]
 }

--- a/src/components/bank-transactions-file/types.ts
+++ b/src/components/bank-transactions-file/types.ts
@@ -8,7 +8,7 @@ export type FileType = {
   type: BankTransactionsFileType
 }
 
-export type UploadBankTransactionFiles = {
+export type UploadBankTransactionsFiles = {
   bankTransactionsFileId: string
   files: File[]
   types: FileType[]

--- a/src/components/donations/AddBankTransactionsFile.tsx
+++ b/src/components/donations/AddBankTransactionsFile.tsx
@@ -1,9 +1,7 @@
 import { useTranslation } from 'next-i18next'
 import { Container } from '@mui/material'
-
 import AdminContainer from 'components/admin/navigation/AdminContainer'
 import AdminLayout from 'components/admin/navigation/AdminLayout'
-
 import BankTransactionsFileForm from './AddBankTransactionsFileForm'
 
 export default function AddBankTransactionsFile() {

--- a/src/components/donations/AddBankTransactionsFile.tsx
+++ b/src/components/donations/AddBankTransactionsFile.tsx
@@ -1,0 +1,21 @@
+import { useTranslation } from 'next-i18next'
+import { Container } from '@mui/material'
+
+import AdminContainer from 'components/admin/navigation/AdminContainer'
+import AdminLayout from 'components/admin/navigation/AdminLayout'
+
+import BankTransactionsFileForm from './AddBankTransactionsFileForm'
+
+export default function AddBankTransactionsFile() {
+  const { t } = useTranslation()
+
+  return (
+    <AdminLayout>
+      <AdminContainer title={t('donations:donations')}>
+        <Container maxWidth="md" sx={{ py: 5 }}>
+          <BankTransactionsFileForm />
+        </Container>
+      </AdminContainer>
+    </AdminLayout>
+  )
+}

--- a/src/components/donations/AddBankTransactionsFileForm.tsx
+++ b/src/components/donations/AddBankTransactionsFileForm.tsx
@@ -7,18 +7,13 @@ import { useTranslation } from 'next-i18next'
 import { AxiosError, AxiosResponse } from 'axios'
 import { Button, Grid, Typography } from '@mui/material'
 import Link from 'next/link'
-
 import { routes } from 'common/routes'
-
 import { AlertStore } from 'stores/AlertStore'
-
 import FileUpload from 'components/file-upload/FileUpload'
 import GenericForm from 'components/common/form/GenericForm'
 import SubmitButton from 'components/common/form/SubmitButton'
 import FormTextField from 'components/common/form/FormTextField'
-
 import { ApiErrors, isAxiosError, matchValidator } from 'service/apiErrors'
-
 import {
   BankTransactionsFileType,
   FileType,

--- a/src/components/donations/AddBankTransactionsFileForm.tsx
+++ b/src/components/donations/AddBankTransactionsFileForm.tsx
@@ -137,7 +137,7 @@ export default function BankTransactionsFileForm({
             />
           </Grid>
           <Link href={routes.admin.campaigns.index} passHref>
-            <Button fullWidth={true}>{t('Отказ')}</Button>
+            <Button fullWidth={true}>{t('donations:cta:cancel')}</Button>
           </Link>
         </Grid>
       </GenericForm>

--- a/src/components/donations/AddBankTransactionsFileForm.tsx
+++ b/src/components/donations/AddBankTransactionsFileForm.tsx
@@ -1,0 +1,151 @@
+import * as yup from 'yup'
+import { useState } from 'react'
+import { useRouter } from 'next/router'
+import { FormikHelpers } from 'formik'
+import { useMutation } from 'react-query'
+import { useTranslation } from 'next-i18next'
+import { AxiosError, AxiosResponse } from 'axios'
+import { Button, Grid, Typography } from '@mui/material'
+import Link from 'next/link'
+
+import { routes } from 'common/routes'
+
+import { AlertStore } from 'stores/AlertStore'
+
+import FileUpload from 'components/file-upload/FileUpload'
+import GenericForm from 'components/common/form/GenericForm'
+import SubmitButton from 'components/common/form/SubmitButton'
+import FormTextField from 'components/common/form/FormTextField'
+
+import { ApiErrors, isAxiosError, matchValidator } from 'service/apiErrors'
+
+import {
+  BankTransactionsFileType,
+  FileType,
+  UploadBankTransactionsFiles,
+} from 'components/bank-transactions-file/types'
+import { useUploadBankTransactionsFiles } from 'service/donation'
+import BankTransactionsFileList from 'components/file-upload/BankTransactionsFileList'
+import { BankTransactionsFileFormData, BankTransactionsUploadImage } from 'gql/donations'
+
+const validationSchema: yup.SchemaOf<BankTransactionsFileFormData> = yup.object().defined().shape({
+  bankTransactionsFileId: yup.string().required(),
+})
+
+const defaults: BankTransactionsFileFormData = {
+  bankTransactionsFileId: '',
+}
+
+export type BankTransactionsFileFormProps = { initialValues?: BankTransactionsFileFormData }
+
+export default function BankTransactionsFileForm({
+  initialValues = defaults,
+}: BankTransactionsFileFormProps) {
+  const router = useRouter()
+  const [files, setFiles] = useState<File[]>([])
+  const [types, setTypes] = useState<FileType[]>([])
+  const { t } = useTranslation()
+
+  const fileUploadMutation = useMutation<
+    AxiosResponse<BankTransactionsUploadImage[]>,
+    AxiosError<ApiErrors>,
+    UploadBankTransactionsFiles
+  >({
+    mutationFn: useUploadBankTransactionsFiles(),
+    onError: () => AlertStore.show(t('common:alerts.error'), 'error'),
+    onSuccess: () => AlertStore.show(t('common:alerts.message-sent'), 'success'),
+  })
+
+  const onSubmit = async (
+    values: BankTransactionsFileFormData,
+    { setFieldError }: FormikHelpers<BankTransactionsFileFormData>,
+  ) => {
+    try {
+      await fileUploadMutation.mutateAsync({
+        files,
+        types,
+        bankTransactionsFileId: values.bankTransactionsFileId,
+      })
+
+      router.push(routes.admin.donations.index)
+    } catch (error) {
+      console.error(error)
+      if (isAxiosError(error)) {
+        const { response } = error as AxiosError<ApiErrors>
+        response?.data.message.map(({ property, constraints }) => {
+          setFieldError(property, t(matchValidator(constraints)))
+        })
+      }
+    }
+  }
+
+  return (
+    <Grid container direction="column" component="section">
+      <Grid item xs={12}>
+        <Typography
+          variant="h5"
+          component="h2"
+          sx={(theme) => ({
+            mb: 5,
+            color: theme.palette.primary.dark,
+            textAlign: 'center',
+          })}>
+          {t('donations:form-heading-bank-transactions-file')}
+        </Typography>
+      </Grid>
+      <GenericForm
+        onSubmit={onSubmit}
+        initialValues={initialValues}
+        validationSchema={validationSchema}>
+        <Grid container spacing={3}>
+          <Grid item xs={12}>
+            <FormTextField
+              type="text"
+              label={t('donations:bankTransactionsFileId')}
+              name="bankTransactionsFileId"
+              autoComplete="bankTransactionsFileId"
+            />
+          </Grid>
+          <Grid item xs={12}>
+            <FileUpload
+              onUpload={(newFiles) => {
+                setFiles((prevFiles) => [...prevFiles, ...newFiles])
+                setTypes((prevTypes) => [
+                  ...prevTypes,
+                  ...newFiles.map((file) => ({
+                    file: file.name,
+                    type: BankTransactionsFileType.xml,
+                  })),
+                ])
+              }}
+              buttonLabel={t('donations:addFiles')}
+            />
+            <BankTransactionsFileList
+              filesType={types}
+              files={files}
+              onDelete={(deletedFile) =>
+                setFiles((prevFiles) => prevFiles.filter((file) => file.name !== deletedFile.name))
+              }
+              onSetFileType={(file, type) => {
+                setTypes((prevTypes) => [
+                  ...prevTypes.filter((f) => f.file !== file.name),
+                  { file: file.name, type },
+                ])
+              }}
+            />
+          </Grid>
+          <Grid item xs={12}>
+            <SubmitButton
+              fullWidth
+              label="donations:cta.submit"
+              loading={fileUploadMutation.isLoading}
+            />
+          </Grid>
+          <Link href={routes.admin.campaigns.index} passHref>
+            <Button fullWidth={true}>{t('Отказ')}</Button>
+          </Link>
+        </Grid>
+      </GenericForm>
+    </Grid>
+  )
+}

--- a/src/components/donations/grid/GridAppbar.tsx
+++ b/src/components/donations/grid/GridAppbar.tsx
@@ -1,7 +1,7 @@
 import { useRouter } from 'next/router'
 import { useTranslation } from 'next-i18next'
 import { Box, Toolbar, Tooltip, Typography } from '@mui/material'
-import { Add as AddIcon } from '@mui/icons-material'
+import { Add as AddIcon, Receipt } from '@mui/icons-material'
 
 import { routes } from 'common/routes'
 
@@ -31,6 +31,13 @@ export default function GridAppbar() {
       </Box>
       <Box sx={{ height: '64px', display: 'flex', alignItems: 'flex-end', pb: 1 }}>
         <Box sx={{ display: 'flex', alignItems: 'center' }}>
+          <Tooltip title={t('donations:form-heading-bank-transactions-file') || ''}>
+            <Receipt
+              sx={addIconStyles}
+              fontSize="large"
+              onClick={() => router.push(routes.admin.donations.addBankTransactionsFile)}
+            />
+          </Tooltip>
           <Tooltip title={t('donations:cta:add') || ''}>
             <AddIcon
               sx={addIconStyles}

--- a/src/components/file-upload/BankTransactionsFileList.tsx
+++ b/src/components/file-upload/BankTransactionsFileList.tsx
@@ -1,0 +1,79 @@
+import React from 'react'
+import { Delete, UploadFile } from '@mui/icons-material'
+import {
+  Avatar,
+  IconButton,
+  List,
+  ListItem,
+  ListItemAvatar,
+  ListItemText,
+  Select,
+  MenuItem,
+  FormControl,
+  InputLabel,
+} from '@mui/material'
+import { SelectChangeEvent } from '@mui/material/Select'
+
+import { BankTransactionsFileType, FileType } from 'components/bank-transactions-file/types'
+
+type Props = {
+  files: File[]
+  onDelete?: (file: File) => void
+  onSetFileType: (file: File, type: BankTransactionsFileType) => void
+  filesType: FileType[]
+}
+
+function BankTransactionsFileList({ files, onDelete, onSetFileType, filesType = [] }: Props) {
+  const setFileType = (file: File) => {
+    return (event: SelectChangeEvent<BankTransactionsFileType>) => {
+      if (
+        Object.values(BankTransactionsFileType).includes(
+          event.target.value as BankTransactionsFileType,
+        )
+      ) {
+        onSetFileType(file, event.target.value as BankTransactionsFileType)
+      }
+    }
+  }
+
+  return (
+    <List dense>
+      {files.map((file, key) => (
+        <ListItem
+          key={key}
+          secondaryAction={
+            <IconButton edge="end" aria-label="delete" onClick={() => onDelete && onDelete(file)}>
+              <Delete />
+            </IconButton>
+          }>
+          <ListItemAvatar>
+            <Avatar>
+              <UploadFile />
+            </Avatar>
+          </ListItemAvatar>
+          <ListItemText primary={file.type} />
+          <ListItemText primary={file.name} />
+          <FormControl>
+            <InputLabel id="choose-type-label">{'Избери вид на файла'}</InputLabel>
+            <Select<BankTransactionsFileType>
+              id="choose-type"
+              label="Избери вид на файла"
+              labelId="choose-type-label"
+              value={
+                filesType.find((f) => f.file === file.name)?.type ?? BankTransactionsFileType.xml
+              }
+              onChange={setFileType(file)}>
+              {Object.values(BankTransactionsFileType).map((type) => (
+                <MenuItem key={type} value={type}>
+                  {type}
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+        </ListItem>
+      ))}
+    </List>
+  )
+}
+
+export default BankTransactionsFileList

--- a/src/gql/donations.d.ts
+++ b/src/gql/donations.d.ts
@@ -146,3 +146,6 @@ export type ThirdStep = {
   message?: string
   anonymous: boolean
 }
+export type BankTransactionsUploadImage = {
+  title: string
+}

--- a/src/gql/donations.d.ts
+++ b/src/gql/donations.d.ts
@@ -147,5 +147,8 @@ export type ThirdStep = {
   anonymous: boolean
 }
 export type BankTransactionsUploadImage = {
-  title: string
+  bankTransactionsFileId: string
+}
+export type BankTransactionsFileFormData = {
+  bankTransactionsFileId: string
 }

--- a/src/pages/admin/donations/add-bank-transactions-file.tsx
+++ b/src/pages/admin/donations/add-bank-transactions-file.tsx
@@ -1,0 +1,10 @@
+import AddBankTransactionsFile from 'components/donations/AddBankTransactionsFile'
+import { securedPropsWithTranslation } from 'middleware/auth/securedProps'
+
+export const getServerSideProps = securedPropsWithTranslation([
+  'common',
+  'auth',
+  'donations',
+  'validation',
+])
+export default AddBankTransactionsFile

--- a/src/service/apiEndpoints.ts
+++ b/src/service/apiEndpoints.ts
@@ -46,6 +46,8 @@ export const endpoints = {
     editDonation: (id: string) => <Endpoint>{ url: `/donation/${id}`, method: 'PATCH' },
     deleteDonation: <Endpoint>{ url: `/donation/delete`, method: 'POST' },
     userDonations: <Endpoint>{ url: 'donation/user-donations', method: 'GET' },
+    uploadBankTransactionsFile: (bankTransactionsFileId: string) =>
+      <Endpoint>{ url: `/bank-transactions-file/${bankTransactionsFileId}`, method: 'POST' },
   },
   documents: {
     documentsList: <Endpoint>{ url: '/document', method: 'GET' },

--- a/src/service/donation.ts
+++ b/src/service/donation.ts
@@ -12,10 +12,7 @@ import {
 import { apiClient } from 'service/apiClient'
 import { endpoints } from 'service/apiEndpoints'
 import { authConfig } from 'service/restRequests'
-import {
-  UploadBankTransactionFiles,
-  UploadBankTransactionsFiles,
-} from 'components/bank-transactions-file/types'
+import { UploadBankTransactionsFiles } from 'components/bank-transactions-file/types'
 
 export const createCheckoutSession = async (data: CheckoutSessionInput) => {
   return await apiClient.post<CheckoutSessionInput, AxiosResponse<CheckoutSessionResponse>>(

--- a/src/service/donation.ts
+++ b/src/service/donation.ts
@@ -2,6 +2,7 @@ import { AxiosResponse } from 'axios'
 import { useSession } from 'next-auth/react'
 
 import {
+  BankTransactionsUploadImage,
   CheckoutSessionInput,
   CheckoutSessionResponse,
   DonationBankInput,
@@ -11,7 +12,10 @@ import {
 import { apiClient } from 'service/apiClient'
 import { endpoints } from 'service/apiEndpoints'
 import { authConfig } from 'service/restRequests'
-import { UploadBankTransactionFiles } from 'components/bank-transactions-file/types'
+import {
+  UploadBankTransactionFiles,
+  UploadBankTransactionsFiles,
+} from 'components/bank-transactions-file/types'
 
 export const createCheckoutSession = async (data: CheckoutSessionInput) => {
   return await apiClient.post<CheckoutSessionInput, AxiosResponse<CheckoutSessionResponse>>(
@@ -69,7 +73,7 @@ export const useUploadBankTransactionsFiles = () => {
     files,
     types: filesType,
     bankTransactionsFileId,
-  }: UploadBankTransactionFiles) => {
+  }: UploadBankTransactionsFiles) => {
     const formData = new FormData()
     files.forEach((file: File) => {
       formData.append('file', file)
@@ -77,7 +81,7 @@ export const useUploadBankTransactionsFiles = () => {
     filesType.forEach((fileType) => {
       formData.append('types', fileType.type)
     })
-    return await apiClient.post<FormData>(
+    return await apiClient.post<FormData, AxiosResponse<BankTransactionsUploadImage[]>>(
       endpoints.donation.uploadBankTransactionsFile(bankTransactionsFileId).url,
       formData,
       {

--- a/src/service/donation.ts
+++ b/src/service/donation.ts
@@ -11,6 +11,7 @@ import {
 import { apiClient } from 'service/apiClient'
 import { endpoints } from 'service/apiEndpoints'
 import { authConfig } from 'service/restRequests'
+import { UploadBankTransactionFiles } from 'components/bank-transactions-file/types'
 
 export const createCheckoutSession = async (data: CheckoutSessionInput) => {
   return await apiClient.post<CheckoutSessionInput, AxiosResponse<CheckoutSessionResponse>>(
@@ -58,6 +59,33 @@ export function useDeleteDonation(ids: string[]) {
       endpoints.donation.deleteDonation.url,
       ids,
       authConfig(session?.accessToken),
+    )
+  }
+}
+
+export const useUploadBankTransactionsFiles = () => {
+  const { data: session } = useSession()
+  return async ({
+    files,
+    types: filesType,
+    bankTransactionsFileId,
+  }: UploadBankTransactionFiles) => {
+    const formData = new FormData()
+    files.forEach((file: File) => {
+      formData.append('file', file)
+    })
+    filesType.forEach((fileType) => {
+      formData.append('types', fileType.type)
+    })
+    return await apiClient.post<FormData>(
+      endpoints.donation.uploadBankTransactionsFile(bankTransactionsFileId).url,
+      formData,
+      {
+        headers: {
+          ...authConfig(session?.accessToken).headers,
+          'Content-Type': 'multipart/form-data',
+        },
+      },
     )
   }
 }


### PR DESCRIPTION
The general idea is that when an admin of this site is give a file of bank transactions in a specific format, then he/she upload on the api and all of the donations which are inside this file will be checked and donations will be made. 
This pr is connected with 238.2 feature functionality for uploading a payment receipt and updating bank transactions/https://github.com/podkrepi-bg/api/pull/263/
## Motivation and context

<!--- Why is this change required? -->
The idea is to simplify the process and automatize it so it won't be done by hand.

## Screenshots:

| Before              | After              |
| ------------------- | ------------------ |
![image](https://user-images.githubusercontent.com/101862171/173349023-e27959be-ef0f-42bb-8e39-8e117c7ef364.png)|![image](https://user-images.githubusercontent.com/101862171/173349235-09e7cdf3-da82-4fdb-978f-23f91600402c.png)

## Testing
[report-bank-transactions-files-for-testing.zip](https://github.com/podkrepi-bg/frontend/files/8890692/report-bank-transactions-files-for-testing.zip)
In order to test, you need to extract the files from the attached zip file, and upload one or both files.

<!--- Please describe in detail how you tested your changes. -->
To reproduce
1. Log in
2. Go to admin/donations
3. Click on "Добави нов файл с банкови транзакции"
4. Add files 

**New environment variables**:

- `env var` : env var details

**New dependencies**:

- `dependency` : dependency details

**New dev dependencies**:

- `dependency` : dependency details
