### PR TITLE
feat: basket on campaign page following scroll

### DIFF
--- a/src/components/auth/profile/DonationTab.tsx
+++ b/src/components/auth/profile/DonationTab.tsx
@@ -36,7 +36,7 @@ const Root = styled('div')(({ theme }) => ({
     boxShadow: theme.shadows[3],
   },
   [`& .${classes.donationsBoxRow}`]: {
-    '&:first-child': {
+    '&:first-of-type': {
       borderBottom: `1px solid ${theme.palette.divider}`,
       marginBottom: theme.spacing(1),
       paddingBottom: theme.spacing(1),

--- a/src/components/campaigns/ViewCampaignPage.tsx
+++ b/src/components/campaigns/ViewCampaignPage.tsx
@@ -21,6 +21,10 @@ const useStyles = makeStyles((theme: Theme) =>
         paddingLeft: theme.spacing(0),
       },
     },
+    donationWrapper: {
+      position: 'sticky',
+      top: theme.spacing(12),
+    },
   }),
 )
 
@@ -44,10 +48,8 @@ export default function ViewCampaignPage({ slug }: Props) {
           direction="column"
           flexWrap="nowrap"
           className={classes.sideWrapper}>
-          <Grid item>
+          <Grid item className={classes.donationWrapper}>
             <InlineDonation campaign={campaign} />
-          </Grid>
-          <Grid item>
             <IrregularityReport campaign={campaign} />
           </Grid>
         </Grid>


### PR DESCRIPTION
**Add position sticky on the basket in Campaigns page**

## Motivation and context

- This features makes it easier for user to have access to the basket component,
independently on where exactly on the page he/she is.

- Fix dev tools console error about using first-child in ssr template.

## Screenshots:

| Before              |
| ------------------- |
| <img width="1647" alt="Screenshot 2022-07-07 at 20 04 12" src="https://user-images.githubusercontent.com/18635490/177830215-1b182004-6de6-4b82-8a66-4a74302254f8.png"> |
| After              |
| ------------------- |
| ![basket](https://user-images.githubusercontent.com/18635490/177830321-b3f9eb8c-90a1-4469-bf8a-b737ed0bb805.gif) |
