### PR TITLE
BankAccount, City and Company as Beneficient fixes

### DIFF
--- a/src/components/admin/AdminPage.tsx
+++ b/src/components/admin/AdminPage.tsx
@@ -7,7 +7,7 @@ import { Box, Card, CardActionArea, CardContent, Grid, Typography } from '@mui/m
 import { isAdmin } from 'common/util/roles'
 import AdminLayout from 'components/admin/navigation/AdminLayout'
 
-import { menuItems } from './navigation/adminMenu'
+import { adminCards } from './navigation/adminMenu'
 import AdminContainer from './navigation/AdminContainer'
 
 export default function AdminPage() {
@@ -45,7 +45,7 @@ export default function AdminPage() {
           <Typography variant="h6">{'Добре дошли!'}</Typography>
         </Box>
         <Grid container spacing={2} rowSpacing={4} px={4} pb={4}>
-          {menuItems.map(({ label, href, icon: Icon }, index) => (
+          {adminCards.map(({ label, href, icon: Icon }, index) => (
             <Grid xs={12} sm={6} md={4} lg={2} item key={index}>
               <Card sx={{ maxWidth: 345 }}>
                 <CardActionArea onClick={() => router.push(href)}>

--- a/src/components/admin/navigation/adminMenu.tsx
+++ b/src/components/admin/navigation/adminMenu.tsx
@@ -38,9 +38,9 @@ export const menuCampaings = [
 ]
 
 export const menuPayments = [
-  { label: 'Плащания', icon: Payment, href: routes.admin.bankaccounts.index },
   { label: 'Дарения', icon: VolunteerActivismOutlinedIcon, href: routes.admin.donations.index },
   { label: 'Трезори', icon: Shield, href: routes.admin.vaults.index },
+  { label: 'Банкови сметки', icon: Payment, href: routes.admin.bankaccounts.index },
   { label: 'Тегления', icon: LocalAtmIcon, href: routes.admin.withdrawals.index },
   { label: 'Прехвърляния', icon: MoveUp, href: routes.admin.transfer.index },
   { label: 'Разходи', icon: Paid, href: routes.admin.expenses.index },
@@ -64,30 +64,31 @@ export const items = [
   { items: menuSetings, menu: 'Системни', icon: DisplaySettings },
 ]
 
-export const menuItems = [
+export const adminCards = [
   { label: 'Кампании', icon: AssignmentInd, href: routes.admin.campaigns.index },
   { label: 'Дарения', icon: VolunteerActivismOutlinedIcon, href: routes.admin.donations.index },
-  { label: 'Доброволци', icon: People, href: routes.admin.supporters },
-  { label: 'Контакти', icon: ContactPhone, href: routes.admin.infoRequests },
-  { label: 'Плащания', icon: Payment, href: routes.admin.bankaccounts.index },
-  { label: 'Потребители', icon: Group, href: routes.admin.person.create },
-  { label: 'ЮЛНЦ', icon: Group, href: routes.admin.company.create },
-  { label: 'Документи', icon: FolderShared, href: routes.admin.documents.index },
-  { label: 'Бенефактори', icon: BeneficiaryIcon, href: routes.admin.benefactor.index },
   { label: 'Бенефициенти', icon: BeneficiaryIcon, href: routes.admin.beneficiary.index },
-  { label: 'Типове кампании', icon: Class, href: routes.admin.campaignTypes.index },
-  { label: 'Градове', icon: LocationCityRoundedIcon, href: routes.admin.cities.home },
-  { label: 'Държави', icon: Public, href: routes.admin.countries.index },
   { label: 'Координатори', icon: People, href: routes.admin.coordinators.index },
+  { label: 'Организатори', icon: Group, href: routes.admin.organizers.index },
+  { label: 'ЮЛНЦ', icon: Group, href: routes.admin.company.create },
+  { label: 'Банкови сметки', icon: Payment, href: routes.admin.bankaccounts.index },
+  { label: 'Тегления', icon: LocalAtmIcon, href: routes.admin.withdrawals.index },
   { label: 'Разходи', icon: Paid, href: routes.admin.expenses.index },
   { label: 'Трезори', icon: Shield, href: routes.admin.vaults.index },
-  { label: 'Тегления', icon: LocalAtmIcon, href: routes.admin.withdrawals.index },
   { label: 'Прехвърляния', icon: MoveUp, href: routes.admin.transfer.index },
   {
     label: 'Повтарящо се дарение',
     icon: VolunteerActivism,
     href: routes.admin.recurringDonation.index,
   },
+  { label: 'Доброволци', icon: People, href: routes.admin.supporters },
+  { label: 'Контакти', icon: ContactPhone, href: routes.admin.infoRequests },
+  { label: 'Потребители', icon: Group, href: routes.admin.person.create },
+  { label: 'Документи', icon: FolderShared, href: routes.admin.documents.index },
+  { label: 'Бенефактори', icon: BeneficiaryIcon, href: routes.admin.benefactor.index },
+  { label: 'Типове кампании', icon: Class, href: routes.admin.campaignTypes.index },
+  { label: 'Градове', icon: LocationCityRoundedIcon, href: routes.admin.cities.home },
+  { label: 'Държави', icon: Public, href: routes.admin.countries.index },
+
   { label: 'Злоупотреби', icon: ReportGmailerrorredIcon, href: routes.admin.irregularity.index },
-  { label: 'Организатори', icon: Group, href: routes.admin.organizers.index },
 ]

--- a/src/components/beneficiary/BeneficiaryTypes.ts
+++ b/src/components/beneficiary/BeneficiaryTypes.ts
@@ -18,7 +18,7 @@ export const PersonRelation = {
   colleague: 'colleague',
 }
 
-export const BeneficiaryType = {
-  individual: 'individual',
-  company: 'company',
+export enum BeneficiaryType {
+  individual = 'individual',
+  company = 'company',
 }

--- a/src/components/beneficiary/CreateForm.tsx
+++ b/src/components/beneficiary/CreateForm.tsx
@@ -138,7 +138,7 @@ export default function CreateForm() {
                 <PersonSelect name="personId" label={t('beneficiary:forms.labels.person-label')} />
               </Grid>
               <Grid item xs={6}>
-                <CountrySelect name="countryCode" />
+                <CountrySelect />
               </Grid>
               <Grid item xs={6}>
                 <CitySelect name="cityId" />

--- a/src/components/beneficiary/EditForm.tsx
+++ b/src/components/beneficiary/EditForm.tsx
@@ -166,7 +166,7 @@ export default function EditForm() {
                 <PersonSelect name="personId" label={t('beneficiary:forms.labels.person-label')} />
               </Grid>
               <Grid item xs={6}>
-                <CountrySelect name="countryCode" />
+                <CountrySelect />
               </Grid>
               <Grid item xs={6}>
                 <CitySelect

--- a/src/components/beneficiary/EditForm.tsx
+++ b/src/components/beneficiary/EditForm.tsx
@@ -169,10 +169,7 @@ export default function EditForm() {
                 <CountrySelect />
               </Grid>
               <Grid item xs={6}>
-                <CitySelect
-                  disabled={initialValues.type === BeneficiaryType.company}
-                  name="cityId"
-                />
+                <CitySelect name="cityId" />
               </Grid>
             </>
           ) : (

--- a/src/components/campaigns/CampaignDetails.tsx
+++ b/src/components/campaigns/CampaignDetails.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import Image from 'next/image'
 import { CampaignResponse } from 'gql/campaigns'
+import { BeneficiaryType } from 'components/beneficiary/BeneficiaryTypes'
 import CampaignMessages from './CampaignMessages'
 import CampaignSlider from './CampaignSlider'
 import {
@@ -125,7 +126,9 @@ export default function CampaignDetails({ campaign }: Props) {
           className={classes.beneficiaryAvatar}
         />
         <Typography variant="subtitle2" component="p" className={classes.beneficiaryName}>
-          {campaign.beneficiary.person.firstName} {campaign.beneficiary.person.lastName}
+          {campaign.beneficiary.type === BeneficiaryType.individual
+            ? campaign.beneficiary.person.firstName + ' ' + campaign.beneficiary.person?.lastName
+            : campaign.beneficiary.company.companyName}
         </Typography>
       </Grid>
       <Typography variant="h1" component="h1" my={8} className={classes.campaignTitle}>

--- a/src/components/campaigns/grid/CampaignGrid.tsx
+++ b/src/components/campaigns/grid/CampaignGrid.tsx
@@ -17,6 +17,7 @@ import { GridCellExpand } from 'components/common/GridCellExpand'
 import GridActions from './GridActions'
 import DeleteModal from './modals/DeleteModal'
 import DetailsModal from './modals/DetailsModal'
+import { BeneficiaryType } from 'components/beneficiary/BeneficiaryTypes'
 
 interface CampaignCellProps {
   params: GridRenderCellParams<AdminCampaignResponse, AdminCampaignResponse>
@@ -40,7 +41,9 @@ const DisplayOrganizer = ({ params }: CampaignCellProps) => {
 const DisplayBeneficiary = ({ params }: CampaignCellProps) => {
   return (
     <>
-      {params.row.beneficiary.person.firstName} {params.row.beneficiary.person.lastName}
+      {params.row.beneficiary.type === BeneficiaryType.individual
+        ? params.row.beneficiary.person.firstName + ' ' + params.row.beneficiary.person?.lastName
+        : params.row.beneficiary.company.companyName}
     </>
   )
 }

--- a/src/components/cities/CreateForm.tsx
+++ b/src/components/cities/CreateForm.tsx
@@ -78,7 +78,7 @@ export default function EditForm() {
             />
           </Grid>
           <Grid item xs={12}>
-            <CountrySelect />
+            <CountrySelect formField="countryId" valueName="id" />
           </Grid>
           <Grid item xs={6}>
             <SubmitButton fullWidth label={t('cities:cta:submit')} />

--- a/src/components/cities/EditForm.tsx
+++ b/src/components/cities/EditForm.tsx
@@ -81,7 +81,7 @@ export default function EditForm() {
             />
           </Grid>
           <Grid item xs={12}>
-            <CountrySelect />
+            <CountrySelect formField="countryId" valueName="id" />
           </Grid>
           <Grid item xs={6}>
             <SubmitButton fullWidth label={t('cities:cta:submit')} />

--- a/src/components/companies/grid/CreateForm.tsx
+++ b/src/components/companies/grid/CreateForm.tsx
@@ -104,7 +104,7 @@ export default function CreateForm() {
                 {t('companies:admin.cta.create-new')}
               </Link>
             </p>
-            <CountrySelect name="countryId" />
+            <CountrySelect formField="countryId" valueName="id" />
           </Grid>
           <Grid item xs={6}>
             <p>

--- a/src/components/countries/CountrySelect.tsx
+++ b/src/components/countries/CountrySelect.tsx
@@ -2,12 +2,21 @@ import { FormControl, FormHelperText, InputLabel, MenuItem, Select } from '@mui/
 import { TranslatableField, translateError } from 'common/form/validation'
 import { useCountriesList } from 'common/hooks/countries'
 import { useField } from 'formik'
+import { CountryResponse } from 'gql/countries'
 import { useTranslation } from 'react-i18next'
 
-export default function CountrySelect({ name = 'countryCode' }) {
+type Props = {
+  formField?: string
+  valueName?: keyof CountryResponse
+}
+
+export default function CountrySelect({
+  formField = 'countryCode',
+  valueName = 'countryCode',
+}: Props) {
   const { t } = useTranslation()
   const { data } = useCountriesList()
-  const [field, meta] = useField(name)
+  const [field, meta] = useField(formField)
 
   const helperText = meta.touched ? translateError(meta.error as TranslatableField, t) : ''
   if (!data) {
@@ -26,7 +35,7 @@ export default function CountrySelect({ name = 'countryCode' }) {
           {t('countries:select-country')}
         </MenuItem>
         {data?.map((country) => (
-          <MenuItem key={country.id} value={country.countryCode}>
+          <MenuItem key={country.id} value={country[valueName] as string}>
             {country.name}
           </MenuItem>
         ))}

--- a/src/gql/beneficiary.d.ts
+++ b/src/gql/beneficiary.d.ts
@@ -3,7 +3,7 @@ import { Person } from './person'
 
 export type BeneficiaryListResponse = {
   id: string
-  type: BeneficiaryType
+  type?: BeneficiaryType
   personId?: string
   person?: Person
   company?: { companyName: string }
@@ -23,7 +23,7 @@ export type ViewBeneficiaryResponse = BeneficiaryListResponse & {
 }
 
 export type BeneficiaryFormData = {
-  type: BeneficiaryType
+  type?: BeneficiaryType
   personId?: string
   companyId?: string
   countryCode: string

--- a/src/gql/campaigns.ts
+++ b/src/gql/campaigns.ts
@@ -4,6 +4,7 @@ import type { CampaignTypeCategory } from 'components/campaign-types/categories'
 import { Currency } from './currency'
 import { PaymentProvider } from './donations.enums'
 import { CampaignState } from 'components/campaigns/helpers/campaign.enums'
+import { BeneficiaryType } from '../components/beneficiary/BeneficiaryTypes'
 
 export type CampaignType = {
   id: UUID
@@ -51,7 +52,11 @@ export type AdminCampaignResponse = BaseCampaignResponse & {
     slug: string
   }
   beneficiary: {
-    person: { firstName: string; lastName: string }
+    id: UUID
+    type: BeneficiaryType
+    publicData: string
+    person: { id: UUID; firstName: string; lastName: string }
+    company: { id: UUID; companyName: string }
   }
   coordinator: {
     person: { firstName: string; lastName: string }
@@ -80,9 +85,10 @@ export type CampaignResponse = BaseCampaignResponse & {
   summary: { reachedAmount: number; donors?: number }
   beneficiary: {
     id: UUID
-    type: string
+    type: BeneficiaryType
     publicData: string
     person: { id: UUID; firstName: string; lastName: string }
+    company: { id: UUID; companyName: string }
   }
   coordinator: {
     id: UUID


### PR DESCRIPTION
## Motivation and context
Several fixes of reported problems:

- admin menu renamed Payments to BankAccounts and reordered for convenience
- fixed: country selection when creating city, beneficiery and company
- fixed: when beneficiary is company, the company name needs to be displayed instead of person name

