### PR TITLE
Fix the shape of the team avatars on About page

### DIFF
--- a/src/components/about/AboutPage.styled.tsx
+++ b/src/components/about/AboutPage.styled.tsx
@@ -15,7 +15,6 @@ export const AboutHeading = styled(Typography)(() => ({
 export const Avatar = styled(Image)(() => ({
   borderRadius: '50%',
   textAlign: 'center',
-  width: '150px',
   objectFit: 'cover',
 }))
 


### PR DESCRIPTION
## Screenshots:

| Before              | After              |
| ------------------- | ------------------ |
| ![0](https://user-images.githubusercontent.com/14351733/203095468-4c81fa2a-9654-4e26-b385-83a4263e147b.png) | ![1](https://user-images.githubusercontent.com/14351733/203095516-3dbc845a-aa2e-42ab-bd0b-6b8bc62e8073.png) |
