### PR TITLE
Enable Terms and Conditions and GDPR validation on Register form

### DIFF
--- a/src/components/auth/register/RegisterForm.tsx
+++ b/src/components/auth/register/RegisterForm.tsx
@@ -21,6 +21,8 @@ export type RegisterFormData = {
   lastName: string
   email: string
   password: string
+  terms: boolean
+  gdpr: boolean
 }
 
 const validationSchema: yup.SchemaOf<RegisterFormData> = yup
@@ -32,6 +34,8 @@ const validationSchema: yup.SchemaOf<RegisterFormData> = yup
     email: email.required(),
     password: password.required(),
     'confirm-password': yup.string().oneOf([yup.ref('password')], 'validation:password-match'),
+    terms: yup.bool().required().oneOf([true], 'validation:terms-of-use'),
+    gdpr: yup.bool().required().oneOf([true], 'validation:terms-of-service'),
   })
 
 const defaults: RegisterFormData = {
@@ -39,6 +43,8 @@ const defaults: RegisterFormData = {
   lastName: '',
   email: '',
   password: '',
+  terms: false,
+  gdpr: false,
 }
 export type RegisterFormProps = { initialValues?: RegisterFormData }
 

--- a/src/components/one-time-donation/RegisterDialog.tsx
+++ b/src/components/one-time-donation/RegisterDialog.tsx
@@ -24,6 +24,8 @@ export default function RegisterForm() {
     lastName: formik.values.registerLastName as string,
     email: formik.values.registerEmail as string,
     password: formik.values.registerPassword as string,
+    terms: formik.values.terms as boolean,
+    gdpr: formik.values.gdpr as boolean,
   }
   const onClick = async () => {
     try {

--- a/src/gql/donations.d.ts
+++ b/src/gql/donations.d.ts
@@ -118,6 +118,8 @@ export type OneTimeDonation = {
   registerLastName?: string
   registerEmail?: string
   registerPassword?: string
+  terms?: boolean
+  gdpr?: boolean
 }
 
 export type DonationStep = {


### PR DESCRIPTION
Enable Terms and Conditions and GDPR validation on Register form so the user cannot continue without accepting both of the fields:

![0](https://user-images.githubusercontent.com/14351733/202867397-69268b69-efd2-4ad6-a850-2b8566f4b306.png)
