### PR TITLE
fixing campign file list not updated

### DIFF
--- a/src/components/campaigns/grid/EditForm.tsx
+++ b/src/components/campaigns/grid/EditForm.tsx
@@ -109,7 +109,7 @@ export default function EditForm({ campaign }: { campaign: CampaignResponse }) {
     onError: () => AlertStore.show(t('common:alerts.error'), 'error'),
     onSuccess: () => {
       //invalidate query for getting new values
-      queryClient.invalidateQueries(endpoints.campaign.uploadFile(campaign.id).url)
+      queryClient.invalidateQueries(endpoints.campaign.viewCampaignById(campaign.id).url)
     },
   })
 

--- a/src/components/campaigns/grid/EditPage.tsx
+++ b/src/components/campaigns/grid/EditPage.tsx
@@ -6,7 +6,6 @@ import { CampaignResponse } from 'gql/campaigns'
 import { useViewCampaignById } from 'common/hooks/campaigns'
 import AdminLayout from 'components/admin/navigation/AdminLayout'
 import AdminContainer from 'components/admin/navigation/AdminContainer'
-import NotFoundIllustration from 'components/errors/assets/NotFoundIllustration'
 
 import EditForm from './EditForm'
 
@@ -17,7 +16,7 @@ export default function EditPage() {
     <AdminLayout>
       <AdminContainer title={'Кампании'}>
         <Container maxWidth="md" sx={{ py: 5 }}>
-          {campaign ? <EditForm campaign={campaign} /> : <NotFoundIllustration />}
+          {campaign && <EditForm campaign={campaign} />}
         </Container>
       </AdminContainer>
     </AdminLayout>

--- a/src/components/campaigns/grid/UploadedCampaignFile.tsx
+++ b/src/components/campaigns/grid/UploadedCampaignFile.tsx
@@ -17,7 +17,6 @@ import {
 import { ApiErrors } from 'service/apiErrors'
 import { endpoints } from 'service/apiEndpoints'
 
-import { routes } from 'common/routes'
 import { AlertStore } from 'stores/AlertStore'
 import { useSession } from 'next-auth/react'
 import { CampaignFile } from 'gql/campaigns'
@@ -41,7 +40,6 @@ export default function UploadedCampaignFile({ file, campaignId }: Props) {
     onSuccess: () => {
       AlertStore.show(t('alerts.deletedFile'), 'success')
       queryClient.invalidateQueries(endpoints.campaign.viewCampaignById(campaignId).url)
-      router.push(routes.admin.campaigns.index)
     },
   })
   const downloadFileHandler = async () => {


### PR DESCRIPTION
## Motivation and context

When editing a campaign, the uploaded file list is not refreshed and leaves the impression the upload was not successful.

- fixed: invalidateFileList when Editing Campaign
- fixed: flashing 404 when loading CampaignEditPage
- fixed: deleting a single campaign file to not return to campaignlist

