### PR TITLE
added token expiration check in admin and profile page

### DIFF
--- a/src/pages/admin/_middleware.ts
+++ b/src/pages/admin/_middleware.ts
@@ -5,7 +5,7 @@ import withAuth from 'next-auth/middleware'
 export default withAuth({
   callbacks: {
     authorized: ({ token }) => {
-      return isAdmin(token)
+      return token ? token.accessTokenExpires > Date.now() && isAdmin(token) : false
     },
   },
 })

--- a/src/pages/api/auth/[...nextauth].ts
+++ b/src/pages/api/auth/[...nextauth].ts
@@ -108,7 +108,7 @@ export const authOptions: NextAuthOptions = {
         // Initial sign in only triggered when a provider is logging
         if (account.provider === 'credentials') {
           // With credentials the user is already a `AuthResponse` that is what is returned from the `authorize` function:
-          console.log(user)
+          console.log('user: ' + user)
           return {
             accessToken: user.accessToken,
             // This is called the first time only here expires always exists and that calculates the timestamp that the token would actually expire in

--- a/src/pages/profile/_middleware.ts
+++ b/src/pages/profile/_middleware.ts
@@ -1,12 +1,10 @@
 // https://next-auth.js.org/configuration/nextjs#middleware
-import { getToken } from 'next-auth/jwt'
 import withAuth from 'next-auth/middleware'
 
 export default withAuth({
   callbacks: {
-    authorized: async ({ req }) => {
-      const session = await getToken({ req })
-      return !!session
+    authorized: async ({ token }) => {
+      return token ? token.accessTokenExpires > Date.now() : false
     },
   },
 })


### PR DESCRIPTION

## Motivation and context
When the session expires and the user is on pages that require login, he is not redirected to login automatically and the site displays errors.
Fixed by adding check for token expiration in next-auth middleware for profile and admin pages.

