### PR TITLE
Improve the UX on the FAQ Page when searching

### DIFF
--- a/src/components/faq/FaqPage.tsx
+++ b/src/components/faq/FaqPage.tsx
@@ -1,7 +1,7 @@
 import { TabContext, TabPanel } from '@mui/lab'
 import { Stack } from '@mui/material'
 import { useTranslation } from 'next-i18next'
-import React, { useState } from 'react'
+import React, { useEffect, useState } from 'react'
 
 import Layout from 'components/layout/Layout'
 
@@ -32,22 +32,31 @@ const FAQ_PAGE_QUESTIONS: Record<string, ContentType[]> = {
 
 export default function FaqPage({ section }: { section: FaqCategory }) {
   const { t } = useTranslation()
-  const [value, setValue] = useState(section)
+  const [selectedFaqCategory, setSelectedFaqCategory] = useState(section)
   const [searchKeyword, setSearchKeyword] = useState('')
 
   const faqQuestionsData = filterFaqQuestions(FAQ_PAGE_QUESTIONS, searchKeyword)
   const faqCategories = Object.keys(faqQuestionsData) as FaqCategory[]
 
+  useEffect(() => {
+    if (faqCategories.length > 0 && !faqCategories.includes(selectedFaqCategory)) {
+      setSelectedFaqCategory(faqCategories[0])
+    }
+  }, [searchKeyword])
+
   return (
     <Layout title={t('nav.campaigns.faq')}>
       {/* <FaqIntro /> */}
       <FaqSearch onChange={setSearchKeyword} />
-      <TabContext value={value}>
+      <TabContext value={selectedFaqCategory}>
         <Stack direction={{ xs: 'column', md: 'row' }}>
-          <VerticalTabs faqCategories={faqCategories} setSelectedFaqCategory={setValue} />
+          <VerticalTabs
+            faqCategories={faqCategories}
+            setSelectedFaqCategory={setSelectedFaqCategory}
+          />
           {faqCategories.map((categoryKey) => {
             return (
-              <TabPanel key={categoryKey} value={categoryKey} sx={{ p: 0 }}>
+              <TabPanel key={categoryKey} value={categoryKey} sx={{ p: 0, flex: 4 }}>
                 {faqQuestionsData[categoryKey]
                   .filter(filterFaqQuestionByVisibility)
                   .filter((question) => filterFaqQuestionBySearchKeyword(question, searchKeyword))

--- a/src/components/faq/VerticalTabs.tsx
+++ b/src/components/faq/VerticalTabs.tsx
@@ -28,12 +28,12 @@ const VerticalTabs = ({ faqCategories, setSelectedFaqCategory }: Props) => {
   }
 
   return (
-    <Box sx={{ bgcolor: 'background.paper', display: 'flex', justifyContent: 'center' }}>
+    <Box sx={{ bgcolor: 'background.paper', display: 'flex', justifyContent: 'center', flex: 1 }}>
       <TabList
         orientation="vertical"
         variant="scrollable"
         onChange={handleChange}
-        sx={{ borderRight: 1, borderColor: 'divider', mb: 4 }}>
+        sx={{ borderRight: 1, borderColor: 'divider', mb: 4, width: '100%' }}>
         {faqCategories.map((category) => {
           return <Tab key={category} value={category} label={t(`categories.${category}`)} />
         })}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and context
Improve the UX on the FAQ Page when searching

- auto-select the first category in the left Tabs pane if we don't have matching results in the current category when searching (see attached videos)
- fix the size/proportion of the tab pane with the categories, so it won't flicker when searching and reducing the amount of visible categories (see attached videos)
- minor refactoring of the names in the `FaqPage` component, so it will be more clear that `value` state stands for `selectedCategory`

References: #1017

## Videos:

Before: 
https://user-images.githubusercontent.com/1233496/203375670-91e59b96-814d-412b-85e6-f5255f7a4e11.mp4

After: 
https://user-images.githubusercontent.com/1233496/203375769-d7850fb6-f9e4-4aec-b96c-44f2b081d416.mp4


## Testing

<!--- Specify test requirements (environment, dependencies, design reviews) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include links to the related pages -->
<!--- Include details of your testing environment -->
<!--- Impact of your change to other areas of the code -->
I tested the new changes manually during the development process by typing different keywords into the new "Search" field on the FAQ page which results in reducing the amount of the categories with available matching results (like "процент", "общество", etc.).

References pages:
- http://localhost:3040/faq
- http://localhost:3040/faq/common-questions
