### PR TITLE
Update mobile menu styles

### DIFF
--- a/src/components/layout/AppNavBar.tsx
+++ b/src/components/layout/AppNavBar.tsx
@@ -62,7 +62,7 @@ export default function AppNavBar({ navMenuToggle }: AppBarDeckProps) {
               [theme.breakpoints.down('md')]: {
                 marginLeft: 0,
                 width: '100%',
-                height: '50%',
+                height: '40px',
               },
               '&.shrink': {
                 height: '50%',

--- a/src/components/layout/AppNavBar.tsx
+++ b/src/components/layout/AppNavBar.tsx
@@ -62,7 +62,7 @@ export default function AppNavBar({ navMenuToggle }: AppBarDeckProps) {
               [theme.breakpoints.down('md')]: {
                 marginLeft: 0,
                 width: '100%',
-                height: '40px',
+                height: theme.spacing(5),
               },
               '&.shrink': {
                 height: '50%',

--- a/src/components/layout/Footer/LogoSocialIcons.tsx
+++ b/src/components/layout/Footer/LogoSocialIcons.tsx
@@ -13,7 +13,7 @@ export const LogoSocialIcons = () => {
   return (
     <Grid item xs={12} sm={8} md={5} container direction="column">
       <Grid item>
-        <Link href={routes.index}>
+        <Link href={routes.index} passHref>
           <PodkrepiLogo locale={locale} size="large" variant="fixed" />
         </Link>
       </Grid>

--- a/src/components/layout/nav/AuthLinks/AuthLinks.styled.tsx
+++ b/src/components/layout/nav/AuthLinks/AuthLinks.styled.tsx
@@ -10,6 +10,7 @@ export const AuthLinksWrapper = styled(Box)(() => ({
   borderTop: '2px solid lightgrey',
   marginLeft: theme.spacing(0.25),
   minHeight: theme.spacing(8),
+  paddingLeft: theme.spacing(1),
 }))
 
 export const AuthLink = styled(LinkButton)(() => ({

--- a/src/components/layout/nav/DonationMenuMobile.tsx
+++ b/src/components/layout/nav/DonationMenuMobile.tsx
@@ -26,6 +26,7 @@ const StyledAccordion = styled(Accordion)(({ theme }) => ({
   [`& .${classes.accordionSummary}`]: {
     fontWeight: 500,
     minHeight: theme.spacing(8),
+    padding: theme.spacing(0, 3),
   },
 
   [`& .${classes.menuItem}`]: {

--- a/src/components/layout/nav/MobileNav/MobileNav.styled.tsx
+++ b/src/components/layout/nav/MobileNav/MobileNav.styled.tsx
@@ -2,17 +2,18 @@ import { Box } from '@mui/material'
 import { styled } from '@mui/material/styles'
 
 import theme from 'common/theme'
-import PodkrepiIcon from 'components/brand/PodkrepiIcon'
 import CloseModalButton from 'components/common/CloseModalButton'
 import Grid from 'components/recurring-donation/grid/Grid'
 import LinkButton from 'components/common/LinkButton'
 
 export const CloseButton = styled(CloseModalButton)(() => ({
   marginRight: theme.spacing(1.25),
+  right: theme.spacing(1.25),
+  top: theme.spacing(0.25),
 }))
 
-export const StyledPodkrepiIcon = styled(PodkrepiIcon)(() => ({
-  margin: theme.spacing(0.7, 0, 1.5, 0),
+export const OpenMenuHeader = styled(Box)(() => ({
+  margin: theme.spacing(0.5, 3, 2),
 }))
 
 export const NavMenuWrapper = styled(Box)(() => ({
@@ -41,6 +42,7 @@ export const LocaleButtonWrapper = styled(Box)(() => ({
   borderBottom: '2px solid lightgrey',
   display: 'flex',
   minHeight: theme.spacing(8),
+  paddingLeft: theme.spacing(1),
 
   '& button': {
     justifyContent: 'start',

--- a/src/components/layout/nav/MobileNav/MobileNav.tsx
+++ b/src/components/layout/nav/MobileNav/MobileNav.tsx
@@ -2,6 +2,7 @@ import React, { useEffect } from 'react'
 
 import { useRouter } from 'next/router'
 import { useTranslation } from 'next-i18next'
+import Link from 'next/link'
 
 import { SwipeableDrawer, Hidden, Grid } from '@mui/material'
 import FavoriteIcon from '@mui/icons-material/Favorite'
@@ -11,13 +12,14 @@ import DonationMenuMobile from '../DonationMenuMobile'
 import ProjectMenuMobile from '../ProjectMenuMobile'
 import { AuthLinks } from '../AuthLinks/AuthLinks'
 import { routes } from 'common/routes'
+import PodkrepiIcon from 'components/brand/PodkrepiIcon'
 
 import {
   CloseButton,
-  NavMenuWrapper,
-  LocaleButtonWrapper,
-  StyledPodkrepiIcon,
   DonateButton,
+  LocaleButtonWrapper,
+  NavMenuWrapper,
+  OpenMenuHeader,
 } from './MobileNav.styled'
 
 type NavDeckProps = {
@@ -49,11 +51,13 @@ export default function MobileNav({ mobileOpen, setMobileOpen }: NavDeckProps) {
         ModalProps={{ keepMounted: true }}
         onOpen={() => setMobileOpen(true)}
         onClose={closeNavMenu}>
-        <CloseButton edge="end" fontSize="inherit" onClose={closeNavMenu} />
         <NavMenuWrapper>
-          <Grid item textAlign="center">
-            <StyledPodkrepiIcon />
-          </Grid>
+          <OpenMenuHeader>
+            <Link href={routes.index} passHref>
+              <PodkrepiIcon />
+            </Link>
+            <CloseButton edge="end" fontSize="large" onClose={closeNavMenu} />
+          </OpenMenuHeader>
           <Grid item>
             <DonationMenuMobile />
           </Grid>

--- a/src/components/layout/nav/ProjectMenuMobile.tsx
+++ b/src/components/layout/nav/ProjectMenuMobile.tsx
@@ -26,6 +26,7 @@ const StyledAccordion = styled(Accordion)(({ theme }) => ({
   [`& .${classes.accordionSummary}`]: {
     fontWeight: 500,
     minHeight: theme.spacing(8),
+    padding: theme.spacing(0, 3),
   },
 
   [`& .${classes.menuItem}`]: {


### PR DESCRIPTION
- Updated the logo on open mobile menu to be a Link.
- Updates styles as discussed with @swolf86:

Before|After
---|---
![image](https://user-images.githubusercontent.com/14351733/204268905-18fb6071-b9aa-4a3e-8f6a-294ef765728d.png) | ![image](https://user-images.githubusercontent.com/14351733/204268989-6218056a-cc6b-4fa8-a71c-1216fea9e07c.png)

Before|After
---|---
![image](https://user-images.githubusercontent.com/14351733/204269129-fca608c4-9a3f-42cf-9034-8cab35e282e6.png) | ![image](https://user-images.githubusercontent.com/14351733/204269172-b494ef74-bbf8-48e1-a5ca-a68b2b4ff469.png)


- Fixed passHref warning in LogoSocialIcons component:

![image](https://user-images.githubusercontent.com/14351733/204269427-ec427e46-9f3d-4544-87d3-f87e1848e832.png)
