### PR TITLE
Consistent date format in update birthday modal

### DIFF
--- a/src/common/util/date.ts
+++ b/src/common/util/date.ts
@@ -10,18 +10,32 @@ export const dateFormatter = (value: Date | string | number, locale?: Locale) =>
   return `${exact} (${relative})`
 }
 
-export const formatDateString = (dateString: string | Date) => {
-  const date = new Date(dateString)
-  const day = date.getDate().toString().padStart(2, '0')
-  const month = (date.getMonth() + 1).toString().padStart(2, '0')
-  const year = date.getFullYear()
-
-  return `${day}.${month}.${year}`
+export const formatDateString = (dateString: string | Date, locale?: string | undefined) => {
+  return format(new Date(dateString), getDateFormat(locale ?? ''))
 }
 
 export const getRelativeDate = (value: Date | string, locale?: Locale) => {
   const date = new Date(value)
   return formatRelative(date, new Date(), { locale })
+}
+
+/**
+ * Value format for storing and passing date strings. Should be used whenever we pass date strings between components.
+ */
+export const DATE_VALUE_FORMAT = 'yyyy-MM-dd'
+
+/**
+ * Utility to return localized date format string. Should be used whenever dates are displayed to end users.
+ * @param language Language to get the corresponding date format
+ * @returns Format string
+ */
+export const getDateFormat = (language: string) => {
+  const defaultFormat = 'dd.MM.yyyy'
+  const languageDateFormats: { [language: string]: string } = {
+    bg: defaultFormat,
+    'en-US': 'MM/dd/yyyy',
+  }
+  return languageDateFormats[language] ?? defaultFormat
 }
 
 /**

--- a/src/common/util/date.ts
+++ b/src/common/util/date.ts
@@ -11,7 +11,10 @@ export const dateFormatter = (value: Date | string | number, locale?: Locale) =>
 }
 
 export const formatDateString = (dateString: string | Date, locale?: string | undefined) => {
-  return format(new Date(dateString), getDateFormat(locale ?? ''))
+  if (locale) {
+    return Intl.DateTimeFormat(locale.split('-')).format(new Date(dateString))
+  }
+  return new Date(dateString).toLocaleDateString()
 }
 
 export const getRelativeDate = (value: Date | string, locale?: Locale) => {
@@ -25,17 +28,32 @@ export const getRelativeDate = (value: Date | string, locale?: Locale) => {
 export const DATE_VALUE_FORMAT = 'yyyy-MM-dd'
 
 /**
- * Utility to return localized date format string. Should be used whenever dates are displayed to end users.
+ * Utility to return localized date format string.
  * @param language Language to get the corresponding date format
  * @returns Format string
  */
 export const getDateFormat = (language: string) => {
-  const defaultFormat = 'dd.MM.yyyy'
-  const languageDateFormats: { [language: string]: string } = {
-    bg: defaultFormat,
-    'en-US': 'MM/dd/yyyy',
-  }
-  return languageDateFormats[language] ?? defaultFormat
+  const dateParts = Intl.DateTimeFormat(language.split('-')).formatToParts(new Date())
+
+  // Find the separator i.e. ".", "/", etc.
+  const literal = dateParts.find((part) => part.type === 'literal')
+
+  // Extract the locale date format
+  return dateParts
+    .filter((part) => part.type !== 'literal')
+    .map((part) => {
+      switch (part.type) {
+        case 'day':
+          return 'dd'
+        case 'month':
+          return 'MM'
+        case 'year':
+          return 'yyyy'
+        default:
+          return ''
+      }
+    })
+    .join(literal?.value ?? '')
 }
 
 /**

--- a/src/components/auth/profile/PersonalInfoTab.tsx
+++ b/src/components/auth/profile/PersonalInfoTab.tsx
@@ -14,7 +14,7 @@ import UpdateBirthdateModal from './UpdateBirthdateModal'
 import UpdateEmailModal from './UpdateEmailModal'
 import UpdatePasswordModal from './UpdatePasswordModal'
 import DisableAccountModal from './DisableAccountModal'
-import { useTranslation } from 'next-i18next'
+import { i18n, useTranslation } from 'next-i18next'
 
 const PREFIX = 'PersonalInfoTab'
 
@@ -188,7 +188,7 @@ export default function PersonalInfoTab() {
               <p className={classes.bold}>{t('profile:personalInfo.birthday')}</p>
               <Typography sx={{ color: person?.birthday ? undefined : '#F22727' }}>
                 {person?.birthday
-                  ? formatDateString(person?.birthday)
+                  ? formatDateString(person?.birthday, i18n?.language)
                   : t('profile:personalInfo.noBirthday')}
               </Typography>
               <Box className={classes.editBox}>

--- a/src/components/auth/profile/UpdateBirthdateModal.tsx
+++ b/src/components/auth/profile/UpdateBirthdateModal.tsx
@@ -1,20 +1,21 @@
 import * as yup from 'yup'
 import { styled } from '@mui/material/styles'
+import { useState } from 'react'
 import { Modal, Box, Grid, IconButton } from '@mui/material'
-import GenericForm from 'components/common/form/GenericForm'
-import SubmitButton from 'components/common/form/SubmitButton'
-import { Person, UpdateUserAccount, UpdatePerson } from 'gql/person'
 import { useMutation } from 'react-query'
 import { AxiosError, AxiosResponse } from 'axios'
-import { ApiErrors } from 'service/apiErrors'
-import { updateCurrentPerson } from 'common/util/useCurrentPerson'
-
-import { AlertStore } from 'stores/AlertStore'
 import { useTranslation } from 'next-i18next'
 import CloseIcon from '@mui/icons-material/Close'
 import { format, parse, isDate } from 'date-fns'
-import FormTextField from 'components/common/form/FormTextField'
-import { useState } from 'react'
+
+import GenericForm from 'components/common/form/GenericForm'
+import SubmitButton from 'components/common/form/SubmitButton'
+import { Person, UpdateUserAccount, UpdatePerson } from 'gql/person'
+import { ApiErrors } from 'service/apiErrors'
+import { updateCurrentPerson } from 'common/util/useCurrentPerson'
+import { AlertStore } from 'stores/AlertStore'
+import FormDatePicker from 'components/common/form/FormDatePicker'
+import { DATE_VALUE_FORMAT } from 'common/util/date'
 
 const PREFIX = 'UpdateBirthdateModal'
 
@@ -42,12 +43,10 @@ const StyledModal = styled(Modal)(({ theme }) => ({
   },
 }))
 
-const formatString = 'yyyy-MM-dd'
-
 const parseDateString = (value: string, originalValue: string) => {
   const parsedDate = isDate(originalValue)
     ? originalValue
-    : parse(originalValue, formatString, new Date())
+    : parse(originalValue, DATE_VALUE_FORMAT, new Date())
 
   return parsedDate
 }
@@ -80,7 +79,7 @@ function UpdateBirthdateModal({
   const dateBefore18Years = new Date(new Date().setFullYear(new Date().getFullYear() - 18))
 
   const initialValues: Pick<UpdateUserAccount, 'birthday'> = {
-    birthday: format(new Date(person.birthday ?? dateBefore18Years), formatString) || '',
+    birthday: format(new Date(person.birthday ?? dateBefore18Years), DATE_VALUE_FORMAT) || '',
   }
 
   const mutation = useMutation<AxiosResponse<Person>, AxiosError<ApiErrors>, UpdatePerson>({
@@ -120,14 +119,7 @@ function UpdateBirthdateModal({
           validationSchema={validationSchema}>
           <Grid container spacing={3}>
             <Grid item xs={12} sm={8}>
-              <FormTextField
-                type="date"
-                name="birthday"
-                label={t('profile:birthdateModal.question')}
-                InputLabelProps={{
-                  shrink: true,
-                }}
-              />
+              <FormDatePicker name="birthday" label={t('profile:birthdateModal.question')} />
             </Grid>
             <Grid item xs={6}>
               <SubmitButton fullWidth label="auth:cta.send" loading={loading} />

--- a/src/components/common/form/FormDatePicker.tsx
+++ b/src/components/common/form/FormDatePicker.tsx
@@ -3,7 +3,7 @@ import { LocalizationProvider, DatePicker } from '@mui/x-date-pickers'
 import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns'
 import { format } from 'date-fns'
 import { useField, useFormikContext } from 'formik'
-import { i18n } from 'next-i18next'
+import { useTranslation } from 'next-i18next'
 
 import { DATE_VALUE_FORMAT, getDateFormat } from 'common/util/date'
 
@@ -16,8 +16,9 @@ import { DATE_VALUE_FORMAT, getDateFormat } from 'common/util/date'
 export default function FormDatePicker({ name, label }: { name: string; label: string }) {
   const [field] = useField(name)
   const { setFieldValue } = useFormikContext()
+  const { i18n } = useTranslation()
 
-  const dateViewFormat = getDateFormat(i18n?.language ?? '')
+  const dateViewFormat = getDateFormat(i18n.language)
   const mask = dateViewFormat.replace(new RegExp(/[^./]/g), '_')
 
   const updateValue = (newValue: Date) => {

--- a/src/components/common/form/FormDatePicker.tsx
+++ b/src/components/common/form/FormDatePicker.tsx
@@ -1,0 +1,46 @@
+import { TextField } from '@mui/material'
+import { LocalizationProvider, DatePicker } from '@mui/x-date-pickers'
+import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns'
+import { format } from 'date-fns'
+import { useField, useFormikContext } from 'formik'
+import { i18n } from 'next-i18next'
+
+import { DATE_VALUE_FORMAT, getDateFormat } from 'common/util/date'
+
+/**
+ * MUI date picker to be connected with Formik. Propagates updates to the passed Formik field name
+ * @param name - name of the Formik field to bind
+ * @param label - prompt text
+ * @returns
+ */
+export default function FormDatePicker({ name, label }: { name: string; label: string }) {
+  const [field] = useField(name)
+  const { setFieldValue } = useFormikContext()
+
+  const dateViewFormat = getDateFormat(i18n?.language ?? '')
+  const mask = dateViewFormat.replace(new RegExp(/[^./]/g), '_')
+
+  const updateValue = (newValue: Date) => {
+    let formattedValue
+    try {
+      formattedValue = format(newValue, DATE_VALUE_FORMAT)
+    } catch {
+      formattedValue = field.value
+    } finally {
+      setFieldValue(name, formattedValue, true)
+    }
+  }
+
+  return (
+    <LocalizationProvider dateAdapter={AdapterDateFns}>
+      <DatePicker
+        mask={mask}
+        inputFormat={dateViewFormat}
+        label={label}
+        value={field.value}
+        onChange={(newValue) => updateValue(newValue)}
+        renderInput={(params) => <TextField size="small" {...params} />}
+      />
+    </LocalizationProvider>
+  )
+}


### PR DESCRIPTION
## Motivation and context
Implements #1095 

The order of day/month between locales can be handled with localization, but the presentation differs by browser
e.g. in Chrome we have a `.` separator, while in Firefox we have `/` for the same locale. This has been worked around with a locale dictionary that maps the user lanugage to a specific date presentation format. Current formats include only `bg` and `en-US`, but others can be added as well.

The _update birthday_ modal now uses a MUI datepicker, as the presentation of the native `input type="date"` is not configurable. The mentioned datepicker lives in a separate convenience component in the `common/form` folder.

## Screenshots:

Before: (https://user-images.githubusercontent.com/48056945/202130942-c09d08b6-8d11-48b3-a7ed-218deaa78b30.gif)
After: 
<img width="1068" alt="Screenshot 2022-11-17 at 14 06 12" src="https://user-images.githubusercontent.com/6130708/202445214-59fe2bdd-c8c9-4b5a-a1d1-8e50db4bfd82.png">

## Testing

For testing, users should change the browser language and locale (for best chances of the browser respecting their want of a different locale).

In chrome, this happens via `Settings -> Language` and then moving your desired language to the top of the list of preferred languages.

In firefox this happens via `Preferences` under `Language`. The whole browser language needs to be changed in order for the localization to take place.

For Bulgarian, we should expect a `day.month.year.` format, whileas for US we should expect `month/day/year/` format.

