### PR TITLE
Hotjar tracking

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@emotion/react": "^11.8.1",
     "@emotion/server": "^11.4.0",
     "@emotion/styled": "^11.8.1",
+    "@hotjar/browser": "^1.0.6",
     "@mui/icons-material": "^5.4.2",
     "@mui/lab": "^5.0.0-alpha.69",
     "@mui/material": "^5.4.2",

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -11,6 +11,13 @@ import DetailsModal from 'components/modal/DetailsModal'
 import AppNavBar from './AppNavBar'
 import MobileNav from './nav/MobileNav'
 
+import Hotjar from '@hotjar/browser'
+
+const siteId = 3217553
+const hotjarVersion = 6
+
+Hotjar.init(siteId, hotjarVersion)
+
 const createPageTitle = (suffix: string, title?: string) => {
   if (title) {
     return `${title} | ${suffix}`

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -18,6 +18,12 @@ const hotjarVersion = 6
 
 Hotjar.init(siteId, hotjarVersion)
 
+const head = document.getElementsByTagName('head')[0]
+const script = document.createElement('script')
+script.type = 'text/javascript'
+script.src = 'https://www.googleoptimize.com/optimize.js?id=OPT-W89QK8X'
+head.appendChild(script)
+
 const createPageTitle = (suffix: string, title?: string) => {
   if (title) {
     return `${title} | ${suffix}`
@@ -71,7 +77,6 @@ export default function Layout({
         maxWidth={maxWidth}
         {...containerProps}>
         <Head>
-          <script async src="https://www.googleoptimize.com/optimize.js?id=OPT-W89QK8X" />
           <title>{pageTitle}</title>
           <meta name="description" content={metaDescription ?? pageTitle} />
           <meta name="og:description" content={metaDescription ?? pageTitle} />

--- a/yarn.lock
+++ b/yarn.lock
@@ -682,6 +682,11 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
+"@hotjar/browser@^1.0.6":
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/@hotjar/browser/-/browser-1.0.6.tgz#5e1c9a2b0c7c21d65acb741b76c39ed81eaa4e5f"
+  integrity sha512-yq8pFrCk/pGe1LeI9kgd4NZNI3C8eQlck+ISmWnL3T8RtN/YYEmzDFEZ1AFZ9GGAbxyxG6xUdaL3/S7sOSqeCQ==
+
 "@istanbuljs/load-nyc-config@^1.0.0":
   version "1.1.0"
   resolved "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz"


### PR DESCRIPTION
I added Google optimize tracker and a tracker for Hotjar. Hotjar added a dependency that was needed for easier access as per instructions. Providing screenshot because the page is account specific:
https://snipboard.io/yjLa6G.jpg

As for the google snippet i parsed it as VSCode was having issues with the <script> tag so now it should work. I named wrongfully the second commit hotjar aswell but its for google optimize

**New dependencies**:

package.json
    "@hotjar/browser": "^1.0.6",

yarn.lock
"@hotjar/browser@^1.0.6":
  version "1.0.6"
  resolved "https://registry.yarnpkg.com/@hotjar/browser/-/browser-1.0.6.tgz#5e1c9a2b0c7c21d65acb741b76c39ed81eaa4e5f"
  integrity sha512-yq8pFrCk/pGe1LeI9kgd4NZNI3C8eQlck+ISmWnL3T8RtN/YYEmzDFEZ1AFZ9GGAbxyxG6xUdaL3/S7sOSqeCQ==
