### PR TITLE
Fixed width of images on homepage

### DIFF
--- a/src/components/index/sections/JoinPodkrepiBgSection/JoinPodkrepiBgSection.tsx
+++ b/src/components/index/sections/JoinPodkrepiBgSection/JoinPodkrepiBgSection.tsx
@@ -26,6 +26,7 @@ export default function WantToHelpPodkrepiBgSection() {
             src={discordTeamImagePath}
             width={1189}
             height={789}
+            layout="intrinsic"
             priority
           />
         </Box>

--- a/src/components/index/sections/TeamMembersSection/TeamMembersSection.tsx
+++ b/src/components/index/sections/TeamMembersSection/TeamMembersSection.tsx
@@ -18,7 +18,7 @@ export default function TeamMembersSection() {
       <Heading variant="h4">{t('team-section.heading')}</Heading>
       <InfoText maxWidth="lg">{t('team-section.content')}</InfoText>
       {/* A11Y TODO: Translate alt text */}
-      <Image alt="Team image" src={teamImagePath} width={1095} height={150} />
+      <Image alt="Team image" src={teamImagePath} width={1095} height={150} layout="intrinsic" />
       <Grid>
         <OutlinedButton href={routes.about} variant="outlined" endIcon={<ChevronRightIcon />}>
           {t('team-section.meet-our-team')}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
The images on Homepage are not responsive

<!--- If it fixes an open issue, please link to the issue here. -->
Closes #1186 

## Motivation and context

<!--- Why is this change required? -->
Design was broken.
<!--- What problem are you trying to solve? -->
Images overflow the container.
<!--- How did you solve the problem? -->
With a nextjs/image property.
<!--- Any links to external sources of documentation -->
<!--- Any links to internal designs -->

## Screenshots:

<!-- You can copy/paste screenshots directly in the editor -->

Before 
![before](https://user-images.githubusercontent.com/75265000/204265443-01cfe099-1307-4bbf-8071-f5a9ad46bd99.png)
After
![after](https://user-images.githubusercontent.com/75265000/204265468-8d5ae7e2-1a82-43bd-a6bc-b86efb10da23.png)


<!-- List of pages that are affected by the changes -->

## Testing

### Steps to test

### Affected urls

<!--- Specify test requirements (environment, dependencies, design reviews) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include links to the related pages -->
<!--- Include details of your testing environment -->
<!--- Impact of your change to other areas of the code -->

## Environment

### New environment variables:

<!-- Mark with [x] when variable is added to `.env.local.example`  -->

- [ ] `NEW_ENV_VAR`: env var details

### New or updated dependencies:

<!-- including dev dependencies -->

Dependency name|Previous version|Updated version|Details
---|---|---|---
`dependency/name`|`v1.0.0`|`v2.0.0`|

