### PR TITLE
Fix fields in auth package not being trimmed automatically

### DIFF
--- a/src/components/auth/forgottenPassword/ForgottenPasswordForm.tsx
+++ b/src/components/auth/forgottenPassword/ForgottenPasswordForm.tsx
@@ -43,6 +43,7 @@ export default function ForgottenPasswordForm({
   const onSubmit = async (values: ForgottenPasswordForm) => {
     try {
       setLoading(true)
+      values.email = values.email.trim()
       await mutation.mutateAsync(values)
     } catch (error) {
       console.error(error)

--- a/src/components/auth/login/LoginForm.tsx
+++ b/src/components/auth/login/LoginForm.tsx
@@ -44,7 +44,7 @@ export default function LoginForm({ initialValues = defaults }: LoginFormProps) 
       setLoading(true)
 
       const resp = await signIn<'credentials'>('credentials', {
-        email: values.email,
+        email: values.email.trim(),
         password: values.password,
         redirect: false,
       })

--- a/src/components/auth/profile/UpdateEmailModal.tsx
+++ b/src/components/auth/profile/UpdateEmailModal.tsx
@@ -87,6 +87,7 @@ function UpdateEmailModal({
         throw new Error('Invalid login')
       }
 
+      values.email = values.email.trim()
       const updateUser = await mutation.mutateAsync({
         ...person,
         email: values.email,

--- a/src/components/auth/profile/UpdateNameModal.tsx
+++ b/src/components/auth/profile/UpdateNameModal.tsx
@@ -91,8 +91,8 @@ function UpdateNameModal({
 
       const updateUser = await mutation.mutateAsync({
         ...person,
-        firstName: values.firstName,
-        lastName: values.lastName,
+        firstName: values.firstName.trim(),
+        lastName: values.lastName.trim(),
       })
 
       const reLogin = await signIn<'credentials'>('credentials', {

--- a/src/components/auth/register/RegisterForm.tsx
+++ b/src/components/auth/register/RegisterForm.tsx
@@ -58,6 +58,9 @@ export default function RegisterForm({ initialValues = defaults }: RegisterFormP
   const onSubmit = async (values: RegisterFormData) => {
     try {
       setLoading(true)
+      values.firstName = values.firstName.trim()
+      values.lastName = values.lastName.trim()
+      values.email = values.email.trim()
 
       // Register in Keycloak
       await register(values)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
When you enter email, firstName or lastName in one of the form in authorisation package and you accidentally put a leading/trailing space, it results into failed login because of invalid credentials. On most of the websites it's a common practice to ignore those "false" spaces when verifying the credentials, so we may apply it as well.


<!--- If it fixes an open issue, please link to the issue here. -->
Closes https://github.com/podkrepi-bg/frontend/issues/1124

## Motivation and context

<!--- Why is this change required? -->
On most of the websites it's a common practice to ignore those "false" spaces when verifying the credentials, so we may apply it as well.
<!--- How did you solve the problem? -->
In order to fix that I had added trim to the end of the strings.

### Note
Unfortunately, in the issue it was suggested that we should add trim to the yup validation chain to fix the problem. This didn't work and it seems that there is a incompatibility between Formik and Yup when there is a transformation. More information can be found here :
https://github.com/jaredpalmer/formik/issues/473
https://stackoverflow.com/questions/60423402/automatically-trim-white-spaces-with-yup-and-formik

## Screenshots:

<!-- You can copy/paste screenshots directly in the editor -->

<img width="1792" alt="Screenshot 2022-12-06 at 20 45 07" src="https://user-images.githubusercontent.com/44066540/206002008-9f5fa676-a72e-48e8-a595-a0d07433309c.png">

<!-- List of pages that are affected by the changes -->

## Testing

### Steps to test

### Affected Forms

* LoginForm
* RegisterForm
* ForgottenPasswordForm
* UpdateNameModal
* UpdateEmailModal
