### PR TITLE
Fixed RichTextEditor for CreateCampaignForm

### DIFF
--- a/src/components/campaigns/grid/CreateForm.tsx
+++ b/src/components/campaigns/grid/CreateForm.tsx
@@ -18,7 +18,9 @@ import FileUpload from 'components/file-upload/FileUpload'
 import GenericForm from 'components/common/form/GenericForm'
 import SubmitButton from 'components/common/form/SubmitButton'
 import FormTextField from 'components/common/form/FormTextField'
+import FormRichTextField from 'components/common/form/FormRichTextField'
 import AcceptTermsField from 'components/common/form/AcceptTermsField'
+
 import { ApiErrors, isAxiosError, matchValidator } from 'service/apiErrors'
 import { useCreateCampaign, useUploadCampaignFiles } from 'service/campaign'
 import { CampaignFileRole, FileRole, UploadCampaignFiles } from 'components/campaign-file/roles'
@@ -36,10 +38,6 @@ import BeneficiarySelect from './BeneficiarySelect'
 import { CampaignState } from '../helpers/campaign.enums'
 import { toMoney } from 'common/util/money'
 import CurrencySelect from 'components/currency/CurrencySelect'
-
-import dynamic from 'next/dynamic'
-import 'react-quill/dist/quill.snow.css'
-const ReactQuill = dynamic(() => import('react-quill'), { ssr: false })
 
 const formatString = 'yyyy-MM-dd'
 
@@ -95,7 +93,6 @@ export default function CampaignForm({ initialValues = defaults }: CampaignFormP
   const router = useRouter()
   const [files, setFiles] = useState<File[]>([])
   const [roles, setRoles] = useState<FileRole[]>([])
-  const [richDescription, setRichDescription] = useState<string>('')
 
   const { t } = useTranslation()
 
@@ -125,7 +122,7 @@ export default function CampaignForm({ initialValues = defaults }: CampaignFormP
       const response = await mutation.mutateAsync({
         title: values.title,
         slug: createSlug(values.title),
-        description: richDescription,
+        description: values.description,
         targetAmount: toMoney(values.targetAmount),
         allowDonationOnComplete: values.allowDonationOnComplete,
         startDate: values.startDate,
@@ -221,7 +218,7 @@ export default function CampaignForm({ initialValues = defaults }: CampaignFormP
           </Grid>
           <Grid item xs={12}>
             <Typography>{t('campaigns:campaign.description')}</Typography>
-            <ReactQuill theme="snow" value={richDescription} onChange={setRichDescription} />
+            <FormRichTextField name="description" />
           </Grid>
           <Grid item xs={12} sm={6}>
             <p>

--- a/src/components/campaigns/grid/EditForm.tsx
+++ b/src/components/campaigns/grid/EditForm.tsx
@@ -17,6 +17,8 @@ import { createSlug } from 'common/util/createSlug'
 import GenericForm from 'components/common/form/GenericForm'
 import SubmitButton from 'components/common/form/SubmitButton'
 import FormTextField from 'components/common/form/FormTextField'
+import FormRichTextField from 'components/common/form/FormRichTextField'
+
 import { ApiErrors, isAxiosError, matchValidator } from 'service/apiErrors'
 import {
   CampaignResponse,
@@ -38,10 +40,6 @@ import { endpoints } from 'service/apiEndpoints'
 import UploadedCampaignFile from './UploadedCampaignFile'
 import { fromMoney, toMoney } from 'common/util/money'
 import CurrencySelect from 'components/currency/CurrencySelect'
-
-import dynamic from 'next/dynamic'
-import 'react-quill/dist/quill.snow.css'
-const ReactQuill = dynamic(() => import('react-quill'), { ssr: false })
 
 const formatString = 'yyyy-MM-dd'
 
@@ -88,7 +86,6 @@ export default function EditForm({ campaign }: { campaign: AdminSingleCampaignRe
   const queryClient = useQueryClient()
   const [files, setFiles] = useState<File[]>([])
   const [roles, setRoles] = useState<FileRole[]>([])
-  const [richDescription, setRichDescription] = useState(campaign.description || '')
 
   const { t } = useTranslation()
 
@@ -159,7 +156,7 @@ export default function EditForm({ campaign }: { campaign: AdminSingleCampaignRe
       await mutation.mutateAsync({
         title: values.title,
         slug: createSlug(values.title),
-        description: richDescription,
+        description: values.description,
         targetAmount: toMoney(values.targetAmount),
         allowDonationOnComplete: campaign.allowDonationOnComplete,
         startDate: values.startDate,
@@ -261,7 +258,8 @@ export default function EditForm({ campaign }: { campaign: AdminSingleCampaignRe
             <CampaignStateSelect />
           </Grid>
           <Grid item xs={12}>
-            <ReactQuill theme="snow" value={richDescription} onChange={setRichDescription} />
+            <Typography>{t('campaigns:campaign.description')}</Typography>
+            <FormRichTextField name="description" />
           </Grid>
           <Grid item xs={12} sm={6}>
             <p>

--- a/src/components/common/form/FormRichTextField.tsx
+++ b/src/components/common/form/FormRichTextField.tsx
@@ -1,0 +1,36 @@
+import React from 'react'
+import { Field, FieldInputProps, useField } from 'formik'
+import { useTranslation } from 'next-i18next'
+import { Typography } from '@mui/material'
+
+import { translateError } from 'common/form/useForm'
+import { TranslatableField } from 'common/form/validation'
+
+import dynamic from 'next/dynamic'
+import 'react-quill/dist/quill.snow.css'
+const ReactQuill = dynamic(() => import('react-quill'), { ssr: false })
+
+export type RegisterFormProps = {
+  name: string
+}
+
+export default function FormRichTextField({ name }: RegisterFormProps) {
+  const { t } = useTranslation()
+  const [, meta] = useField(name)
+  const helperText = meta.touched ? translateError(meta.error as TranslatableField, t) : ''
+
+  return (
+    <div>
+      {meta.touched && meta.error && (
+        <Typography className="error" color="red">
+          {helperText}
+        </Typography>
+      )}
+      <Field name={name}>
+        {({ field }: { field: FieldInputProps<string> }) => (
+          <ReactQuill theme="snow" value={field.value} onChange={field.onChange(field.name)} />
+        )}
+      </Field>
+    </div>
+  )
+}


### PR DESCRIPTION

## Motivation and context
RichText editor in CreateCampaignForm was not showing errors and submit form button was not working.

Fixed by creating a custom error placeholder. Side improvement: extracted the ReactQuill editor as common component.
