### PR TITLE
Improve the accessibility of the homepage

### DIFF
--- a/public/locales/bg/common.json
+++ b/public/locales/bg/common.json
@@ -73,7 +73,13 @@
       "privacy-policy": "Защита на лични данни",
       "terms-of-service": "Общи условия",
       "copyrights": "Podkrepi.bg ©2022 Всички права запазени.",
-      "hosting-partner": "Хостинг партньор:"
+      "hosting-partner": "Хостинг партньор:",
+      "social": {
+        "facebook": "Facebook",
+        "linkedin": "Linkedin",
+        "youtube": "YouTube",
+        "instagram": "Instagram"
+      }
     }
   },
   "or": "или",

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -73,7 +73,13 @@
       "privacy-policy": "Privacy Policy",
       "terms-of-service": "Terms of Service",
       "copyrights": "Podkrepi.bg ©2022 All rights reserved.",
-      "hosting-partner": "Hosting partner:"
+      "hosting-partner": "Hosting partner:",
+      "social": {
+        "facebook": "Facebook",
+        "linkedin": "Linkedin",
+        "youtube": "YouTube",
+        "instagram": "Instagram"
+      }
     }
   },
   "or": "or",

--- a/src/components/campaigns/CampaignCard.tsx
+++ b/src/components/campaigns/CampaignCard.tsx
@@ -107,6 +107,7 @@ export default function CampaignCard({ campaign }: Props) {
   const { t } = useTranslation()
 
   const {
+    id,
     targetAmount: target,
     summary,
     currency,
@@ -142,9 +143,13 @@ export default function CampaignCard({ campaign }: Props) {
       <CardActions className={classes.cardActions}>
         <Grid container justifyContent="space-around">
           <Box p={2} width={1}>
-            <CampaignProgress raised={reached} target={target} />
+            <CampaignProgress campaignId={id} raised={reached} target={target} />
           </Box>
-          <Typography variant="body1" component="p" className={classes.progressBar}>
+          <Typography
+            id={`campaign-${id}--donations-progressbar`}
+            variant="body1"
+            component="p"
+            className={classes.progressBar}>
             {t('campaigns:campaign.reached')}{' '}
             <b>
               {moneyPublic(reached, currency)}

--- a/src/components/campaigns/CampaignProgress.tsx
+++ b/src/components/campaigns/CampaignProgress.tsx
@@ -2,6 +2,8 @@ import React, { useMemo } from 'react'
 import { styled } from '@mui/material/styles'
 import LinearProgress from '@mui/material/LinearProgress'
 import { Grid } from '@mui/material'
+import { UUID } from 'gql/types'
+
 const PREFIX = 'CampaignProgress'
 
 const classes = {
@@ -28,10 +30,11 @@ const StyledGrid = styled(Grid)(({ theme }) => ({
 const BorderLinearProgress = LinearProgress
 
 type Props = {
+  campaignId: UUID
   raised: number
   target: number
 }
-export default function CampaignProgress({ raised, target }: Props) {
+export default function CampaignProgress({ campaignId, raised, target }: Props) {
   const percentage = useMemo(() => (raised / target) * 100, [raised, target])
   return (
     <StyledGrid className={classes.donationProgress} container>
@@ -39,6 +42,7 @@ export default function CampaignProgress({ raised, target }: Props) {
         <BorderLinearProgress
           variant="determinate"
           value={percentage > 100 ? 100 : percentage}
+          aria-labelledby={`campaign-${campaignId}--donations-progressbar`}
           classes={{
             root: classes.root,
             bar: classes.bar,

--- a/src/components/campaigns/InlineDonation.tsx
+++ b/src/components/campaigns/InlineDonation.tsx
@@ -165,7 +165,7 @@ export default function InlineDonation({ campaign }: Props) {
           {t('campaigns:campaign.from')} {moneyPublic(target, currency)}
         </Typography>
       </Grid>
-      <CampaignProgress raised={reached} target={target} />
+      <CampaignProgress campaignId={campaignId} raised={reached} target={target} />
       {detailsShown && (
         <>
           <Grid display="inline-block" m={3} ml={0}>

--- a/src/components/faq/ExpandableListItem.tsx
+++ b/src/components/faq/ExpandableListItem.tsx
@@ -16,6 +16,7 @@ const ExpandableListItem = ({ header, content }: Props) => {
 
   return (
     <List
+      component="div"
       sx={{
         my: 0,
         mx: { xs: 0, md: 3 },

--- a/src/components/layout/AppNavBar.tsx
+++ b/src/components/layout/AppNavBar.tsx
@@ -14,7 +14,7 @@ import PublicMenu from './nav/PublicMenu'
 import PrivateMenu from './nav/PrivateMenu'
 import MainNavMenu from './nav/MainNavMenu'
 import { useSession } from 'next-auth/react'
-import { useTranslation } from 'react-i18next'
+import { useTranslation } from 'next-i18next'
 
 type AppBarDeckProps = {
   navMenuToggle: () => void

--- a/src/components/layout/AppNavBar.tsx
+++ b/src/components/layout/AppNavBar.tsx
@@ -14,6 +14,7 @@ import PublicMenu from './nav/PublicMenu'
 import PrivateMenu from './nav/PrivateMenu'
 import MainNavMenu from './nav/MainNavMenu'
 import { useSession } from 'next-auth/react'
+import { useTranslation } from 'react-i18next'
 
 type AppBarDeckProps = {
   navMenuToggle: () => void
@@ -22,6 +23,7 @@ export default function AppNavBar({ navMenuToggle }: AppBarDeckProps) {
   const { locale } = useRouter()
   const { status } = useSession()
   const shrink = useScrollTrigger()
+  const { t } = useTranslation()
 
   return (
     <AppBar
@@ -56,6 +58,7 @@ export default function AppNavBar({ navMenuToggle }: AppBarDeckProps) {
         <Link href={routes.index} passHref>
           <ButtonBase
             className={clsx({ shrink })}
+            aria-label={t('meta.title')}
             sx={(theme) => ({
               transition: 'height .5s',
               height: theme.spacing(7.5),

--- a/src/components/layout/Footer/LogoSocialIcons.tsx
+++ b/src/components/layout/Footer/LogoSocialIcons.tsx
@@ -1,6 +1,6 @@
 import Link from 'next/link'
 import { useRouter } from 'next/router'
-
+import { useTranslation } from 'react-i18next'
 import { Grid } from '@mui/material'
 
 import { routes } from 'common/routes'
@@ -9,11 +9,12 @@ import { SocialIcons } from './SocialIcons'
 
 export const LogoSocialIcons = () => {
   const { locale } = useRouter()
+  const { t } = useTranslation()
 
   return (
     <Grid item xs={12} sm={8} md={5} container direction="column">
       <Grid item>
-        <Link href={routes.index} passHref>
+        <Link href={routes.index} passHref aria-label={t('meta.title')}>
           <PodkrepiLogo locale={locale} size="large" variant="fixed" />
         </Link>
       </Grid>

--- a/src/components/layout/Footer/SocialIcons.tsx
+++ b/src/components/layout/Footer/SocialIcons.tsx
@@ -2,22 +2,27 @@ import { Facebook, LinkedIn, YouTube, Instagram } from '@mui/icons-material'
 
 import { socialUrls } from 'common/routes'
 import ExternalLink from 'components/common/ExternalLink'
+import { useTranslation } from 'react-i18next'
 
 import { SocialIconsWrapper } from './Footer.styled'
 
 export const SocialIcons = () => {
+  const { t } = useTranslation()
+
   return (
     <SocialIconsWrapper container direction="row">
-      <ExternalLink href={socialUrls.facebook}>
+      <ExternalLink href={socialUrls.facebook} aria-label={t('components.footer.social.facebook')}>
         <Facebook />
       </ExternalLink>
-      <ExternalLink href={socialUrls.linkedin}>
+      <ExternalLink href={socialUrls.linkedin} aria-label={t('components.footer.social.linkedin')}>
         <LinkedIn />
       </ExternalLink>
-      <ExternalLink href={socialUrls.youtube}>
+      <ExternalLink href={socialUrls.youtube} aria-label={t('components.footer.social.youtube')}>
         <YouTube />
       </ExternalLink>
-      <ExternalLink href={socialUrls.instagram}>
+      <ExternalLink
+        href={socialUrls.instagram}
+        aria-label={t('components.footer.social.instagram')}>
         <Instagram />
       </ExternalLink>
     </SocialIconsWrapper>

--- a/src/components/layout/Footer/SocialIcons.tsx
+++ b/src/components/layout/Footer/SocialIcons.tsx
@@ -2,7 +2,7 @@ import { Facebook, LinkedIn, YouTube, Instagram } from '@mui/icons-material'
 
 import { socialUrls } from 'common/routes'
 import ExternalLink from 'components/common/ExternalLink'
-import { useTranslation } from 'react-i18next'
+import { useTranslation } from 'next-i18next'
 
 import { SocialIconsWrapper } from './Footer.styled'
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Improve the accessibility of the homepage
- improve the a11y of the buttons on the homepage
- improve the a11y of the progressbars on the homepage
- improve the a11y of the items in the FAQ section on the homepage
- improve the a11y of the footer links

<!--- If it fixes an open issue, please link to the issue here. -->
References #1211 

## Motivation and context

<!--- Why is this change required? -->
Considering we are a platform for everyone, accessibility should be something we take seriously so anyone can access and sufficiently interact with our website!

<!--- What problem are you trying to solve? -->
Within this PR I have used the Google Chrome's DevTools to generate an accessibility analysis and tried to resolve some of the reported issues.

<!--- How did you solve the problem? -->
In order to resolve some of those issues I have followed the community standards (defined by WCAG) and applied to following changes:
- added "aria-label" attribute to the button which is serving the logo in the top `MainNav` in order to comply with the a11y standards
 - added "aria-labeledby" attribute to the progressbars of the campaign cards on the homepage in order to comply with the a11y standards
- added "aria-label" attribute to the logo and the social links in the footer in order to comply with the a11y standards
- replace "ul" elements with "div" since those items don't contain any "li" elements, which makes it to report issues with the a11y standards

<!--- Any links to external sources of documentation -->
More details:
- https://dequeuniversity.com/rules/axe/4.4/link-name
- https://dequeuniversity.com/rules/axe/4.4/aria-progressbar-name
- https://dequeuniversity.com/rules/axe/4.4/button-name

## Screenshots:
As a result of the following changes,  the accessibility score for the homepage have been increased by 14%.

Before|After
---|---
![image](https://user-images.githubusercontent.com/1233496/205977228-3e07b623-10e6-4554-9825-159e4f08d5ee.png)|![image](https://user-images.githubusercontent.com/1233496/205977102-e4804a8f-1ce3-4fec-b460-549efdb354a7.png)

<!-- List of pages that are affected by the changes -->
The changes introduced within this PR affect the following pages:
- elements on the homepage
- footer elements which are visible on all pages

## Testing
I don't have setup for a screen reader on my local environment, so I checked manually for the presence of the a11y attributes in the code and the accessibility report created by the Lighthouse extension of the Google Chrome's DevTools.

### Steps to test
1. Open Chrome DevTools
2. Go to "Lighthouse" tab
3. Generate a new report including "Accessibility" analysys