### PR TITLE
1186 - fix homepage images to now be responsive

### DIFF
--- a/src/components/index/sections/JoinPodkrepiBgSection/JoinPodkrepiBgSection.tsx
+++ b/src/components/index/sections/JoinPodkrepiBgSection/JoinPodkrepiBgSection.tsx
@@ -23,9 +23,13 @@ export default function WantToHelpPodkrepiBgSection() {
           {/* A11Y TODO: Translate alt text */}
           <Image
             alt="Discord team image"
-            src={discordTeamImagePath}
             width={1189}
             height={789}
+            style={{
+              width: '100%',
+              height: 'auto',
+            }}
+            src={discordTeamImagePath}
             priority
           />
         </Box>

--- a/src/components/index/sections/TeamMembersSection/TeamMembersSection.tsx
+++ b/src/components/index/sections/TeamMembersSection/TeamMembersSection.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import Image from 'next/image'
 import { useTranslation } from 'next-i18next'
 import ChevronRightIcon from '@mui/icons-material/ChevronRight'
-import { Grid } from '@mui/material'
+import { Box, Grid } from '@mui/material'
 
 import { routes } from 'common/routes'
 
@@ -17,8 +17,16 @@ export default function TeamMembersSection() {
     <Root>
       <Heading variant="h4">{t('team-section.heading')}</Heading>
       <InfoText maxWidth="lg">{t('team-section.content')}</InfoText>
+      <Box>
+        <Image
+          alt="Team image"
+          src={teamImagePath}
+          style={{ maxWidth: '100%', height: 'auto', objectFit: 'contain' }}
+          width={1095}
+          height={150}
+        />
+      </Box>
       {/* A11Y TODO: Translate alt text */}
-      <Image alt="Team image" src={teamImagePath} width={1095} height={150} />
       <Grid>
         <OutlinedButton href={routes.about} variant="outlined" endIcon={<ChevronRightIcon />}>
           {t('team-section.meet-our-team')}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!--- If it fixes an open issue, please link to the issue here. -->
Closes #1186

## Motivation and context

2 images on the homepage were not responsive.
Fixed them as per the examples provided by NextJS 
https://github.com/vercel/next.js/tree/canary/examples/image-component/pages

## Screenshots:

<!-- You can copy/paste screenshots directly in the editor -->

Team|Discord
---|---
<img width="390" alt="image" src="https://user-images.githubusercontent.com/61479393/206011282-e04fccb3-677a-4403-aa36-9351754daae3.png">|<img width="395" alt="image" src="https://user-images.githubusercontent.com/61479393/206011329-5ef96261-acd2-4bac-8006-667df7e4bd0e.png">

<!-- List of pages that are affected by the changes -->

## Testing
Tested on all resolutions and images are responsive width width as the viewport until they hit the given `widths`

### Affected urls

`index` - 'https://podkrepi.bg'


