### PR TITLE
Fixing tests before deployment on dev

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -120,6 +120,7 @@ jobs:
   run-playwright:
     name: Run Playwright
     uses: ./.github/workflows/playwright.yml
+    secrets: inherit
 
   release-dev:
     name: Release to dev


### PR DESCRIPTION
## Motivation and context

Tests that run before deployment on Dev were failing. Fixed by adding secrets: inherit on the imported github workflow.


