### PR TITLE
add richtext editor for campaign description

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "react-gtm-module": "2.0.11",
     "react-in-viewport": "1.0.0-alpha.17",
     "react-query": "^3.23.2",
+    "react-quill": "^2.0.0-beta.4",
     "sass": "1.34.1",
     "sharp": "^0.30.5",
     "slugify": "^1.6.0",

--- a/src/components/campaigns/CampaignDetails.tsx
+++ b/src/components/campaigns/CampaignDetails.tsx
@@ -1,6 +1,5 @@
 import React from 'react'
 import Image from 'next/image'
-import { useTranslation } from 'next-i18next'
 import { CampaignResponse } from 'gql/campaigns'
 import CampaignMessages from './CampaignMessages'
 import CampaignSlider from './CampaignSlider'
@@ -81,8 +80,6 @@ type Props = {
 }
 
 export default function CampaignDetails({ campaign }: Props) {
-  const { t } = useTranslation()
-
   const bannerSource = backgroundCampaignPictureUrl(campaign)
   const beneficiaryAvatarSource = beneficiaryCampaignPictureUrl(campaign)
 

--- a/src/components/campaigns/CampaignDetails.tsx
+++ b/src/components/campaigns/CampaignDetails.tsx
@@ -12,6 +12,10 @@ import CampaignInfo from './CampaignInfo'
 import { styled } from '@mui/material/styles'
 import { Grid, Typography } from '@mui/material'
 
+import dynamic from 'next/dynamic'
+import 'react-quill/dist/quill.bubble.css'
+const ReactQuill = dynamic(() => import('react-quill'), { ssr: false })
+
 const PREFIX = 'CampaignDetails'
 
 const classes = {
@@ -110,9 +114,7 @@ export default function CampaignDetails({ campaign }: Props) {
       </Typography>
       <CampaignInfo campaign={campaign} />
       <Grid>
-        <Typography variant="subtitle2" component="p" mb={5}>
-          {campaign.description}
-        </Typography>
+        <ReactQuill readOnly theme="bubble" value={campaign.description} />
         <CampaignSlider />
         <CampaignMessages />
       </Grid>

--- a/src/components/campaigns/CampaignInfo.tsx
+++ b/src/components/campaigns/CampaignInfo.tsx
@@ -7,7 +7,6 @@ import { Button, Grid, Typography } from '@mui/material'
 import { styled } from '@mui/material/styles'
 import ThumbUpIcon from '@mui/icons-material/ThumbUp'
 import FavoriteIcon from '@mui/icons-material/Favorite'
-import WhatshotIcon from '@mui/icons-material/Whatshot'
 import EmailIcon from '@mui/icons-material/Email'
 import Divider from '@mui/material/Divider'
 
@@ -92,17 +91,17 @@ export default function CampaignInfo({ campaign }: Props) {
           display="flex"
           className={classes.campaignText}>
           <FavoriteIcon color="action" className={classes.campaignInfoIcon} />
-          <strong>{t('campaigns:campaign.type')}</strong> {campaign.campaignType?.name}
+          <strong>{t('campaigns:campaign.type')}</strong>: {campaign.campaignType?.name}
         </Typography>
-        <Typography
+        {/* TODO: Dynamic campaign tagging is needed here based on activity (urgent, hot, the long-shot, etc) */}
+        {/* <Typography
           variant="subtitle2"
           component="p"
           display="flex"
           className={classes.campaignText}>
           <WhatshotIcon color="action" className={classes.campaignInfoIcon} />
-          {/* TODO: get data from endpoint */}
-          <strong>{t('campaigns:campaign.profile')}</strong> Спешна
-        </Typography>
+          <strong>{t('campaigns:campaign.profile')}</strong>Спешна
+        </Typography> */}
         <Typography variant="subtitle2" component="p" className={classes.campaignText}>
           <strong>{t('campaigns:campaign.status')}</strong> {campaign.state}
         </Typography>

--- a/src/components/campaigns/grid/CampaignGrid.tsx
+++ b/src/components/campaigns/grid/CampaignGrid.tsx
@@ -251,14 +251,6 @@ export default function CampaignGrid() {
     },
   ]
 
-  const addIconStyles = {
-    background: '#4ac3ff',
-    borderRadius: '50%',
-    cursor: 'pointer',
-    padding: 1.2,
-    boxShadow: 3,
-  }
-
   return (
     <>
       <Toolbar

--- a/src/components/campaigns/grid/CreateForm.tsx
+++ b/src/components/campaigns/grid/CreateForm.tsx
@@ -36,6 +36,10 @@ import BeneficiarySelect from './BeneficiarySelect'
 import { CampaignState } from '../helpers/campaign.enums'
 import { toMoney } from 'common/util/money'
 
+import dynamic from 'next/dynamic'
+import 'react-quill/dist/quill.snow.css'
+const ReactQuill = dynamic(() => import('react-quill'), { ssr: false })
+
 const formatString = 'yyyy-MM-dd'
 
 const parseDateString = (value: string, originalValue: string) => {
@@ -88,6 +92,8 @@ export default function CampaignForm({ initialValues = defaults }: CampaignFormP
   const router = useRouter()
   const [files, setFiles] = useState<File[]>([])
   const [roles, setRoles] = useState<FileRole[]>([])
+  const [richDescription, setRichDescription] = useState<string>('')
+
   const { t } = useTranslation()
 
   const mutation = useMutation<
@@ -116,7 +122,7 @@ export default function CampaignForm({ initialValues = defaults }: CampaignFormP
       const response = await mutation.mutateAsync({
         title: values.title,
         slug: createSlug(values.title),
-        description: values.description,
+        description: richDescription,
         targetAmount: toMoney(values.targetAmount),
         allowDonationOnComplete: values.allowDonationOnComplete,
         startDate: values.startDate,
@@ -208,15 +214,8 @@ export default function CampaignForm({ initialValues = defaults }: CampaignFormP
             />
           </Grid>
           <Grid item xs={12}>
-            <FormTextField
-              rows={5}
-              multiline
-              type="text"
-              name="description"
-              label="campaigns:campaign.description"
-              autoComplete="description"
-              sx={{ '& textarea': { resize: 'vertical' } }}
-            />
+            <Typography>{t('campaigns:campaign.description')}</Typography>
+            <ReactQuill theme="snow" value={richDescription} onChange={setRichDescription} />
           </Grid>
           <Grid item xs={12} sm={6}>
             <p>

--- a/src/components/campaigns/grid/EditForm.tsx
+++ b/src/components/campaigns/grid/EditForm.tsx
@@ -37,6 +37,10 @@ import { endpoints } from 'service/apiEndpoints'
 import UploadedCampaignFile from './UploadedCampaignFile'
 import { fromMoney, toMoney } from 'common/util/money'
 
+import dynamic from 'next/dynamic'
+import 'react-quill/dist/quill.snow.css'
+const ReactQuill = dynamic(() => import('react-quill'), { ssr: false })
+
 const formatString = 'yyyy-MM-dd'
 
 const parseDateString = (value: string, originalValue: string) => {
@@ -71,6 +75,8 @@ export default function EditForm({ campaign }: { campaign: CampaignResponse }) {
   const queryClient = useQueryClient()
   const [files, setFiles] = useState<File[]>([])
   const [roles, setRoles] = useState<FileRole[]>([])
+  const [richDescription, setRichDescription] = useState(campaign.description || '')
+
   const { t } = useTranslation()
 
   const initialValues: CampaignEditFormData = {
@@ -122,7 +128,7 @@ export default function EditForm({ campaign }: { campaign: CampaignResponse }) {
       await mutation.mutateAsync({
         title: values.title,
         slug: createSlug(values.title),
-        description: values.description,
+        description: richDescription,
         targetAmount: toMoney(values.targetAmount),
         allowDonationOnComplete: campaign.allowDonationOnComplete,
         startDate: values.startDate,
@@ -221,15 +227,7 @@ export default function EditForm({ campaign }: { campaign: CampaignResponse }) {
             <CampaignStateSelect />
           </Grid>
           <Grid item xs={12}>
-            <FormTextField
-              rows={5}
-              multiline
-              type="text"
-              name="description"
-              label="campaigns:campaign.description"
-              autoComplete="description"
-              sx={{ '& textarea': { resize: 'vertical' } }}
-            />
+            <ReactQuill theme="snow" value={richDescription} onChange={setRichDescription} />
           </Grid>
           <Grid item xs={12} sm={6}>
             <p>

--- a/src/components/campaigns/grid/UploadedCampaignFile.tsx
+++ b/src/components/campaigns/grid/UploadedCampaignFile.tsx
@@ -1,4 +1,3 @@
-import { useRouter } from 'next/router'
 import { useTranslation } from 'next-i18next'
 import { AxiosError, AxiosResponse } from 'axios'
 import { useMutation, useQueryClient } from 'react-query'
@@ -31,7 +30,6 @@ type Props = {
 export default function UploadedCampaignFile({ file, campaignId }: Props) {
   const { t } = useTranslation('campaigns')
   const queryClient = useQueryClient()
-  const router = useRouter()
   const { data: session } = useSession()
 
   const mutation = useMutation<AxiosResponse<CampaignFile>, AxiosError<ApiErrors>>({

--- a/src/components/pdf/Certificate.tsx
+++ b/src/components/pdf/Certificate.tsx
@@ -128,8 +128,9 @@ export default function Certificate({ donation, person }: Props) {
         </View>
         <View>
           <Text style={styles.donationText}>
-            дари сума в размер на <Text style={{ color: '#2A4E84' }}>{money(donation?.amount ?? 0)}</Text>{' '}
-            за дейността на сдружението.
+            дари сума в размер на{' '}
+            <Text style={{ color: '#2A4E84' }}>{money(donation?.amount ?? 0)}</Text> за дейността на
+            сдружението.
           </Text>
         </View>
         <View style={styles.dateAndSignView}>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1643,6 +1643,13 @@
   resolved "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.4.tgz"
   integrity sha512-rZ5drC/jWjrArrS8BR6SIr4cWpW09RNTYt9AMZo3Jwwif+iacXAqgVjm0B0Bv/S1jhDXKHqRVNCbACkJ89RAnQ==
 
+"@types/quill@^1.3.10":
+  version "1.3.10"
+  resolved "https://registry.yarnpkg.com/@types/quill/-/quill-1.3.10.tgz#dc1f7b6587f7ee94bdf5291bc92289f6f0497613"
+  integrity sha512-IhW3fPW+bkt9MLNlycw8u8fWb7oO7W5URC9MfZYHBlA24rex9rs23D5DETChu1zvgVdc5ka64ICjJOgQMr6Shw==
+  dependencies:
+    parchment "^1.1.2"
+
 "@types/react-gtm-module@2.0.0":
   version "2.0.0"
   resolved "https://registry.npmjs.org/@types/react-gtm-module/-/react-gtm-module-2.0.0.tgz"
@@ -2773,6 +2780,11 @@ clone@^1.0.4:
   resolved "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz"
   integrity sha1-2jCcwmPfFZlMaIypAheco8fNfH4=
 
+clone@^2.1.1:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/clone/-/clone-2.1.2.tgz#1b7f4b9f591f1e8f83670401600345a02887435f"
+  integrity sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==
+
 clsx@^1.1.1:
   version "1.1.1"
   resolved "https://registry.npmjs.org/clsx/-/clsx-1.1.1.tgz"
@@ -3104,7 +3116,7 @@ dedent@^0.7.0:
   resolved "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz"
   integrity sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw=
 
-deep-equal@^1.0.0:
+deep-equal@^1.0.0, deep-equal@^1.0.1:
   version "1.1.1"
   resolved "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.1.tgz"
   integrity sha512-yd9c5AdiqVcR+JjcwUQb9DkhJc8ngNr0MahEBGvDiJw8puWab2yZlh+nkasOnZP+EGTAP6rRp2JzJhJZzvNF8g==
@@ -3657,6 +3669,11 @@ esutils@~1.0.0:
   resolved "https://registry.npmjs.org/esutils/-/esutils-1.0.0.tgz"
   integrity sha1-gVHTWOIMisx/t0XnRywAJf5JZXA=
 
+eventemitter3@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-2.0.3.tgz#b5e1079b59fb5e1ba2771c0a993be060a58c99ba"
+  integrity sha512-jLN68Dx5kyFHaePoXWPsCGW5qdyZQtLYHkxkg02/Mz6g0kYpDx4FyP6XfArhQdlOC4b8Mv+EMxPo/8La7Tzghg==
+
 execa@^5.0.0:
   version "5.1.1"
   resolved "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz"
@@ -3706,6 +3723,11 @@ expect@^27.3.1:
     jest-message-util "^27.3.1"
     jest-regex-util "^27.0.6"
 
+extend@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa"
+  integrity sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==
+
 external-editor@^3.0.3:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/external-editor/-/external-editor-3.1.0.tgz#cb03f740befae03ea4d283caed2741a83f335495"
@@ -3719,6 +3741,11 @@ fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   version "3.1.3"
   resolved "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz"
   integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
+
+fast-diff@1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/fast-diff/-/fast-diff-1.1.2.tgz#4b62c42b8e03de3f848460b639079920695d0154"
+  integrity sha512-KaJUt+M9t1qaIteSvjc6P3RbMdXsNhK61GRftR6SNxqmhthcd9MGIi4T+o0jD8LUSpSnSKXE20nLtJ3fOHxQig==
 
 fast-diff@^1.1.2:
   version "1.2.0"
@@ -5371,7 +5398,7 @@ lodash.truncate@^4.4.2:
   resolved "https://registry.npmjs.org/lodash.truncate/-/lodash.truncate-4.4.2.tgz"
   integrity sha1-WjUNoLERO4N+z//VgSy+WNbq4ZM=
 
-lodash@^4.11.2, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.7.0:
+lodash@^4.11.2, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.17.4, lodash@^4.7.0:
   version "4.17.21"
   resolved "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
@@ -6038,6 +6065,11 @@ pako@^0.2.5:
   resolved "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz"
   integrity sha1-8/dSL073gjSNqBYbrZ7P1Rv4OnU=
 
+parchment@^1.1.2, parchment@^1.1.4:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/parchment/-/parchment-1.1.4.tgz#aeded7ab938fe921d4c34bc339ce1168bc2ffde5"
+  integrity sha512-J5FBQt/pM2inLzg4hEWmzQx/8h8D0CiDxaG3vyp9rKrQRSDgBlhjdP5jQGgosEajXPSQouXGHOmVdgo7QmJuOg==
+
 parent-module@^1.0.0:
   version "1.0.1"
   resolved "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz"
@@ -6399,6 +6431,27 @@ quick-lru@^4.0.1:
   resolved "https://registry.npmjs.org/quick-lru/-/quick-lru-4.0.1.tgz"
   integrity sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==
 
+quill-delta@^3.6.2:
+  version "3.6.3"
+  resolved "https://registry.yarnpkg.com/quill-delta/-/quill-delta-3.6.3.tgz#b19fd2b89412301c60e1ff213d8d860eac0f1032"
+  integrity sha512-wdIGBlcX13tCHOXGMVnnTVFtGRLoP0imqxM696fIPwIf5ODIYUHIvHbZcyvGlZFiFhK5XzDC2lpjbxRhnM05Tg==
+  dependencies:
+    deep-equal "^1.0.1"
+    extend "^3.0.2"
+    fast-diff "1.1.2"
+
+quill@^1.3.7:
+  version "1.3.7"
+  resolved "https://registry.yarnpkg.com/quill/-/quill-1.3.7.tgz#da5b2f3a2c470e932340cdbf3668c9f21f9286e8"
+  integrity sha512-hG/DVzh/TiknWtE6QmWAF/pxoZKYxfe3J/d/+ShUWkDvvkZQVTPeVmUJVu1uE6DDooC4fWTiCLh84ul89oNz5g==
+  dependencies:
+    clone "^2.1.1"
+    deep-equal "^1.0.1"
+    eventemitter3 "^2.0.3"
+    extend "^3.0.2"
+    parchment "^1.1.4"
+    quill-delta "^3.6.2"
+
 raf@^3.4.0:
   version "3.4.1"
   resolved "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz"
@@ -6473,6 +6526,15 @@ react-query@^3.23.2:
     "@babel/runtime" "^7.5.5"
     broadcast-channel "^3.4.1"
     match-sorter "^6.0.2"
+
+react-quill@^2.0.0-beta.4:
+  version "2.0.0-beta.4"
+  resolved "https://registry.yarnpkg.com/react-quill/-/react-quill-2.0.0-beta.4.tgz#522bd2680dc55713068c6cac12f2bf2ccfebcd28"
+  integrity sha512-KyAHvAlPjP4xLElKZJefMth91Z6FbbXRvq9OSu6xN3KBaoasLP9p+3dcxg4Ywr4tBlpMGXcPszYSAgd5CpJ45Q==
+  dependencies:
+    "@types/quill" "^1.3.10"
+    lodash "^4.17.4"
+    quill "^1.3.7"
 
 react-reconciler@^0.23.0:
   version "0.23.0"


### PR DESCRIPTION
## Motivation and context
Campaign description field should allow rich-text formatting as per https://github.com/podkrepi-bg/frontend/issues/845
Decided to add React Quill as one of the most popular wysiwyg editors and also low-code integration.

- added: react-quill as wysiwyg richtext editor with default toolbar
- cleanup and formatting

## Screenshots:
After
 <img width="1125" alt="Screenshot 2022-06-30 at 10 09 23" src="https://user-images.githubusercontent.com/91589884/176615037-f89473bd-a4a8-4086-8f83-42dd146750bd.png"> 

## Testing
manual

**New dependencies**:

- `dependency` : React Quill v2 (yarn add react-quill@beta) 
