### PR TITLE
1044 bug hidden scroll bar on selected dropdown menu

### DIFF
--- a/src/components/layout/nav/GenericMenu.tsx
+++ b/src/components/layout/nav/GenericMenu.tsx
@@ -28,6 +28,7 @@ export default function GenericMenu({ label, children }: Props) {
         {label}
       </Button>
       <Menu
+        disableScrollLock={true}
         keepMounted
         id="menu-donation"
         anchorEl={anchorEl}

--- a/src/components/layout/nav/GenericMenu.tsx
+++ b/src/components/layout/nav/GenericMenu.tsx
@@ -28,8 +28,8 @@ export default function GenericMenu({ label, children }: Props) {
         {label}
       </Button>
       <Menu
-        disableScrollLock={true}
         keepMounted
+        disableScrollLock={true}
         id="menu-donation"
         anchorEl={anchorEl}
         elevation={6}

--- a/src/components/layout/nav/GenericMenu.tsx
+++ b/src/components/layout/nav/GenericMenu.tsx
@@ -28,8 +28,8 @@ export default function GenericMenu({ label, children }: Props) {
         {label}
       </Button>
       <Menu
-        keepMounted
         disableScrollLock={true}
+        keepMounted
         id="menu-donation"
         anchorEl={anchorEl}
         elevation={6}


### PR DESCRIPTION
## Motivation and context

<!--- Why is this change required? -->
The user can't scroll down if a dropdown menu is openned
<!--- If it fixes an open issue, please link to the issue here. -->
Closing #1044 
<!--- Any links to external sources of documentation -->
The bug was noticed in the MUI github repository 
From the comments on the issue i found a solution on stackoverflow https://stackoverflow.com/questions/69065717/material-ui-menu-component-locks-body-scrollbar/71671897#71671897

<!--- What problem are you trying to solve? -->
Solved disabled scroll when a dropdown menu is opened
<!--- How did you solve the problem? -->
I solved the issue like on the Menu Component that is comming from MUI there is a property disableScrollLock and i set it to true
<!--- Provide link to ora.pm task if any -->

## Screenshots:

### Before     
 
![Screenshot (30)](https://user-images.githubusercontent.com/99186919/194528260-da6054ab-2012-44ee-9ff0-ae461254c47a.png)

 ### After  
    
![Screenshot (31)](https://user-images.githubusercontent.com/99186919/194528362-0a19bc78-a787-4c40-9b26-92bf367e6f07.png)


## Testing

<!--- Please describe in detail how you tested your changes. -->
I checked the desktop pages if it's working everywhere and it's okay 

P.S
Sorry for the 3 commits i forgot to configure my git author name and email properly 


