### PR TITLE
Fixed page positioning in donation workflow

### DIFF
--- a/src/components/one-time-donation/OneTimeDonationPage.tsx
+++ b/src/components/one-time-donation/OneTimeDonationPage.tsx
@@ -56,6 +56,16 @@ const StyledLayout = styled(Layout)(({ theme }) => ({
   },
 }))
 
+const scrollWindow = () => {
+  const bannerWrapper = document.getElementsByClassName(classes.bannerWrapper)[0]
+  const avatarWrapper = document.getElementsByClassName(classes.beneficiaryAvatarWrapper)[0]
+  let calculatedScrollY = 0
+  if (bannerWrapper && avatarWrapper) {
+    calculatedScrollY = bannerWrapper.clientHeight + avatarWrapper.clientHeight / 2
+  }
+  window.scroll(window.scrollX, calculatedScrollY)
+}
+
 export default function OneTimeDonation({ slug }: { slug: string }) {
   const { data } = useViewCampaign(slug)
   if (!data || !data.campaign) return <NotFoundPage />
@@ -101,7 +111,7 @@ export default function OneTimeDonation({ slug }: { slug: string }) {
           <Typography variant="h4" sx={{ textAlign: 'center', marginBottom: theme.spacing(4) }}>
             {campaign.title}
           </Typography>
-          <DonationStepper />
+          <DonationStepper onStepChange={scrollWindow} />
         </Grid>
       </Grid>
     </StyledLayout>

--- a/src/components/one-time-donation/OneTimeDonationPage.tsx
+++ b/src/components/one-time-donation/OneTimeDonationPage.tsx
@@ -63,7 +63,7 @@ const scrollWindow = () => {
   if (bannerWrapper && avatarWrapper) {
     calculatedScrollY = bannerWrapper.clientHeight + avatarWrapper.clientHeight / 2
   }
-  window.scroll(window.scrollX, calculatedScrollY)
+  window.scrollTo({ top: calculatedScrollY, behavior: 'smooth' })
 }
 
 export default function OneTimeDonation({ slug }: { slug: string }) {

--- a/src/components/one-time-donation/Steps.tsx
+++ b/src/components/one-time-donation/Steps.tsx
@@ -132,6 +132,23 @@ export default function DonationStepper() {
     },
   ]
   const [step, setStep] = React.useState(0)
+
+  const onChangeStepScrollWindow = () => {
+    const bannerWrapper = document.getElementsByClassName('OneTimeDonationPage-bannerWrapper')[0]
+    const avatarWrapper = document.getElementsByClassName(
+      'OneTimeDonationPage-beneficiaryAvatarWrapper',
+    )[0]
+    let calculatedScrollY = 0
+    if (bannerWrapper && avatarWrapper) {
+      calculatedScrollY = bannerWrapper.clientHeight + avatarWrapper.clientHeight / 2
+    }
+    window.scroll(window.scrollX, calculatedScrollY)
+  }
+
+  React.useEffect(() => {
+    onChangeStepScrollWindow()
+  }, [step])
+
   return (
     <StepsContext.Provider value={{ step, setStep, campaign }}>
       {isLoading ? (

--- a/src/components/one-time-donation/Steps.tsx
+++ b/src/components/one-time-donation/Steps.tsx
@@ -41,8 +41,11 @@ const initialValues: OneTimeDonation = {
   registerFirstName: '',
   registerPassword: '',
 }
+interface DonationStepperProps {
+  onStepChange: () => void
+}
 
-export default function DonationStepper() {
+export default function DonationStepper({ onStepChange }: DonationStepperProps) {
   const { t } = useTranslation('one-time-donation')
   const router = useRouter()
   const success = router.query.success === 'true' ? true : false
@@ -133,20 +136,8 @@ export default function DonationStepper() {
   ]
   const [step, setStep] = React.useState(0)
 
-  const onChangeStepScrollWindow = () => {
-    const bannerWrapper = document.getElementsByClassName('OneTimeDonationPage-bannerWrapper')[0]
-    const avatarWrapper = document.getElementsByClassName(
-      'OneTimeDonationPage-beneficiaryAvatarWrapper',
-    )[0]
-    let calculatedScrollY = 0
-    if (bannerWrapper && avatarWrapper) {
-      calculatedScrollY = bannerWrapper.clientHeight + avatarWrapper.clientHeight / 2
-    }
-    window.scroll(window.scrollX, calculatedScrollY)
-  }
-
   React.useEffect(() => {
-    onChangeStepScrollWindow()
+    onStepChange()
   }, [step])
 
   return (


### PR DESCRIPTION
## Motivation and context
#906 
It was confusing for the donor that the screen is showing the big campaign picture when one-time-donation page is opened. It was fixed and now the page is positioned to the title on every step.

## Screenshots:

| Before              | After              |
| ------------------- | ------------------ |
| ![before](https://user-images.githubusercontent.com/14825765/181182408-d5f27740-5ff9-4e72-a1b1-129ca424797b.PNG) | ![after](https://user-images.githubusercontent.com/14825765/181182432-fe37df51-5932-4970-aaf7-1b4624efb079.PNG) |
