### PR TITLE
Containers and manifests hardening

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Build target dependencies #
 ###########################
-FROM node:16.14.2-alpine3.15 AS base
+FROM node:16-alpine3.16 AS base
 WORKDIR /app
 ARG NODE_ENV=production
 ENV PATH=/app/node_modules/.bin:$PATH \
@@ -44,6 +44,9 @@ COPY --from=builder /app/.next /app/.next
 COPY --from=builder /app/public /app/public
 COPY --from=dependencies /prod_node_modules /app/node_modules
 COPY next.config.js next-i18next.config.js /app/
+
+USER 1000:1001
+
 CMD [ "yarn", "start" ]
 
 HEALTHCHECK --interval=5s --timeout=3s --retries=3 CMD curl --fail http://localhost:3040 || exit 1

--- a/Dockerfile.maintenance
+++ b/Dockerfile.maintenance
@@ -1,4 +1,4 @@
-FROM nginx:stable-alpine
+FROM nginxinc/nginx-unprivileged:1.23-alpine
 COPY public/maintenance.html /usr/share/nginx/html/index.html
 COPY public/maintenance-illustration.svg /usr/share/nginx/html/
 COPY public/favicon.ico /usr/share/nginx/html/

--- a/manifests/base/deployment.yaml
+++ b/manifests/base/deployment.yaml
@@ -14,10 +14,14 @@ spec:
       labels:
         app: frontend
     spec:
+      automountServiceAccountToken: false
       containers:
         - name: frontend
           image: ghcr.io/podkrepi-bg/frontend
           imagePullPolicy: Always
+          securityContext:
+            runAsNonRoot: true
+            readOnlyRootFilesystem: true
           env:
             - name: NODE_ENV
               value: production

--- a/manifests/base/maintenance.yaml
+++ b/manifests/base/maintenance.yaml
@@ -10,7 +10,7 @@ spec:
   ports:
     - name: http
       port: 80
-      targetPort: 80
+      targetPort: 8080
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -28,11 +28,16 @@ spec:
       labels:
         app: frontend-maintenance
     spec:
+      automountServiceAccountToken: false
       containers:
         - name: frontend
           image: ghcr.io/podkrepi-bg/frontend/maintenance:master
+          imagePullPolicy: Always
+          securityContext:
+            runAsNonRoot: true
+            readOnlyRootFilesystem: true
           ports:
-            - containerPort: 80
+            - containerPort: 8080
           resources:
             limits:
               memory: 40Mi
@@ -43,12 +48,12 @@ spec:
           livenessProbe:
             httpGet:
               path: /
-              port: 80
+              port: 8080
             initialDelaySeconds: 10
             periodSeconds: 5
           readinessProbe:
             httpGet:
               path: /
-              port: 80
+              port: 8080
             initialDelaySeconds: 5
             periodSeconds: 5


### PR DESCRIPTION
Containers:
- [x] use unprivileged container for maintenance page
- [x] update base image for frontend
- [x] run frontend as non-root

Manifests:
- [x] do not auto-mount k8s service account token
- [x] enforce running as non-root
- [x] use read-only filesystem