### PR TITLE
Change number formatting for money

### DIFF
--- a/src/common/util/money.ts
+++ b/src/common/util/money.ts
@@ -22,7 +22,7 @@ export const moneyPublic = (
   minimumFractionDigits = 0,
 ) => {
   if (!i18n?.language || i18n.language === 'bg' || i18n.language === 'bg-BG') {
-    const amount = new Intl.NumberFormat('de-DE', {
+    const amount = new Intl.NumberFormat('fr-FR', {
       style: 'decimal',
       maximumFractionDigits,
       minimumFractionDigits,


### PR DESCRIPTION
It was requested to change the number formatting for money. Currently, we use `.` for splitting the thousands which becomes confusing. This PR changes the format to use ` ` instead.

Old: `18.000`
New: `18 000`