### PR TITLE
Fixed the disabled scrolling when openning all dropdown menus

### DIFF
--- a/src/components/layout/nav/AdminMenu.tsx
+++ b/src/components/layout/nav/AdminMenu.tsx
@@ -90,6 +90,7 @@ export default function AdminMenu() {
         )}
       </IconButton>
       <Menu
+        disableScrollLock={true}
         keepMounted
         id="menu-appbar"
         anchorEl={anchorEl}

--- a/src/components/layout/nav/PrivateMenu.tsx
+++ b/src/components/layout/nav/PrivateMenu.tsx
@@ -83,6 +83,7 @@ export default function PrivateMenu() {
         )}
       </IconButton>
       <Menu
+        disableScrollLock={true}
         keepMounted
         id="menu-appbar"
         anchorEl={anchorEl}

--- a/src/components/layout/nav/PublicMenu.tsx
+++ b/src/components/layout/nav/PublicMenu.tsx
@@ -65,6 +65,7 @@ export default function PublicMenu() {
         <PersonIcon />
       </Button>
       <Menu
+        disableScrollLock={true}
         open={Boolean(anchorEl)}
         keepMounted
         id="menu-appbar"


### PR DESCRIPTION
The user can't scroll down if a dropdown menu is opened.I already fixed that in #1044 but then i wasn't having the backend installed.Now when i have it i noticed that the problem also appears when a user(PrivateMenu)/admin(AdminMenu) is logged in.Also it appeared when clicking on the user profile icon(PublicMenu) (obviously i didn't checked that).But now i fixed the issue in every dropdown menu.

Closing https://github.com/podkrepi-bg/frontend/issues/1047

The bug was noticed in the MUI github repository
From the comments on the issue i found a solution on stackoverflow https://stackoverflow.com/questions/69065717/material-ui-menu-component-locks-body-scrollbar/71671897#71671897

Solved disabled scroll when a dropdown menu is opened

I solved the issue like on the Menu Component that is comming from MUI there is a property disableScrollLock and i set it to true in three other Dropdown Menu Components (Admin,Private,Public)