### PR TITLE
extending campaign description

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@
 ## Perequisites
 
 - Node.js
-  - Installation 
+  - Installation
     - [Windows / MacOS](https://nodejs.org/en/download/)
     - [Debian and Ubuntu based Linux distributions](https://nodejs.org/en/download/package-manager/#debian-and-ubuntu-based-linux-distributions)
     ```shell
@@ -46,10 +46,10 @@
   - Installation https://yarnpkg.com/getting-started/install
   ```shell
   corepack enable
-  yarn set version berry 
+  yarn set version berry
   ```
   - make sure `cmdtest` is not installed, it has a different `yarn` command
-  
+
 ## Initial setup
 
 ```shell
@@ -98,7 +98,9 @@ Watch releases of this repository to be notified about future updates:
 ## Contributors ✨
 
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
+
 [![All Contributors](https://img.shields.io/badge/all_contributors-64-orange.svg?style=flat-square)](#contributors-)
+
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 
 Please check [contributors guide](https://github.com/podkrepi-bg/frontend/blob/master/CONTRIBUTING.md) for:

--- a/src/components/campaigns/CampaignForm.tsx
+++ b/src/components/campaigns/CampaignForm.tsx
@@ -50,7 +50,7 @@ const validationSchema: yup.SchemaOf<CampaignCreateFormData> = yup
   .defined()
   .shape({
     title: yup.string().trim().min(10).max(200).required(),
-    description: yup.string().trim().min(50).max(40000).required(),
+    description: yup.string().trim().min(50).max(60000).required(),
     targetAmount: yup.number().required(),
     allowDonationOnComplete: yup.bool().optional(),
     campaignTypeId: yup.string().uuid().required(),

--- a/src/components/campaigns/grid/CreateForm.tsx
+++ b/src/components/campaigns/grid/CreateForm.tsx
@@ -60,7 +60,7 @@ const validationSchema: yup.SchemaOf<CampaignAdminCreateFormData> = yup
   .defined()
   .shape({
     title: yup.string().trim().min(10).max(200).required(),
-    description: yup.string().trim().min(50).max(40000).required(),
+    description: yup.string().trim().min(50).max(60000).required(),
     targetAmount: yup.number().integer().positive().required(),
     allowDonationOnComplete: yup.bool().optional(),
     campaignTypeId: yup.string().uuid().required(),

--- a/src/components/campaigns/grid/EditForm.tsx
+++ b/src/components/campaigns/grid/EditForm.tsx
@@ -62,7 +62,7 @@ const validationSchema: yup.SchemaOf<Omit<CampaignEditFormData, 'campaignFiles'>
   .defined()
   .shape({
     title: yup.string().trim().min(10).max(200).required(),
-    description: yup.string().trim().min(50).max(40000).required(),
+    description: yup.string().trim().min(50).max(60000).required(),
     targetAmount: yup.number().integer().positive().required(),
     allowDonationOnComplete: yup.bool().optional(),
     campaignTypeId: yup.string().uuid().required(),

--- a/src/components/common/form/FormRichTextField.tsx
+++ b/src/components/common/form/FormRichTextField.tsx
@@ -70,6 +70,11 @@ export default function FormRichTextField({ name }: RegisterFormProps) {
           />
         )}
       </Field>
+      {meta.touched && meta.error && (
+        <Typography className="error" color="red">
+          {helperText}
+        </Typography>
+      )}
     </div>
   )
 }


### PR DESCRIPTION
It was reported the limit of 40k symbols is not enough so extending now.

- increased campaign description to 60K symbols
- added error helper on bottom of the richtexteditor too


