### PR TITLE
Changed thousand separators in BG money format

### DIFF
--- a/src/common/util/money.ts
+++ b/src/common/util/money.ts
@@ -22,7 +22,7 @@ export const moneyPublic = (
   minimumFractionDigits = 0,
 ) => {
   if (!i18n?.language || i18n.language === 'bg' || i18n.language === 'bg-BG') {
-    const amount = new Intl.NumberFormat('de-DE', {
+    const amount = new Intl.NumberFormat('bg-BG', {
       style: 'decimal',
       maximumFractionDigits,
       minimumFractionDigits,


### PR DESCRIPTION
## Motivation and context
closes #939 

## Screenshots:

- in BG
![Screenshot (209)](https://user-images.githubusercontent.com/78322634/181174751-747db7f9-a6f8-4b30-9cc0-1494263436f9.png)

- in EN
![Screenshot (211)](https://user-images.githubusercontent.com/78322634/181174870-6927428f-94c3-4b25-adf1-541978280554.png)

