### PR TITLE
1119 - Confirm password in registration field is now required

### DIFF
--- a/src/common/form/validation.ts
+++ b/src/common/form/validation.ts
@@ -1,5 +1,6 @@
 import { setLocale, string } from 'yup'
 import { TFunction } from 'next-i18next'
+import * as yup from 'yup'
 export type TranslatableField =
   | (string | undefined)
   | { key: string; values?: Record<string, string> }
@@ -39,6 +40,7 @@ export const customValidators = {
     values: { max },
   }),
   password: () => ({ key: 'validation:password' }),
+  confirmPassword: () => ({ key: 'validation:password-match' }),
   phone: () => ({ key: 'validation:phone' }),
   name: () => ({ key: 'validation:invalid' }),
 }
@@ -76,3 +78,8 @@ export const password = string()
   .min(8, customValidators.passwordMin)
   .max(30, customValidators.passwordMax)
   .matches(passwordRegex, customValidators.password)
+
+export const confirmPassword = string().oneOf(
+  [yup.ref('password')],
+  customValidators.confirmPassword,
+)

--- a/src/components/auth/register/RegisterForm.tsx
+++ b/src/components/auth/register/RegisterForm.tsx
@@ -21,6 +21,7 @@ export type RegisterFormData = {
   lastName: string
   email: string
   password: string
+  'confirm-password': string
   terms: boolean
   gdpr: boolean
 }
@@ -33,7 +34,10 @@ const validationSchema: yup.SchemaOf<RegisterFormData> = yup
     lastName: name.required(),
     email: email.required(),
     password: password.required(),
-    'confirm-password': yup.string().oneOf([yup.ref('password')], 'validation:password-match'),
+    'confirm-password': yup
+      .string()
+      .required('validation:password-match')
+      .oneOf([yup.ref('password')], 'validation:password-match'),
     terms: yup.bool().required().oneOf([true], 'validation:terms-of-use'),
     gdpr: yup.bool().required().oneOf([true], 'validation:terms-of-service'),
   })
@@ -43,6 +47,7 @@ const defaults: RegisterFormData = {
   lastName: '',
   email: '',
   password: '',
+  'confirm-password': '',
   terms: false,
   gdpr: false,
 }

--- a/src/components/auth/register/RegisterForm.tsx
+++ b/src/components/auth/register/RegisterForm.tsx
@@ -6,7 +6,7 @@ import { signIn } from 'next-auth/react'
 import { useTranslation } from 'next-i18next'
 
 import { routes } from 'common/routes'
-import { email, password, name } from 'common/form/validation'
+import {email, password, name, confirmPassword} from 'common/form/validation'
 import { useRegister } from 'service/auth'
 import { AlertStore } from 'stores/AlertStore'
 import GenericForm from 'components/common/form/GenericForm'
@@ -21,7 +21,7 @@ export type RegisterFormData = {
   lastName: string
   email: string
   password: string
-  'confirm-password': string
+  confirmPassword: string
   terms: boolean
   gdpr: boolean
 }
@@ -34,10 +34,7 @@ const validationSchema: yup.SchemaOf<RegisterFormData> = yup
     lastName: name.required(),
     email: email.required(),
     password: password.required(),
-    'confirm-password': yup
-      .string()
-      .required('validation:password-match')
-      .oneOf([yup.ref('password')], 'validation:password-match'),
+    confirmPassword: confirmPassword.required('validation:password-match'),
     terms: yup.bool().required().oneOf([true], 'validation:terms-of-use'),
     gdpr: yup.bool().required().oneOf([true], 'validation:terms-of-service'),
   })
@@ -47,7 +44,7 @@ const defaults: RegisterFormData = {
   lastName: '',
   email: '',
   password: '',
-  'confirm-password': '',
+  confirmPassword: '',
   terms: false,
   gdpr: false,
 }
@@ -76,7 +73,7 @@ export default function RegisterForm({ initialValues = defaults }: RegisterFormP
       }
       if (resp?.ok) {
         AlertStore.show(t('auth:alerts.welcome'), 'success')
-        router.push(routes.profile.index)
+        await router.push(routes.profile.index)
       }
     } catch (error) {
       console.error(error)
@@ -116,7 +113,7 @@ export default function RegisterForm({ initialValues = defaults }: RegisterFormP
         </Grid>
         <Grid item xs={12}>
           <PasswordField
-            name="confirm-password"
+            name="confirmPassword"
             label="auth:account.confirm-password"
             autoComplete="new-password"
           />

--- a/src/components/auth/register/RegisterForm.tsx
+++ b/src/components/auth/register/RegisterForm.tsx
@@ -6,7 +6,7 @@ import { signIn } from 'next-auth/react'
 import { useTranslation } from 'next-i18next'
 
 import { routes } from 'common/routes'
-import {email, password, name, confirmPassword} from 'common/form/validation'
+import { email, password, name, confirmPassword } from 'common/form/validation'
 import { useRegister } from 'service/auth'
 import { AlertStore } from 'stores/AlertStore'
 import GenericForm from 'components/common/form/GenericForm'

--- a/src/components/one-time-donation/RegisterDialog.tsx
+++ b/src/components/one-time-donation/RegisterDialog.tsx
@@ -24,6 +24,7 @@ export default function RegisterForm() {
     lastName: formik.values.registerLastName as string,
     email: formik.values.registerEmail as string,
     password: formik.values.registerPassword as string,
+    confirmPassword: formik.values.confirmPassword as string,
     terms: formik.values.terms as boolean,
     gdpr: formik.values.gdpr as boolean,
   }
@@ -88,6 +89,13 @@ export default function RegisterForm() {
         </Grid>
         <Grid item xs={12}>
           <PasswordField name="registerPassword" autoComplete="new-password" />
+        </Grid>
+        <Grid item xs={12}>
+          <PasswordField
+            name="confirmPassword"
+            label="auth:account.confirm-password"
+            autoComplete="new-password"
+          />
         </Grid>
         <Grid item xs={12}>
           <Button

--- a/src/gql/donations.d.ts
+++ b/src/gql/donations.d.ts
@@ -118,6 +118,7 @@ export type OneTimeDonation = {
   registerLastName?: string
   registerEmail?: string
   registerPassword?: string
+  confirmPassword?: string
   terms?: boolean
   gdpr?: boolean
 }


### PR DESCRIPTION
Now when someone want to register and they dont fill up confirmation password, it will throw error message for users.

<!--- If it fixes an open issue, please link to the issue here. -->
Closes #1119 

## Screenshots:
Before:
![image](https://user-images.githubusercontent.com/104101610/204675131-e5834d09-5383-4ca7-959d-e695eda3c8e2.png)
After:
![image](http<!--- What problem are you trying to solve? -->
<!--- How did you solve the problem? -->
<!--- Any links to external sources of documentation -->
<!--- Any links to internal designs -->

## Screenshots:
Before:
![image](https://user-images.githubusercontent.com/104101610/204675131-e5834d09-5383-4ca7-959d-e695eda3c8e2.png)
After:
![image](https://user-images.githubusercontent.com/104101610/204675035-9666277d-cf54-4c81-bcd2-dbbe45309ae4.png)

<!-- List of pages that are affected by the changes -->
http://localhost:3040/en/register

## Testing

### Steps to test
Get on registration page: http://localhost:3040/en/register.
Try to fill up form without confirm password field.
Click on register button.

### Affected urls
http://localhost:3040/en/register
<!--- Specify test requirements (environment, dependencies, design reviews) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include links to the related pages -->
<!--- Include details of your testing environment -->
<!--- Impact of your channge to other areas of the code -->


