### PR TITLE
Urgent campaigns on two rows

### DIFF
--- a/src/components/index/sections/CampaignsSection.tsx
+++ b/src/components/index/sections/CampaignsSection.tsx
@@ -81,7 +81,7 @@ export default function CampaignsSection() {
           {t('index:campaign.urgent-campaigns')}
         </Heading>
         <Grid container justifyContent="center" spacing={4}>
-          {data?.slice(0, 4).map((campaign, index, array) => (
+          {data?.slice(0, 8).map((campaign, index, array) => (
             <Grid key={index} item xs={12} sm={6} lg={3}>
               <Box
                 sx={(theme) => ({


### PR DESCRIPTION
## Motivation and context
Now that we have more campaigns, urgent campaigns need to appear on two rows.
Fixed by extending the slice from 4 to 8.

