### PR TITLE
Fix visual issue with the Donations block on the Campaign page

### DIFF
--- a/src/components/campaigns/DonorsAndDonations.tsx
+++ b/src/components/campaigns/DonorsAndDonations.tsx
@@ -13,18 +13,14 @@ import { moneyPublic } from 'common/util/money'
 const PREFIX = 'DonorsAndDonations'
 
 const classes = {
-  donationsWrapper: `${PREFIX}-donationsWrapper`,
   donationItemWrapper: `${PREFIX}-donationItemWrapper`,
   donationQuantityAndTimeWrapper: `${PREFIX}-donationQuantityAndTimeWrapper`,
   separatorIcon: `${PREFIX}-separatorIcon`,
 }
 
 const Root = styled('div')(({ theme }) => ({
-  [`& .${classes.donationsWrapper}`]: {
-    marginTop: theme.spacing(5),
-    maxHeight: 400,
-    overflowY: 'scroll',
-  },
+  marginTop: theme.spacing(5),
+  overflowY: 'auto',
 
   [`& .${classes.donationItemWrapper}`]: {
     display: 'flex',
@@ -62,7 +58,7 @@ export default function DonorsAndDonations({
 
   return (
     <Root>
-      <Grid item className={classes.donationsWrapper}>
+      <Grid item>
         {donationsToShow && donationsToShow.length !== 0 ? (
           donationsToShow.map(({ person, amount, createdAt, currency }, key) => (
             <Grid key={key} className={classes.donationItemWrapper}>

--- a/src/components/campaigns/InlineDonation.tsx
+++ b/src/components/campaigns/InlineDonation.tsx
@@ -28,6 +28,7 @@ const classes = {
   inlineDonationWrapper: `${PREFIX}-inlineDonationWrapper`,
   reachedMoney: `${PREFIX}-reachedMoney`,
   targetMoney: `${PREFIX}-targetMoney`,
+  donorsSharesWrapper: `${PREFIX}-donorsSharesWrapper`,
   donorsSharesCount: `${PREFIX}-donorsSharesCount`,
   donationPriceList: `${PREFIX}-donationPriceList`,
   dropdownLinkButton: `${PREFIX}-dropdownLinkButton`,
@@ -41,8 +42,11 @@ const StyledGrid = styled(Grid)(({ theme }) => ({
   [`&.${classes.inlineDonationWrapper}`]: {
     backgroundColor: '#EEEEEE',
     borderRadius: theme.spacing(1),
-    height: 'fit-content',
+    maxHeight: '70vh',
     boxShadow: '2px 4px 5px rgba(0, 0, 0, 0.25)',
+    display: 'flex',
+    flexDirection: 'column',
+    overflow: 'hidden',
     [theme.breakpoints.down('md')]: {
       margin: theme.spacing(0),
       borderRadius: theme.spacing(0),
@@ -62,6 +66,11 @@ const StyledGrid = styled(Grid)(({ theme }) => ({
     [theme.breakpoints.down('md')]: {
       fontSize: theme.spacing(2),
     },
+  },
+
+  [`& .${classes.donorsSharesWrapper}`]: {
+    display: 'flex',
+    flexDirection: 'row',
   },
 
   [`& .${classes.donorsSharesCount}`]: {
@@ -158,7 +167,7 @@ export default function InlineDonation({ campaign }: Props) {
       </Grid>
       <CampaignProgress raised={reached} target={target} />
       {detailsShown && (
-        <>
+        <Grid className={classes.donorsSharesWrapper}>
           <Grid display="inline-block" m={3} ml={0}>
             <Typography className={classes.donorsSharesCount}>{donors}</Typography>
             <Typography>{t('campaigns:campaign.donors')}</Typography>
@@ -167,7 +176,7 @@ export default function InlineDonation({ campaign }: Props) {
             <Typography className={classes.donorsSharesCount}>{0}</Typography>
             <Typography>{t('campaigns:campaign.shares')}</Typography>
           </Grid>
-        </>
+        </Grid>
       )}
       <Grid container gap={2} className={classes.buttonContainer}>
         <Button
@@ -251,7 +260,6 @@ export default function InlineDonation({ campaign }: Props) {
             ) : null}
           </>
         ))}
-      {/* <pre>{JSON.stringify(prices, null, 2)}</pre> */}
       {mobile && (
         <Grid textAlign="center">
           <Button variant="text" onClick={() => setIsOpen(!isOpen)} className={classes.openButton}>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fix visual issue with the "Donations" block on the "Campaign" page

- make the list with the donations scrollable and always fit the viewport on the Campaign details page

<!--- If it fixes an open issue, please link to the issue here. -->
Closes #1108

## Motivation and context

Observe the campaign's donation block - it is not fully visible at the bottom until the user scrolls down to the bottom of the page which makes the UX really bad, especially for campaign with a lot of comments (it takes some time until you reach the bottom of the page in order to see the full list with the donations).

Examples:
- https://podkrepi.bg/campaigns/tanya-kosmicheskoto-momiche-na-bulgariya-po-putya-kum-zvezdite

<!--- Why is this change required? -->
<!--- What problem are you trying to solve? -->
### How did you solve the problem?
I made some minor changes in the way we make the donations block scrollable:
- changed the size of the parent element by putting a maximum height so it won't exceed the viewport anymore
- changed the overflow of the parent element, so it will trigger properly the auto-scroll of the inline block with the donations

### Any links to external sources of documentation:
I made an example js fiddle to showcase the changes with an isolated and a bit more simpler markup:
- https://jsfiddle.net/e2g6nthy/
<!--- Any links to internal designs -->

## Screenshots:

<!-- You can copy/paste screenshots directly in the editor -->

Before|After
---|---
![image](https://user-images.githubusercontent.com/1233496/204338536-87ad6e7f-2536-4a0f-ac4f-148a2d20c488.png)|![image](https://user-images.githubusercontent.com/1233496/204338594-3a6e4c9f-041a-41ea-a4cc-5b85ed180881.png)

And here it is how it looks like on a bigger screen when we have enough viewport height to show all the donations without an inline scroll:
![image](https://user-images.githubusercontent.com/1233496/204340535-05c10ec6-a7f7-4820-9ab0-2ab0fdd690ea.png)


<!-- List of pages that are affected by the changes -->

## Testing

### Steps to test

1. Go to https://podkrepi.bg/campaigns
2. Open a campaign
3. Observe the campaign's donation block

_Note: For some reason there are no any campaigns on DEV right now, so you can test it only on your LOCAL env._