### PR TITLE
Added default value for allowDelete in GridActions

### DIFF
--- a/src/components/auth/profile/MyCampaignsTable.tsx
+++ b/src/components/auth/profile/MyCampaignsTable.tsx
@@ -56,7 +56,6 @@ export default function MyCampaingsTable() {
         return (
           <GridActions
             id={cellValues.row.id}
-            allowDelete={false}
             onView={() => setViewId(cellValues.row.id)}
             onDelete={() => null}
           />

--- a/src/components/campaigns/grid/GridActions.tsx
+++ b/src/components/campaigns/grid/GridActions.tsx
@@ -9,12 +9,12 @@ import { routes } from 'common/routes'
 
 type Props = {
   id: string
-  allowDelete: boolean
+  allowDelete?: boolean
   onView: () => void
   onDelete: () => void
 }
 
-export default function GridActions({ id, allowDelete, onView, onDelete }: Props) {
+export default function GridActions({ id, allowDelete = false, onView, onDelete }: Props) {
   return (
     <Box
       style={{


### PR DESCRIPTION
I added a default value for allowDelete in the GridActions, so the allowDelete propery is per default set to false and in the admin CampaignGrid it set to true, while in the /profile/my-campaigns it's set to false per default (without setting it explicitly). The change was made as per recommendation of @kachar in #1073 