### PR TITLE
Swap report links on finance page

### DIFF
--- a/src/components/about-project/FinanceReportPage.tsx
+++ b/src/components/about-project/FinanceReportPage.tsx
@@ -17,7 +17,7 @@ export default function FinanceReportPage() {
         <Typography>Финансов репорт за 2021:</Typography>
         <LinkButton
           endIcon={<FileDownloadIcon />}
-          href="/finance-reports/Podkrepi.bg_Financial_Report_062022.pdf">
+          href="/finance-reports/Podkrepi.bg_Financial_Report_2021_1.pdf">
           Свалете от тук
         </LinkButton>
       </Container>
@@ -25,7 +25,7 @@ export default function FinanceReportPage() {
         <Typography>Финансов репорт за 2022 Януари-Юни:</Typography>
         <LinkButton
           endIcon={<FileDownloadIcon />}
-          href="/finance-reports/Podkrepi.bg_Financial_Report_2021_1.pdf">
+          href="/finance-reports/Podkrepi.bg_Financial_Report_062022.pdf">
           Свалете от тук
         </LinkButton>
       </Container>


### PR DESCRIPTION
## Motivation and context

Links of the finance reports were swapped and the link for 2021 opened 2022 report.


## Screenshots:
![image](https://user-images.githubusercontent.com/893608/182079148-9e931dc3-1bb5-45c9-aee6-d906c9bb2edd.png)

