### PR TITLE
Switch static blog builds to dynamic content

### DIFF
--- a/src/pages/blog/[slug].tsx
+++ b/src/pages/blog/[slug].tsx
@@ -1,10 +1,10 @@
 import * as Sentry from '@sentry/nextjs'
-import { GetStaticPaths, GetStaticProps } from 'next'
+import { GetServerSideProps } from 'next'
 import BlogPostPage from 'components/blog/BlogPostPage'
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
 import { createGhostClient } from 'common/util/ghost-client'
 
-export const getStaticProps: GetStaticProps = async ({ params, locale }) => {
+export const getServerSideProps: GetServerSideProps = async ({ params, locale }) => {
   if (typeof params?.slug !== 'string') return { notFound: true }
 
   try {
@@ -25,22 +25,6 @@ export const getStaticProps: GetStaticProps = async ({ params, locale }) => {
     Sentry.captureException(error)
     return { notFound: true }
   }
-}
-
-export const getStaticPaths: GetStaticPaths = async () => {
-  const client = createGhostClient()
-  const posts = await client.posts.browse({
-    limit: 'all',
-    fields: ['slug'],
-  })
-
-  // Get the paths we want to create based on posts
-  const paths = posts.map((post) => ({
-    params: { slug: post.slug },
-  }))
-
-  // { fallback: false } means posts not found should 404.
-  return { paths, fallback: false }
 }
 
 export default BlogPostPage

--- a/src/pages/blog/index.tsx
+++ b/src/pages/blog/index.tsx
@@ -1,11 +1,11 @@
-import { GetStaticProps } from 'next'
+import { GetServerSideProps } from 'next'
 import * as Sentry from '@sentry/nextjs'
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
 
 import BlogIndexPage from 'components/blog/BlogIndexPage'
 import { createGhostClient } from 'common/util/ghost-client'
 
-export const getStaticProps: GetStaticProps = async ({ locale }) => {
+export const getServerSideProps: GetServerSideProps = async ({ locale }) => {
   try {
     const client = createGhostClient()
     const posts = await client.posts.browse()

--- a/src/pages/page/[slug].tsx
+++ b/src/pages/page/[slug].tsx
@@ -1,11 +1,11 @@
 import * as Sentry from '@sentry/nextjs'
-import { GetStaticPaths, GetStaticProps } from 'next'
+import { GetServerSideProps } from 'next'
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
 
 import BlogPage from 'components/blog/BlogPage'
 import { createGhostClient } from 'common/util/ghost-client'
 
-export const getStaticProps: GetStaticProps = async ({ params, locale }) => {
+export const getServerSideProps: GetServerSideProps = async ({ params, locale }) => {
   if (typeof params?.slug !== 'string') return { notFound: true }
 
   try {
@@ -25,22 +25,6 @@ export const getStaticProps: GetStaticProps = async ({ params, locale }) => {
     Sentry.captureException(error)
     return { notFound: true }
   }
-}
-
-export const getStaticPaths: GetStaticPaths = async () => {
-  const client = createGhostClient()
-  const pages = await client.pages.browse({
-    limit: 'all',
-    fields: ['slug'],
-  })
-
-  // Get the paths we want to create based on pages
-  const paths = pages.map((page) => ({
-    params: { slug: page.slug },
-  }))
-
-  // { fallback: false } means pages not found should 404.
-  return { paths, fallback: false }
 }
 
 export default BlogPage


### PR DESCRIPTION
Closes #1167

## Motivation and context

Building the docker container with all needed variables in order to properly display the page. This process makes some of the missing env files undefined in the production build.

Replaced `getStaticProps` and `getStaticPaths` with `getServerSideProps`

This adds additional enhancement - the content is always fresh, and not cached between releases.


