### PR TITLE
1166 - Fix flashing 404 page between page changes

### DIFF
--- a/src/common/hooks/campaigns.ts
+++ b/src/common/hooks/campaigns.ts
@@ -21,8 +21,8 @@ const shuffleQueryFn: QueryFunction<CampaignResponse[]> = async ({ queryKey }) =
 
 export function useCampaignList() {
   return useQuery<CampaignResponse[]>([endpoints.campaign.listCampaigns.url], shuffleQueryFn, {
-    // Add 3 hours of cache time
-    staleTime: 1000 * 60 * 60 * 3,
+    // Add 15 minutes of cache time
+    staleTime: 1000 * 60 * 15,
   })
 }
 

--- a/src/common/hooks/campaigns.ts
+++ b/src/common/hooks/campaigns.ts
@@ -20,7 +20,10 @@ const shuffleQueryFn: QueryFunction<CampaignResponse[]> = async ({ queryKey }) =
 }
 
 export function useCampaignList() {
-  return useQuery<CampaignResponse[]>([endpoints.campaign.listCampaigns.url], shuffleQueryFn)
+  return useQuery<CampaignResponse[]>([endpoints.campaign.listCampaigns.url], shuffleQueryFn, {
+    // Add 3 hours of cache time
+    staleTime: 1000 * 60 * 60 * 3,
+  })
 }
 
 export function useCampaignAdminList() {

--- a/src/components/campaigns/IrregularityPage.tsx
+++ b/src/components/campaigns/IrregularityPage.tsx
@@ -4,25 +4,23 @@ import { Container } from '@mui/material'
 
 import { useViewCampaign } from 'common/hooks/campaigns'
 import { useCurrentPerson } from 'common/util/useCurrentPerson'
-
-import NotFoundPage from 'pages/404'
 import Layout from 'components/layout/Layout'
 import IrregularityForm from 'components/irregularity/IrregularityForm'
+import CenteredSpinner from 'components/common/CenteredSpinner'
 
 type Props = { slug: string }
 
 export default function IrregularityPage({ slug }: Props) {
-  const { data } = useViewCampaign(slug)
+  const { data, isLoading } = useViewCampaign(slug)
   const { data: userData } = useCurrentPerson()
-  if (!data || !data.campaign) return <NotFoundPage />
-  const { campaign } = data
+  if (isLoading || !data) return <CenteredSpinner size="2rem" />
 
   const person = userData?.user || undefined
 
   return (
     <Layout maxWidth={false}>
       <Container maxWidth="md">
-        <IrregularityForm campaign={campaign} person={person} />
+        <IrregularityForm campaign={data.campaign} person={person} />
       </Container>
     </Layout>
   )

--- a/src/components/campaigns/ViewCampaignPage.tsx
+++ b/src/components/campaigns/ViewCampaignPage.tsx
@@ -5,19 +5,19 @@ import { Grid } from '@mui/material'
 import { useViewCampaign } from 'common/hooks/campaigns'
 import { campaignListPictureUrl } from 'common/util/campaignImageUrls'
 import theme from 'common/theme'
-
-import NotFoundPage from 'pages/404'
+import useMobile from 'common/hooks/useMobile'
 import Layout from 'components/layout/Layout'
+import CenteredSpinner from 'components/common/CenteredSpinner'
+
 import InlineDonation from './InlineDonation'
 import CampaignDetails from './CampaignDetails'
-import useMobile from 'common/hooks/useMobile'
 
 type Props = { slug: string }
 
 export default function ViewCampaignPage({ slug }: Props) {
-  const { data } = useViewCampaign(slug)
+  const { data, isLoading } = useViewCampaign(slug)
   const { mobile, small } = useMobile()
-  if (!data || !data.campaign) return <NotFoundPage />
+  if (isLoading || !data) return <CenteredSpinner size="2rem" />
   const { campaign } = data
   const ogImageUrl = campaignListPictureUrl(campaign)
 

--- a/src/components/common/CenteredSpinner.tsx
+++ b/src/components/common/CenteredSpinner.tsx
@@ -1,0 +1,12 @@
+import { CircularProgress } from '@mui/material'
+import { styled } from '@mui/styles'
+
+//center spinner absolutely
+const CenteredSpinner = styled(CircularProgress)(() => ({
+  position: 'absolute',
+  top: '50%',
+  left: '50%',
+  transform: 'translate(-50%, -50%)',
+}))
+
+export default CenteredSpinner

--- a/src/components/one-time-donation/OneTimeDonationPage.tsx
+++ b/src/components/one-time-donation/OneTimeDonationPage.tsx
@@ -1,14 +1,16 @@
 import Image from 'next/image'
 import { styled } from '@mui/material/styles'
 import { Box, Grid, Typography, useMediaQuery } from '@mui/material'
-import Layout from 'components/layout/Layout'
+
 import { useViewCampaign } from 'common/hooks/campaigns'
 import theme from 'common/theme'
 import {
   backgroundCampaignPictureUrl,
   beneficiaryCampaignPictureUrl,
 } from 'common/util/campaignImageUrls'
-import NotFoundPage from 'pages/404'
+import Layout from 'components/layout/Layout'
+import CenteredSpinner from 'components/common/CenteredSpinner'
+
 import DonationStepper from './Steps'
 
 const PREFIX = 'OneTimeDonationPage'
@@ -68,9 +70,9 @@ const scrollWindow = () => {
 }
 
 export default function OneTimeDonation({ slug }: { slug: string }) {
-  const { data } = useViewCampaign(slug)
+  const { data, isLoading } = useViewCampaign(slug)
   const matches = useMediaQuery('sm')
-  if (!data || !data.campaign) return <NotFoundPage />
+  if (isLoading || !data) return <CenteredSpinner size="2rem" />
   const { campaign } = data
 
   const bannerSource = backgroundCampaignPictureUrl(campaign)

--- a/src/components/one-time-donation/Steps.tsx
+++ b/src/components/one-time-donation/Steps.tsx
@@ -1,15 +1,21 @@
 import * as React from 'react'
 import { useTranslation } from 'next-i18next'
 import { useRouter } from 'next/router'
+import { useSession } from 'next-auth/react'
 import { CircularProgress } from '@mui/material'
 import { AxiosError } from 'axios'
 import { FormikHelpers } from 'formik'
+
+import { CardRegion } from 'gql/donations.enums'
+import { OneTimeDonation, DonationStep as StepType } from 'gql/donations'
+import { createDonationWish } from 'service/donationWish'
+import { ApiErrors, isAxiosError, matchValidator } from 'service/apiErrors'
+import { useCurrentPerson } from 'common/util/useCurrentPerson'
+import CenteredSpinner from 'components/common/CenteredSpinner'
 import { useDonationSession } from 'common/hooks/donation'
 import { useViewCampaign } from 'common/hooks/campaigns'
 import { baseUrl, routes } from 'common/routes'
-import { ApiErrors, isAxiosError, matchValidator } from 'service/apiErrors'
-import { OneTimeDonation, DonationStep as StepType } from 'gql/donations'
-import NotFoundPage from 'pages/404'
+
 import FirstStep from './steps/FirstStep'
 import SecondStep from './steps/SecondStep'
 import ThirdStep from './steps/ThirdStep'
@@ -18,10 +24,6 @@ import Fail from './steps/Fail'
 import { FormikStep, FormikStepper } from './FormikStepper'
 import { validateFirst, validateSecond, validateThird } from './helpers/validation-schema'
 import { StepsContext } from './helpers/stepperContext'
-import { useSession } from 'next-auth/react'
-import { CardRegion } from 'gql/donations.enums'
-import { createDonationWish } from 'service/donationWish'
-import { useCurrentPerson } from 'common/util/useCurrentPerson'
 
 const initialValues: OneTimeDonation = {
   message: '',
@@ -57,7 +59,7 @@ export default function DonationStepper({ onStepChange }: DonationStepperProps) 
   const mutation = useDonationSession()
   const { data: session } = useSession()
   const { data: { user: person } = { user: null } } = useCurrentPerson()
-  if (!data || !data.campaign) return <NotFoundPage />
+  if (isLoading || !data) return <CenteredSpinner size="2rem" />
   const { campaign } = data
 
   const userEmail = session?.user?.email

--- a/src/pages/campaigns/[slug]/index.tsx
+++ b/src/pages/campaigns/[slug]/index.tsx
@@ -5,13 +5,15 @@ import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
 import ViewCampaignPage from 'components/campaigns/ViewCampaignPage'
 import { endpoints } from 'service/apiEndpoints'
 import { CampaignResponse } from 'gql/campaigns'
+import { queryFnFactory } from 'service/restRequests'
 
 export const getServerSideProps: GetServerSideProps = async ({ query, locale }) => {
   const { slug } = query
   const client = new QueryClient()
-  await client.prefetchQuery<CampaignResponse>([
-    endpoints.campaign.viewCampaign(slug as string).url,
-  ])
+  await client.prefetchQuery<CampaignResponse>(
+    [endpoints.campaign.viewCampaign(slug as string).url],
+    queryFnFactory<CampaignResponse>(),
+  )
   return {
     props: {
       slug,

--- a/src/pages/campaigns/[slug]/index.tsx
+++ b/src/pages/campaigns/[slug]/index.tsx
@@ -2,7 +2,6 @@ import { dehydrate, QueryClient } from '@tanstack/react-query'
 import { GetServerSideProps } from 'next'
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
 
-import { queryFnFactory } from 'service/restRequests'
 import ViewCampaignPage from 'components/campaigns/ViewCampaignPage'
 import { endpoints } from 'service/apiEndpoints'
 import { CampaignResponse } from 'gql/campaigns'
@@ -10,10 +9,9 @@ import { CampaignResponse } from 'gql/campaigns'
 export const getServerSideProps: GetServerSideProps = async ({ query, locale }) => {
   const { slug } = query
   const client = new QueryClient()
-  await client.prefetchQuery<CampaignResponse>(
-    [endpoints.campaign.viewCampaign(slug as string).url],
-    queryFnFactory<CampaignResponse>(),
-  )
+  await client.prefetchQuery<CampaignResponse>([
+    endpoints.campaign.viewCampaign(slug as string).url,
+  ])
   return {
     props: {
       slug,

--- a/src/pages/campaigns/[slug]/irregularity.tsx
+++ b/src/pages/campaigns/[slug]/irregularity.tsx
@@ -2,18 +2,13 @@ import { dehydrate, QueryClient } from '@tanstack/react-query'
 import { GetServerSideProps } from 'next'
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
 
-import { queryFnFactory } from 'service/restRequests'
 import IrregularityPage from 'components/campaigns/IrregularityPage'
 import { endpoints } from 'service/apiEndpoints'
-import { CampaignResponse } from 'gql/campaigns'
 
 export const getServerSideProps: GetServerSideProps = async ({ query, locale }) => {
   const { slug } = query
   const client = new QueryClient()
-  await client.prefetchQuery(
-    [endpoints.campaign.viewCampaign(slug as string)],
-    queryFnFactory<CampaignResponse>(),
-  )
+  await client.prefetchQuery([endpoints.campaign.viewCampaign(slug as string)])
   return {
     props: {
       slug,

--- a/src/pages/campaigns/[slug]/irregularity.tsx
+++ b/src/pages/campaigns/[slug]/irregularity.tsx
@@ -4,11 +4,16 @@ import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
 
 import IrregularityPage from 'components/campaigns/IrregularityPage'
 import { endpoints } from 'service/apiEndpoints'
+import { queryFnFactory } from 'service/restRequests'
+import { CampaignResponse } from 'gql/campaigns'
 
 export const getServerSideProps: GetServerSideProps = async ({ query, locale }) => {
   const { slug } = query
   const client = new QueryClient()
-  await client.prefetchQuery([endpoints.campaign.viewCampaign(slug as string)])
+  await client.prefetchQuery<CampaignResponse>(
+    [endpoints.campaign.viewCampaign(slug as string)],
+    queryFnFactory<CampaignResponse>(),
+  )
   return {
     props: {
       slug,

--- a/src/pages/campaigns/donation/[slug].tsx
+++ b/src/pages/campaigns/donation/[slug].tsx
@@ -1,20 +1,14 @@
-import { dehydrate } from '@tanstack/react-query'
-import { QueryClient } from '@tanstack/react-query'
 import { GetServerSideProps, GetServerSidePropsContext } from 'next'
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
+import { QueryClient, dehydrate } from '@tanstack/react-query'
 
-import { queryFnFactory } from 'service/restRequests'
 import OneTimeDonation from 'components/one-time-donation/OneTimeDonationPage'
 import { endpoints } from 'service/apiEndpoints'
-import { CampaignResponse } from 'gql/campaigns'
 
 export const getServerSideProps: GetServerSideProps = async (ctx: GetServerSidePropsContext) => {
   const { slug } = ctx.query
   const client = new QueryClient()
-  await client.prefetchQuery(
-    [endpoints.campaign.viewCampaign(slug as string)],
-    queryFnFactory<CampaignResponse>(),
-  )
+  await client.prefetchQuery([endpoints.campaign.viewCampaign(slug as string)])
   return {
     props: {
       slug,

--- a/src/pages/campaigns/donation/[slug].tsx
+++ b/src/pages/campaigns/donation/[slug].tsx
@@ -4,11 +4,16 @@ import { QueryClient, dehydrate } from '@tanstack/react-query'
 
 import OneTimeDonation from 'components/one-time-donation/OneTimeDonationPage'
 import { endpoints } from 'service/apiEndpoints'
+import { queryFnFactory } from 'service/restRequests'
+import { CampaignResponse } from 'gql/campaigns'
 
 export const getServerSideProps: GetServerSideProps = async (ctx: GetServerSidePropsContext) => {
   const { slug } = ctx.query
   const client = new QueryClient()
-  await client.prefetchQuery([endpoints.campaign.viewCampaign(slug as string)])
+  await client.prefetchQuery<CampaignResponse>(
+    [endpoints.campaign.viewCampaign(slug as string)],
+    queryFnFactory<CampaignResponse>(),
+  )
   return {
     props: {
       slug,

--- a/src/pages/campaigns/index.tsx
+++ b/src/pages/campaigns/index.tsx
@@ -5,11 +5,15 @@ import { dehydrate, QueryClient } from '@tanstack/react-query'
 import CampaignsPage from 'components/campaigns/CampaignsPage'
 import { prefetchCampaignTypesList } from 'service/campaignTypes'
 import { endpoints } from 'service/apiEndpoints'
+import { queryFnFactory } from 'service/restRequests'
 import { CampaignResponse } from 'gql/campaigns'
 
 export const getServerSideProps: GetServerSideProps = async (params) => {
   const client = new QueryClient()
-  await client.prefetchQuery<CampaignResponse[]>([endpoints.campaign.listCampaigns.url])
+  await client.prefetchQuery<CampaignResponse[]>(
+    [endpoints.campaign.listCampaigns.url],
+    queryFnFactory<CampaignResponse[]>(),
+  )
   await prefetchCampaignTypesList(client)
   return {
     props: {

--- a/src/pages/campaigns/index.tsx
+++ b/src/pages/campaigns/index.tsx
@@ -1,18 +1,15 @@
 import { GetServerSideProps } from 'next'
-import { dehydrate, QueryClient } from '@tanstack/react-query'
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
+import { dehydrate, QueryClient } from '@tanstack/react-query'
+
 import CampaignsPage from 'components/campaigns/CampaignsPage'
 import { prefetchCampaignTypesList } from 'service/campaignTypes'
 import { endpoints } from 'service/apiEndpoints'
-import { queryFnFactory } from 'service/restRequests'
 import { CampaignResponse } from 'gql/campaigns'
 
 export const getServerSideProps: GetServerSideProps = async (params) => {
   const client = new QueryClient()
-  await client.prefetchQuery<CampaignResponse[]>(
-    [endpoints.campaign.listCampaigns.url],
-    queryFnFactory<CampaignResponse[]>(),
-  )
+  await client.prefetchQuery<CampaignResponse[]>([endpoints.campaign.listCampaigns.url])
   await prefetchCampaignTypesList(client)
   return {
     props: {

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,22 +1,19 @@
 import { Session, unstable_getServerSession } from 'next-auth'
 import { GetServerSideProps } from 'next'
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
-
-import IndexPage from 'components/index/IndexPage'
-import { authOptions } from './api/auth/[...nextauth]'
 import { QueryClient } from '@tanstack/react-query'
-import { queryFnFactory } from 'service/restRequests'
+
 import { CampaignResponse } from 'gql/campaigns'
 import { endpoints } from 'service/apiEndpoints'
+import IndexPage from 'components/index/IndexPage'
+
+import { authOptions } from './api/auth/[...nextauth]'
 
 export const getServerSideProps: GetServerSideProps<{
   session: Session | null
 }> = async (ctx) => {
   const client = new QueryClient()
-  await client.prefetchQuery<CampaignResponse[]>(
-    [endpoints.campaign.listCampaigns.url],
-    queryFnFactory<CampaignResponse[]>(),
-  )
+  await client.prefetchQuery<CampaignResponse[]>([endpoints.campaign.listCampaigns.url])
 
   //For getting session on server side the docs recommend using unstable_getServerSession as per
   //here: https://next-auth.js.org/getting-started/introduction#server-side

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -8,12 +8,16 @@ import { endpoints } from 'service/apiEndpoints'
 import IndexPage from 'components/index/IndexPage'
 
 import { authOptions } from './api/auth/[...nextauth]'
+import { queryFnFactory } from 'service/restRequests'
 
 export const getServerSideProps: GetServerSideProps<{
   session: Session | null
 }> = async (ctx) => {
   const client = new QueryClient()
-  await client.prefetchQuery<CampaignResponse[]>([endpoints.campaign.listCampaigns.url])
+  await client.prefetchQuery<CampaignResponse[]>(
+    [endpoints.campaign.listCampaigns.url],
+    queryFnFactory<CampaignResponse[]>(),
+  )
 
   //For getting session on server side the docs recommend using unstable_getServerSession as per
   //here: https://next-auth.js.org/getting-started/introduction#server-side

--- a/src/service/campaignTypes.ts
+++ b/src/service/campaignTypes.ts
@@ -1,9 +1,10 @@
 import { useSession } from 'next-auth/react'
+import { QueryClient, useQuery } from '@tanstack/react-query'
+
+import { CampaignTypeFormData, CampaignTypesResponse } from 'gql/campaign-types'
 
 import { endpoints } from './apiEndpoints'
-import { authConfig, authQueryFnFactory, queryFnFactory } from './restRequests'
-import { CampaignTypeFormData, CampaignTypesResponse } from 'gql/campaign-types'
-import { QueryClient, useQuery } from '@tanstack/react-query'
+import { authConfig, authQueryFnFactory } from './restRequests'
 import { apiClient } from './apiClient'
 
 export const useCampaignTypesList = () => {
@@ -67,8 +68,7 @@ export async function prefetchCampaignTypeById(client: QueryClient, slug: string
 }
 
 export async function prefetchCampaignTypesList(client: QueryClient) {
-  await client.prefetchQuery<CampaignTypesResponse[]>(
-    [endpoints.campaignTypes.listCampaignTypes.url],
-    queryFnFactory<CampaignTypesResponse[]>(),
-  )
+  await client.prefetchQuery<CampaignTypesResponse[]>([
+    endpoints.campaignTypes.listCampaignTypes.url,
+  ])
 }

--- a/src/service/campaignTypes.ts
+++ b/src/service/campaignTypes.ts
@@ -4,7 +4,7 @@ import { QueryClient, useQuery } from '@tanstack/react-query'
 import { CampaignTypeFormData, CampaignTypesResponse } from 'gql/campaign-types'
 
 import { endpoints } from './apiEndpoints'
-import { authConfig, authQueryFnFactory } from './restRequests'
+import { authConfig, authQueryFnFactory, queryFnFactory } from './restRequests'
 import { apiClient } from './apiClient'
 
 export const useCampaignTypesList = () => {
@@ -68,7 +68,8 @@ export async function prefetchCampaignTypeById(client: QueryClient, slug: string
 }
 
 export async function prefetchCampaignTypesList(client: QueryClient) {
-  await client.prefetchQuery<CampaignTypesResponse[]>([
-    endpoints.campaignTypes.listCampaignTypes.url,
-  ])
+  await client.prefetchQuery<CampaignTypesResponse[]>(
+    [endpoints.campaignTypes.listCampaignTypes.url],
+    queryFnFactory<CampaignTypesResponse[]>(),
+  )
 }

--- a/src/service/restRequests.ts
+++ b/src/service/restRequests.ts
@@ -1,15 +1,20 @@
-import { QueryFunction } from '@tanstack/react-query'
+import getConfig from 'next/config'
 import { Session } from 'next-auth'
+
+import { QueryFunction } from '@tanstack/react-query'
 import { AxiosRequestConfig } from 'axios'
 
 import { apiClient } from 'service/apiClient'
 
+const {
+  publicRuntimeConfig: { APP_URL },
+} = getConfig()
 export async function fetchSession(): Promise<Session | null> {
-  const res = await fetch('/api/auth/session')
-  const session = await res.json()
-
+  const res = await apiClient.get('/api/auth/session', { baseURL: APP_URL })
+  const session = res.data
   console.log('Fetching session from /api/auth/session')
 
+  console.log(session)
   if (Object.keys(session).length) {
     console.log('Fetching session successful.')
     return session

--- a/src/service/restRequests.ts
+++ b/src/service/restRequests.ts
@@ -1,7 +1,7 @@
 import getConfig from 'next/config'
 import { Session } from 'next-auth'
 
-import { QueryFunction } from '@tanstack/react-query'
+import { QueryFunction, QueryFunctionContext } from '@tanstack/react-query'
 import { AxiosRequestConfig } from 'axios'
 
 import { apiClient } from 'service/apiClient'
@@ -28,7 +28,13 @@ export const queryFn: QueryFunction = async function ({ queryKey }) {
   return await response.data
 }
 
-export const queryFnFactory = <T>(token?: string): QueryFunction<T> =>
+export const queryFnFactory = <T>(): QueryFunction<T> =>
+  async function ({ queryKey }) {
+    const response = await apiClient.get(queryKey.join('/'))
+    return await response.data
+  }
+
+const attachTokenToQueryFn = <T>(token?: string): QueryFunction<T> =>
   async function ({ queryKey }) {
     if (!token) {
       const session = await fetchSession()
@@ -42,7 +48,7 @@ export const queryFnFactory = <T>(token?: string): QueryFunction<T> =>
   }
 
 export const authQueryFnFactory = <T>(token?: string): QueryFunction<T> => {
-  return queryFnFactory<T>(token)
+  return attachTokenToQueryFn<T>(token)
 }
 
 export const authConfig = (token?: string): AxiosRequestConfig => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and context

Addressed the issue specified here https://github.com/podkrepi-bg/frontend/pull/1152#issuecomment-1323969262 and #1166.
<!--- Why is this change required? -->
This returning of a `<NotFoundPage />` in the components that were changed seemed to cause the issue. Added a loader in it's place. This way though the case where `data` is empty is not handled, but we shouldn't get to this case since if the `campaigns/<slug>` does not exist the server should give us back a 404 and that will get handled by Next.

| Before              | After              |
| ------------------- | ------------------ |
|![404-flash-bug](https://user-images.githubusercontent.com/61479393/203661274-b3cc8423-2e7c-4ebb-9064-97cdf7221143.gif)|![404-flash-fix](https://user-images.githubusercontent.com/61479393/203661295-3e99f903-9f72-4398-960a-170862d8eb30.gif)|

* Also added a `staleTime` to the campaign list query, which keeps them in cache for 3 hours. I felt like the campaigns getting reshuffled on every page change was confusing.

## Testing

Tried all the pages that had the if check for the `<NotFoundPage>`.
