### PR TITLE
Fix discord team image on about page to be responsive

### DIFF
--- a/src/components/about/sections/AboutTheTeamSection/AboutTheTeamSection.styled.tsx
+++ b/src/components/about/sections/AboutTheTeamSection/AboutTheTeamSection.styled.tsx
@@ -1,10 +1,15 @@
+import { Box } from '@mui/material'
 import { styled } from '@mui/material/styles'
-import { Typography } from '@mui/material'
 
 import theme from 'common/theme'
 
-export const DiscordTeamImage = styled(Typography)(() => ({
+export const DiscordTeamImage = styled(Box)(() => ({
   marginTop: theme.spacing(8),
   display: 'flex',
   justifyContent: 'center',
+
+  '& img': {
+    width: '100%',
+    height: 'auto',
+  },
 }))


### PR DESCRIPTION
## Screenshots:

Before|After
---|---
![4](https://user-images.githubusercontent.com/14351733/206170467-053954de-443e-4fa0-9218-33b62d2b2bc9.png)|![5](https://user-images.githubusercontent.com/14351733/206170413-f0aee648-80c4-49b1-b061-da428dad6a24.png)
