### PR TITLE
Always pull container in k8s

### DIFF
--- a/manifests/overlays/development/manual/deployment.patch.yaml
+++ b/manifests/overlays/development/manual/deployment.patch.yaml
@@ -13,7 +13,6 @@ spec:
     spec:
       containers:
         - name: frontend
-          imagePullPolicy: Always
           resources:
             limits:
               memory: 350Mi

--- a/manifests/overlays/production/manual/deployment.patch.yaml
+++ b/manifests/overlays/production/manual/deployment.patch.yaml
@@ -13,7 +13,6 @@ spec:
     spec:
       containers:
         - name: frontend
-          imagePullPolicy: IfNotPresent
           resources:
             limits:
               memory: 350Mi


### PR DESCRIPTION
For security reasons it is important to always pull the container image prior to starting it. This was not done until now because the container was very big. Since we now have a decently sized container we can implement this change. Thanks @kachar 