### PR TITLE
fixed: organizer mail on campaign display page

### DIFF
--- a/src/components/campaigns/CampaignInfoOrganizer.tsx
+++ b/src/components/campaigns/CampaignInfoOrganizer.tsx
@@ -100,7 +100,7 @@ export default function CampaignInfoOrganizer({ campaign }: Props) {
             campaign.title
           }
           className={classes.trustedButton}>
-          {campaign.coordinator.person.email}
+          {campaign?.organizer?.person.email}
         </Button>
         {/*TODO: No current implementation of organizer profile */}
         {/* <Button href={''} className={classes.linkButton}>


### PR DESCRIPTION

## Motivation and context
Fixed organizer mail on campaign display page - instead of organizer it was wrongly displaying coordinator's mail.
