### PR TITLE
Added the page title as default og title

### DIFF
--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -77,7 +77,7 @@ export default function Layout({
           <meta property="og:type" content="article" />
           <meta property="og:locale" content={i18n.language === 'bg' ? 'bg_BG' : 'en_US'} />
           {/* TODO: think of how to make campaign level localization */}
-          <meta key="og:title" property="og:title" content={title} />
+          <meta key="og:title" property="og:title" content={pageTitle} />
           <meta key="og:image" property="og:image" content={ogImage ?? defaultOgImage.src} />
           {!ogImage && (
             <meta key="og:image:width" property="og:image:width" content={defaultOgImage.width} />


### PR DESCRIPTION
Closes #1170

When passing `metaTitle` it wasn't properly populated to the `og:title` property.

## Testing

See no warning about `og:title` in 
https://developers.facebook.com/tools/debug/?q=https%3A%2F%2Fdev.podkrepi.bg%2Fblog%2Fyanika-novo-nachalo
