### PR TITLE
Made my profile tabs scrollable in mobile view

### DIFF
--- a/src/components/auth/profile/ProfilePage.tsx
+++ b/src/components/auth/profile/ProfilePage.tsx
@@ -9,7 +9,7 @@ import {
   VolunteerActivism as DonationIcon,
   AccountBox as AccountBoxIcon,
   Assignment as CertificateIcon,
-  AssignmentInd as CampaignIcon,
+  AccountBalance as CampaignIcon,
 } from '@mui/icons-material'
 import { useSession } from 'next-auth/react'
 
@@ -77,12 +77,14 @@ export default function ProfilePage() {
           sx={{
             backgroundColor: 'white',
             borderRadius: '25px 25px 0px 0px',
-            padding: '10px 30px',
+            padding: '10px 10px',
             boxShadow: 3,
           }}>
-          <h1 className={classes.h1}>{t('profile:header')}</h1>
+          <h1 className={classes.h1} style={{ marginLeft: '20px' }}>
+            {t('profile:header')}
+          </h1>
           <Box sx={{ borderBottom: 1, borderColor: 'divider' }}>
-            <Tabs value={tab.slug}>
+            <Tabs value={tab.slug} variant="scrollable" scrollButtons allowScrollButtonsMobile>
               <Tab
                 className={matches ? classes.tabMobile : ''}
                 value={ProfileTabs.donations}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and context

<!--- Why is this change required? -->
There was a problem, that I saw from a message in discrod, that when the user in in https://podkrepi.bg/profile/[slug] in mobile view, not all tabs are visible. So basically the user can see only 3 of the 4 tabs, and there is no way that the user can see the fourth tab - the tabs are neither scrollable, nor they provide a button that can act like horizontal scrollbar.

I also changed the icon of my-campaigns section because they were kinda the same with the edit personal information icon( see the image below) 
I don't know if this is the perfect icon and I'm open to suggestions.


![Screenshot (80)](https://user-images.githubusercontent.com/99186919/202414419-07cbb251-6769-4228-b416-b8b241667a79.png)




<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Any links to external sources of documentation -->
<!--- Any links to internal designs -->
<!--- What problem are you trying to solve? -->
<!--- How did you solve the problem? -->
I followed the MUI documentation and implemented the Forced scroll buttons from there, because if you add just scroll buttons, they are available only in desktop mode, but not in mobile and that's not what we want. 
There was another way to fix this, so I basically had to make the tabs scrollable, but I think that this way the user won't even understand that there is fourth tab ( if he doesn't see the chevron icon, that indicates that the user can scroll ). So now the user can see the fourth tab with click on the chevron and scrolling can also be initiated through user agent scrolling mechanisms (e.g. left/right swipe, shift mouse wheel, etc.)



##Screenshots

THE PROBLEM ( 4th tab not visible and not reachable ) 

![Screenshot_20221117-083239_Chrome](https://user-images.githubusercontent.com/99186919/202412787-89367a3e-215a-4985-9dd9-9378aac19080.jpg)

THE SOLUTION

![Screenshot (82)](https://user-images.githubusercontent.com/99186919/202413515-cccaeccd-d134-47f2-b4c2-b206c5d03110.png)
![Screenshot (83)](https://user-images.githubusercontent.com/99186919/202413516-9ec4ba98-0963-4d13-ae73-2e4110202d21.png)



If you wonder why is there to much place on the left and right, when the chevrons are not visible, the reason is that they don't dissapear from the dom and stay always there.



