### PR TITLE
Fix missing autocompletion when entering a new password

### DIFF
--- a/src/components/auth/changePassword/ChangePasswordForm.tsx
+++ b/src/components/auth/changePassword/ChangePasswordForm.tsx
@@ -79,13 +79,19 @@ export default function ChangePasswordForm({ initialValues = defaults }: ChangeP
       validationSchema={validationSchema}>
       <Grid container spacing={3}>
         <Grid item xs={12}>
-          <PasswordField type="password" label="auth:fields.password" name="password" />
+          <PasswordField
+            type="password"
+            label="auth:fields.password"
+            name="password"
+            autoComplete="new-password"
+          />
         </Grid>
         <Grid item xs={12}>
           <PasswordField
             type="password"
             label="auth:fields.confirm-password"
             name="confirmPassword"
+            autoComplete="new-password"
           />
         </Grid>
         <Grid item xs={12}>

--- a/src/components/auth/profile/UpdatePasswordModal.tsx
+++ b/src/components/auth/profile/UpdatePasswordModal.tsx
@@ -132,10 +132,18 @@ function UpdatePasswordModal({
               <PasswordField name={'previous-password'} label={'auth:account.previous-password'} />
             </Grid>
             <Grid item xs={12} sm={8}>
-              <PasswordField name={'password'} label={'auth:account.new-password'} />
+              <PasswordField
+                name={'password'}
+                label={'auth:account.new-password'}
+                autoComplete="new-password"
+              />
             </Grid>
             <Grid item xs={12} sm={8}>
-              <PasswordField name={'confirm-password'} label={'auth:account.confirm-password'} />
+              <PasswordField
+                name={'confirm-password'}
+                label={'auth:account.confirm-password'}
+                autoComplete="new-password"
+              />
             </Grid>
             <Grid item xs={6}>
               <SubmitButton fullWidth label="auth:cta.send" loading={loading} />

--- a/src/components/auth/profile/UpdatePasswordModal.tsx
+++ b/src/components/auth/profile/UpdatePasswordModal.tsx
@@ -140,8 +140,8 @@ function UpdatePasswordModal({
             </Grid>
             <Grid item xs={12} sm={8}>
               <PasswordField
-                name={'confirm-password'}
-                label={'auth:account.confirm-password'}
+                name="confirm-password"
+                label="auth:account.confirm-password"
                 autoComplete="new-password"
               />
             </Grid>

--- a/src/components/auth/profile/UpdatePasswordModal.tsx
+++ b/src/components/auth/profile/UpdatePasswordModal.tsx
@@ -133,8 +133,8 @@ function UpdatePasswordModal({
             </Grid>
             <Grid item xs={12} sm={8}>
               <PasswordField
-                name={'password'}
-                label={'auth:account.new-password'}
+                name="password"
+                label="auth:account.new-password"
                 autoComplete="new-password"
               />
             </Grid>

--- a/src/components/auth/register/RegisterForm.tsx
+++ b/src/components/auth/register/RegisterForm.tsx
@@ -101,10 +101,14 @@ export default function RegisterForm({ initialValues = defaults }: RegisterFormP
           <FormTextField type="text" label="auth:fields.email" name="email" autoComplete="email" />
         </Grid>
         <Grid item xs={12}>
-          <PasswordField />
+          <PasswordField autoComplete="new-password" />
         </Grid>
         <Grid item xs={12}>
-          <PasswordField name={'confirm-password'} label={'auth:account.confirm-password'} />
+          <PasswordField
+            name={'confirm-password'}
+            label={'auth:account.confirm-password'}
+            autoComplete="new-password"
+          />
         </Grid>
         <Grid item xs={12}>
           <AcceptTermsField name="terms" />

--- a/src/components/auth/register/RegisterForm.tsx
+++ b/src/components/auth/register/RegisterForm.tsx
@@ -105,8 +105,8 @@ export default function RegisterForm({ initialValues = defaults }: RegisterFormP
         </Grid>
         <Grid item xs={12}>
           <PasswordField
-            name={'confirm-password'}
-            label={'auth:account.confirm-password'}
+            name="confirm-password"
+            label="auth:account.confirm-password"
             autoComplete="new-password"
           />
         </Grid>

--- a/src/components/common/form/PasswordField.tsx
+++ b/src/components/common/form/PasswordField.tsx
@@ -20,9 +20,9 @@ export default function PasswordField({
   return (
     <FormTextField
       name={name}
+      autoComplete="current-password"
       {...props}
       type={showPassword ? 'text' : 'password'}
-      autoComplete="current-password"
       label={t(label)}
       InputProps={{
         endAdornment: (

--- a/src/components/one-time-donation/RegisterDialog.tsx
+++ b/src/components/one-time-donation/RegisterDialog.tsx
@@ -85,7 +85,7 @@ export default function RegisterForm() {
           />
         </Grid>
         <Grid item xs={12}>
-          <PasswordField name="registerPassword" />
+          <PasswordField name="registerPassword" autoComplete="new-password" />
         </Grid>
         <Grid item xs={12}>
           <Button


### PR DESCRIPTION
Hello and admiration for the project!
This is a fix for a tiny issue that I noticed while signing up for the platform.

## Motivation and context

Password managers or some browsers' built-in password features can generate and save passwords for you when they detect you're entering a new password - e.g. when you're registering, changing your password, etc.

They use the attribute `autocomplete` to do that. When it's set to `current-password`, they suggest existing stored passwords for you. When it's set to `new-password` they suggest generating and saving a new password.

[Mozilla docs on the subject](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete)

In this project currently, all authentication forms use a default `PasswordField` component, which sets autocomplete to `current-password`.
This PR allows to override this default prop and overrides it to `new-password` in the appropriate places.

## Screenshots:
Here's a preview using 1Password

| Before              | After              |
| ------------------- | ------------------ |
| [Podkrepi BG signup form before.webm](https://user-images.githubusercontent.com/57956282/202743017-1de3b2a7-936b-467b-84e1-6df364b1fcf3.webm) | [Podkrepi BG signup form after.webm](https://user-images.githubusercontent.com/57956282/202743070-4d4ca0d1-8691-40e4-b43d-15cfcf30c5e3.webm) |

## Testing

I tested the changed forms manually.


