### PR TITLE
Fixed campaignType translation bug

### DIFF
--- a/src/components/campaigns/CampaignInfo.tsx
+++ b/src/components/campaigns/CampaignInfo.tsx
@@ -9,6 +9,7 @@ import FavoriteIcon from '@mui/icons-material/Favorite'
 import CalendarTodayIcon from '@mui/icons-material/CalendarToday'
 import { getExactDate } from 'common/util/date'
 import CampaignInfoOrganizer from './CampaignInfoOrganizer'
+import { createSlug } from 'common/util/createSlug'
 
 const PREFIX = 'CampaignInfo'
 
@@ -99,6 +100,8 @@ export default function CampaignInfo({ campaign }: Props) {
   const { t, i18n } = useTranslation()
   const locale = i18n.language == 'bg' ? bg : enUS
 
+  const campaignTypeSlug = campaign.campaignType.slug || createSlug(campaign.campaignType.name)
+
   return (
     <StyledGrid mb={5}>
       <Grid container gap={0} className={classes.infoBlockWrapper}>
@@ -115,8 +118,8 @@ export default function CampaignInfo({ campaign }: Props) {
             className={classes.campaignTextWithIcon}>
             <FavoriteIcon color="action" sx={{ mb: '-6px', mr: '3px' }} />
             <strong>
-              {t('campaigns:filters.' + `${campaign.campaignType.category}`)}/{' '}
-              {t('campaigns:campaign.types.' + `${campaign.campaignType?.slug}`)}
+              {t(`campaigns:filters.${campaign.campaignType.category}`)}/{' '}
+              {t(`campaigns:campaign.types.${campaignTypeSlug}`)}
             </strong>
           </Typography>
           {/* TODO: Dynamic campaign tagging is needed here based on activity (urgent, hot, the long-shot, etc) 

--- a/src/components/campaigns/CampaignTypeSelect.tsx
+++ b/src/components/campaigns/CampaignTypeSelect.tsx
@@ -1,6 +1,7 @@
 import { FormControl, FormHelperText, InputLabel, MenuItem, Select } from '@mui/material'
 import { TranslatableField, translateError } from 'common/form/validation'
 import { useCampaignTypesList } from 'common/hooks/campaigns'
+import { createSlug } from 'common/util/createSlug'
 import { useField } from 'formik'
 import { useTranslation } from 'react-i18next'
 
@@ -8,8 +9,6 @@ export default function CampaignTypeSelect({ name = 'campaignTypeId' }) {
   const { t } = useTranslation()
   const { data } = useCampaignTypesList()
   const [field, meta] = useField(name)
-
-  console.log(data)
 
   const helperText = meta.touched ? translateError(meta.error as TranslatableField, t) : ''
   return (
@@ -25,7 +24,7 @@ export default function CampaignTypeSelect({ name = 'campaignTypeId' }) {
         </MenuItem>
         {data?.map((campaignType, index) => (
           <MenuItem key={index} value={campaignType.id}>
-            {t('campaigns:campaign.types.' + `${campaignType.slug}`)}
+            {t(`campaigns:campaign.types.${campaignType.slug || createSlug(campaignType.name)}`)}
           </MenuItem>
         ))}
       </Select>

--- a/src/components/campaigns/grid/CampaignGrid.tsx
+++ b/src/components/campaigns/grid/CampaignGrid.tsx
@@ -18,6 +18,7 @@ import { GridCellExpand } from 'components/common/GridCellExpand'
 import GridActions from './GridActions'
 import DeleteModal from './modals/DeleteModal'
 import DetailsModal from './modals/DetailsModal'
+import { createSlug } from 'common/util/createSlug'
 
 interface CampaignCellProps {
   params: GridRenderCellParams<AdminCampaignResponse, AdminCampaignResponse>
@@ -159,7 +160,13 @@ export default function CampaignGrid() {
       align: 'left',
       width: 250,
       renderCell: (cellValues: GridRenderCellParams) => (
-        <>{t('campaigns:campaign.types.' + `${cellValues.row.campaignType.slug}`)}</>
+        <>
+          {t(
+            `campaigns:campaign.types.${
+              cellValues.row.campaignType.slug || createSlug(cellValues.row.campaignType.name)
+            }`,
+          )}
+        </>
       ),
     },
     {

--- a/src/components/campaigns/grid/modals/DetailsModal.tsx
+++ b/src/components/campaigns/grid/modals/DetailsModal.tsx
@@ -14,6 +14,7 @@ import { useTranslation } from 'next-i18next'
 import { AdminCampaignResponse } from 'gql/campaigns'
 import { money } from 'common/util/money'
 import { getExactDateTime } from 'common/util/date'
+import { createSlug } from 'common/util/createSlug'
 
 type Props = {
   campaign: AdminCampaignResponse
@@ -22,6 +23,7 @@ type Props = {
 
 export default function DetailsModal({ campaign, onClose }: Props) {
   const { t } = useTranslation()
+  const campaignTypeSlug = campaign.campaignType.slug || createSlug(campaign.campaignType.name)
 
   return (
     <Dialog open scroll="body" onClose={onClose}>
@@ -42,7 +44,7 @@ export default function DetailsModal({ campaign, onClose }: Props) {
           <Typography variant="body1">Крайна Дата: {getExactDateTime(campaign.endDate)}</Typography>
           <Typography variant="body1">Същество: {campaign.essence}</Typography>
           <Typography variant="body1">
-            Тип на кампанията: {t('campaigns:campaign.types.' + `${campaign.campaignType.slug}`)}
+            Тип на кампанията: {t(`campaigns:campaign.types.${campaignTypeSlug}`)}
           </Typography>
           <Typography variant="body1">
             Бенефициент: {campaign.beneficiary.person.firstName}{' '}

--- a/src/gql/campaigns.ts
+++ b/src/gql/campaigns.ts
@@ -48,7 +48,7 @@ type BaseCampaignResponse = {
 export type AdminCampaignResponse = BaseCampaignResponse & {
   campaignType: {
     name: string
-    slug: string
+    slug?: string
   }
   beneficiary: {
     person: { firstName: string; lastName: string }
@@ -73,7 +73,7 @@ export type CampaignResponse = BaseCampaignResponse & {
   campaignType: {
     name: string
     category: CampaignTypeCategory
-    slug: string
+    slug?: string
   }
   summary: { reachedAmount: number; donors?: number }[]
   beneficiary: {


### PR DESCRIPTION
## Motivation and context
Usecase: when `campaignType` is missing `slug` , `campaignType.name` is used to create a slug 

## Screenshots:

![Screenshot (179)](https://user-images.githubusercontent.com/78322634/178959814-a94abee6-6e31-4368-8bf9-ef9c545a7cb2.jpg)

![Screenshot (180)](https://user-images.githubusercontent.com/78322634/178959926-d602a577-2823-4f00-b448-41ea572aa2da.png)

