### PR TITLE
[Bug] You can click Next if you are both not logged and not anonymous

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,9 @@ Read more at [End-2-End Testing](https://github.com/podkrepi-bg/frontend/blob/ma
 ## Contributors ✨
 
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
+
 [![All Contributors](https://img.shields.io/badge/all_contributors-57-orange.svg?style=flat-square)](#contributors-)
+
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 
 Please check [contributors guide](https://github.com/podkrepi-bg/frontend/blob/master/CONTRIBUTING.md) for:

--- a/src/components/one-time-donation/AnonymousForm.tsx
+++ b/src/components/one-time-donation/AnonymousForm.tsx
@@ -1,16 +1,10 @@
 import * as React from 'react'
 import { useTranslation } from 'next-i18next'
-import { useSession } from 'next-auth/react'
 import { Grid, Typography } from '@mui/material'
 import FormTextField from 'components/common/form/FormTextField'
-import CheckboxField from 'components/common/form/CheckboxField'
 
 export default function AnonymousForm() {
   const { t } = useTranslation('one-time-donation')
-  const { data: session } = useSession()
-  function isLogged() {
-    return session && session.accessToken ? true : false
-  }
   return (
     <>
       <Typography variant="subtitle2" fontWeight="bold">

--- a/src/components/one-time-donation/AnonymousForm.tsx
+++ b/src/components/one-time-donation/AnonymousForm.tsx
@@ -21,16 +21,6 @@ export default function AnonymousForm() {
         <Grid item xs={12} color="#343434" sx={{ opacity: 0.9 }}>
           <Typography>{t('anonymous-menu.info-start')}</Typography>
         </Grid>
-        {isLogged() ? (
-          <Grid item xs={12}>
-            <CheckboxField
-              name="isAnonymous"
-              label={t('anonymous-menu.want-anonymous-donation').toString()}
-            />
-          </Grid>
-        ) : (
-          ''
-        )}
         <Grid item xs={12} md={12}>
           <FormTextField name="personsEmail" type="text" label="Email" fullWidth />
         </Grid>

--- a/src/components/one-time-donation/FormikStepper.tsx
+++ b/src/components/one-time-donation/FormikStepper.tsx
@@ -1,4 +1,4 @@
-import React, { PropsWithChildren, useContext, useEffect } from 'react'
+import React, { PropsWithChildren, useCallback, useContext, useEffect } from 'react'
 import { styled } from '@mui/material/styles'
 import { useTranslation } from 'next-i18next'
 import { useRouter } from 'next/router'
@@ -44,6 +44,10 @@ export function FormikStepper({ children, ...props }: GenericFormProps<OneTimeDo
   const currentChild = childrenArray[step]
   const { data: session } = useSession()
 
+  function isLoginStep() {
+    return step === childrenArray.length - 3
+  }
+
   function isLastStep() {
     return step === childrenArray.length - 2
   }
@@ -56,7 +60,18 @@ export function FormikStepper({ children, ...props }: GenericFormProps<OneTimeDo
     return true
   }
   const { t } = useTranslation('one-time-donation')
-
+  const hideNextButton = useCallback(
+    (isAnonymous: boolean) => {
+      console.log('anon', isAnonymous)
+      console.log('logged', isLogged())
+      console.log('loginStep', isLoginStep())
+      if (isLoginStep() && !isLogged() && !isAnonymous) {
+        return true
+      }
+      return false
+    },
+    [step],
+  )
   return (
     <Formik
       {...props}
@@ -72,7 +87,7 @@ export function FormikStepper({ children, ...props }: GenericFormProps<OneTimeDo
       }}
       validateOnMount
       validateOnBlur>
-      {({ isSubmitting, handleSubmit, isValid }) => (
+      {({ isSubmitting, handleSubmit, isValid, values: { isAnonymous } }) => (
         <Form
           onSubmit={handleSubmit}
           style={{
@@ -112,7 +127,7 @@ export function FormikStepper({ children, ...props }: GenericFormProps<OneTimeDo
               </Grid>
               <Grid item xs={12} md={6}>
                 <LoadingButton
-                  disabled={!isValid}
+                  disabled={!isValid || isSubmitting || hideNextButton(isAnonymous)}
                   fullWidth
                   type="submit"
                   variant="contained"

--- a/src/components/one-time-donation/FormikStepper.tsx
+++ b/src/components/one-time-donation/FormikStepper.tsx
@@ -62,9 +62,6 @@ export function FormikStepper({ children, ...props }: GenericFormProps<OneTimeDo
   const { t } = useTranslation('one-time-donation')
   const hideNextButton = useCallback(
     (isAnonymous: boolean) => {
-      console.log('anon', isAnonymous)
-      console.log('logged', isLogged())
-      console.log('loginStep', isLoginStep())
       if (isLoginStep() && !isLogged() && !isAnonymous) {
         return true
       }

--- a/src/components/one-time-donation/LoginForm.tsx
+++ b/src/components/one-time-donation/LoginForm.tsx
@@ -35,7 +35,7 @@ function LoginForm() {
       }
       if (resp?.ok) {
         setLoading(false)
-        formik.values.isAnonymous = false
+        formik.setFieldValue('isAnonymous', false)
         setStep(2)
         AlertStore.show(t('auth:alerts.welcome'), 'success')
       }

--- a/src/components/one-time-donation/RegisterDialog.tsx
+++ b/src/components/one-time-donation/RegisterDialog.tsx
@@ -46,7 +46,7 @@ export default function RegisterForm() {
       if (resp?.ok) {
         setLoading(false)
         AlertStore.show(t('auth:alerts.welcome'), 'success')
-        formik.values.isAnonymous = false
+        formik.setFieldValue('isAnonymous', false)
         setStep(2)
       }
     } catch (error) {

--- a/src/components/one-time-donation/Steps.tsx
+++ b/src/components/one-time-donation/Steps.tsx
@@ -25,7 +25,7 @@ import { useCurrentPerson } from 'common/util/useCurrentPerson'
 
 const initialValues: OneTimeDonation = {
   message: '',
-  isAnonymous: true,
+  isAnonymous: false,
   amount: '',
   amountWithFees: 0,
   cardIncludeFees: false,
@@ -64,7 +64,6 @@ export default function DonationStepper({ onStepChange }: DonationStepperProps) 
     return session && session.accessToken ? true : false
   }
 
-  initialValues.isAnonymous = !isLogged()
   const userEmail = session?.user?.email
 
   const donate = React.useCallback(
@@ -76,7 +75,7 @@ export default function DonationStepper({ onStepChange }: DonationStepperProps) 
         firstName: values?.personsFirstName ? values.personsFirstName : 'Anonymous',
         lastName: values?.personsLastName ? values.personsLastName : 'Donor',
         personEmail: values?.personsEmail ? values.personsEmail : userEmail,
-        isAnonymous: values?.isAnonymous ?? !isLogged(),
+        isAnonymous: values?.isAnonymous ? values.isAnonymous : true,
         phone: values?.personsPhone ? values.personsPhone : null,
         successUrl: `${baseUrl}${routes.campaigns.oneTimeDonation(campaign.slug)}?success=true`,
         cancelUrl: `${baseUrl}${routes.campaigns.oneTimeDonation(campaign.slug)}?success=false`,

--- a/src/components/one-time-donation/Steps.tsx
+++ b/src/components/one-time-donation/Steps.tsx
@@ -75,7 +75,7 @@ export default function DonationStepper({ onStepChange }: DonationStepperProps) 
         firstName: values?.personsFirstName ? values.personsFirstName : 'Anonymous',
         lastName: values?.personsLastName ? values.personsLastName : 'Donor',
         personEmail: values?.personsEmail ? values.personsEmail : userEmail,
-        isAnonymous: values?.isAnonymous ? values.isAnonymous : true,
+        isAnonymous: values?.isAnonymous !== undefined ? values.isAnonymous : true,
         phone: values?.personsPhone ? values.personsPhone : null,
         successUrl: `${baseUrl}${routes.campaigns.oneTimeDonation(campaign.slug)}?success=true`,
         cancelUrl: `${baseUrl}${routes.campaigns.oneTimeDonation(campaign.slug)}?success=false`,

--- a/src/components/one-time-donation/steps/SecondStep.tsx
+++ b/src/components/one-time-donation/steps/SecondStep.tsx
@@ -1,6 +1,8 @@
 import { TabContext, TabList } from '@mui/lab'
 import TabPanel from '@mui/lab/TabPanel'
 import { Box, Tab, Typography, useMediaQuery } from '@mui/material'
+import { useFormikContext } from 'formik'
+import { OneTimeDonation } from 'gql/donations'
 import { useSession } from 'next-auth/react'
 import { useTranslation } from 'next-i18next'
 import React, { useState } from 'react'
@@ -15,8 +17,13 @@ export default function SecondStep() {
   const { data: session } = useSession()
 
   const [value, setValue] = useState('1')
-
+  const formik = useFormikContext<OneTimeDonation>()
   const handleChange = (event: React.SyntheticEvent, newValue: string) => {
+    if (Number(newValue) === 3) {
+      formik.setFieldValue('isAnonymous', true)
+    } else {
+      formik.setFieldValue('isAnonymous', false)
+    }
     setValue(newValue)
   }
 

--- a/src/components/one-time-donation/steps/SecondStep.tsx
+++ b/src/components/one-time-donation/steps/SecondStep.tsx
@@ -12,9 +12,9 @@ import LoginForm from '../LoginForm'
 import RegisterForm from '../RegisterDialog'
 
 enum Tabs {
-  Login = 1,
-  Register = 2,
-  Anonymous = 3,
+  Login = '1',
+  Register = '2',
+  Anonymous = '3',
 }
 export default function SecondStep() {
   const { t } = useTranslation('one-time-donation')

--- a/src/components/one-time-donation/steps/SecondStep.tsx
+++ b/src/components/one-time-donation/steps/SecondStep.tsx
@@ -11,6 +11,11 @@ import LoggedUserDialog from '../LoggedUserDialog'
 import LoginForm from '../LoginForm'
 import RegisterForm from '../RegisterDialog'
 
+enum Tabs {
+  Login = 1,
+  Register = 2,
+  Anonymous = 3,
+}
 export default function SecondStep() {
   const { t } = useTranslation('one-time-donation')
   const mobile = useMediaQuery('(max-width:575px)')
@@ -18,13 +23,13 @@ export default function SecondStep() {
 
   const [value, setValue] = useState('1')
   const formik = useFormikContext<OneTimeDonation>()
-  const handleChange = (event: React.SyntheticEvent, newValue: string) => {
-    if (Number(newValue) === 3) {
+  const handleChange = (event: React.SyntheticEvent, newTab: string) => {
+    if (newTab === Tabs.Anonymous) {
       formik.setFieldValue('isAnonymous', true)
     } else {
       formik.setFieldValue('isAnonymous', false)
     }
-    setValue(newValue)
+    setValue(newTab)
   }
 
   return (


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and context

The anonymous donation felt like it is not working properly. It was unpredictable.
**Now in order enable the button click next on the login step you have to either**:
* Be logged in in which case if you click next you will donate with your name
* Click the anonymous tab in which case it doesn't matter if you are logged in or not you will in both cases donate as *Anonymous*

## Screenshots:

| Before              | After              |
| ------------------- | ------------------ |
| ![donation-anon-before](https://user-images.githubusercontent.com/61479393/202899426-af130c7e-a7b3-479e-b3e1-6ff9c7bab821.gif) | ![donation-anon-after](https://user-images.githubusercontent.com/61479393/202899430-06cd7156-fd4f-4cc6-af5d-37f98aace741.gif) |

## Testing

Went through the donation flow in all 3 cases:
- Logged in normal
- Logged in anonymous
- Just anonymous
