### PR TITLE
Fix Campaigns section max width and alignment on Homepage and Campaigns page

### DIFF
--- a/src/components/campaigns/CampaignsList.tsx
+++ b/src/components/campaigns/CampaignsList.tsx
@@ -37,6 +37,7 @@ export default function CampaignsList({ campaignToShow }: Props) {
     <Grid
       container
       justifyContent="center"
+      spacing={4}
       sx={(theme) => ({
         width: `calc(100% + ${theme.spacing(1.5)})`,
         marginLeft: `-${theme.spacing(2.75)}`,
@@ -46,8 +47,6 @@ export default function CampaignsList({ campaignToShow }: Props) {
           <Box
             sx={(theme) => ({
               textAlign: 'center',
-              marginLeft: '16px',
-              paddingLeft: theme.spacing(2),
               [theme.breakpoints.down('lg')]: { textAlign: cardAlignment(index, array) },
               [theme.breakpoints.down('md')]: { textAlign: 'center' },
             })}>

--- a/src/components/campaigns/CampaignsList.tsx
+++ b/src/components/campaigns/CampaignsList.tsx
@@ -36,9 +36,8 @@ export default function CampaignsList({ campaignToShow }: Props) {
   return (
     <Grid container justifyContent="center" spacing={2}>
       <Grid container justifyContent="center" spacing={2} ml={0}>
-        {/* <pre>{JSON.stringify(data, null, 2)}</pre> */}
         {campaigns?.map((campaign, index, array) => (
-          <Grid key={index} item xs={12} sm={8} md={6} lg={3}>
+          <Grid key={index} item xs={12} sm={6} lg={3}>
             <Box
               sx={(theme) => ({
                 textAlign: 'center',

--- a/src/components/campaigns/CampaignsList.tsx
+++ b/src/components/campaigns/CampaignsList.tsx
@@ -34,21 +34,27 @@ export default function CampaignsList({ campaignToShow }: Props) {
   }, [campaignToShow, all])
 
   return (
-    <Grid container justifyContent="center" spacing={2}>
-      <Grid container justifyContent="center" spacing={2} ml={0}>
-        {campaigns?.map((campaign, index, array) => (
-          <Grid key={index} item xs={12} sm={6} lg={3}>
-            <Box
-              sx={(theme) => ({
-                textAlign: 'center',
-                [theme.breakpoints.down('lg')]: { textAlign: cardAlignment(index, array) },
-                [theme.breakpoints.down('md')]: { textAlign: 'center' },
-              })}>
-              <CampaignCard campaign={campaign} />
-            </Box>
-          </Grid>
-        ))}
-      </Grid>
+    <Grid
+      container
+      justifyContent="center"
+      sx={(theme) => ({
+        width: `calc(100% + ${theme.spacing(1.5)})`,
+        marginLeft: `-${theme.spacing(2.75)}`,
+      })}>
+      {campaigns?.map((campaign, index, array) => (
+        <Grid key={index} item xs={12} sm={6} lg={3}>
+          <Box
+            sx={(theme) => ({
+              textAlign: 'center',
+              marginLeft: '16px',
+              paddingLeft: theme.spacing(2),
+              [theme.breakpoints.down('lg')]: { textAlign: cardAlignment(index, array) },
+              [theme.breakpoints.down('md')]: { textAlign: 'center' },
+            })}>
+            <CampaignCard campaign={campaign} />
+          </Box>
+        </Grid>
+      ))}
       {campaignToShow && campaignToShow?.length > numberOfMinimalShownCampaigns && (
         <Grid container justifyContent="center">
           <Button onClick={() => setAll((prev) => !prev)} variant="outlined" sx={{ mt: 1 }}>

--- a/src/components/campaigns/CampaignsPage.tsx
+++ b/src/components/campaigns/CampaignsPage.tsx
@@ -18,6 +18,17 @@ const classes = {
 }
 
 const Root = styled(Grid)(({ theme }) => ({
+  margin: theme.spacing(7, 3, 0, 3),
+
+  [theme.breakpoints.up('sm')]: {
+    margin: theme.spacing(12, 4, 0, 4),
+  },
+
+  [theme.breakpoints.up(2000)]: {
+    maxWidth: theme.spacing(165),
+    margin: `${theme.spacing(4)} auto`,
+  },
+
   [`& .${classes.title}`]: {
     marginBottom: theme.spacing(3),
     marginTop: theme.spacing(6),

--- a/src/components/campaigns/CampaignsPage.tsx
+++ b/src/components/campaigns/CampaignsPage.tsx
@@ -18,15 +18,17 @@ const classes = {
 }
 
 const Root = styled(Grid)(({ theme }) => ({
-  margin: theme.spacing(7, 3, 0, 3),
+  paddingTop: theme.spacing(7),
+  width: '100%',
+  margin: '0 auto',
 
   [theme.breakpoints.up('sm')]: {
-    margin: theme.spacing(12, 4, 0, 4),
+    paddingTop: theme.spacing(12),
   },
 
   [theme.breakpoints.up(2000)]: {
     maxWidth: theme.spacing(165),
-    margin: `${theme.spacing(4)} auto`,
+    paddingTop: theme.spacing(4),
   },
 
   [`& .${classes.title}`]: {

--- a/src/components/campaigns/CampaignsPage.tsx
+++ b/src/components/campaigns/CampaignsPage.tsx
@@ -1,9 +1,11 @@
 import React from 'react'
-import { styled } from '@mui/material/styles'
+
 import { useTranslation } from 'next-i18next'
-import Layout from 'components/layout/Layout'
-import { Container, Typography } from '@mui/material'
+import { Container, Grid, Typography } from '@mui/material'
+
 import CampaignFilter from './CampaignFilter'
+
+import { styled } from '@mui/material/styles'
 
 const PREFIX = 'CampaignsPage'
 
@@ -15,7 +17,7 @@ const classes = {
   arrowIcon: `${PREFIX}-arrowIcon`,
 }
 
-const StyledLayout = styled(Layout)(({ theme }) => ({
+const Root = styled(Grid)(({ theme }) => ({
   [`& .${classes.title}`]: {
     marginBottom: theme.spacing(3),
     marginTop: theme.spacing(6),
@@ -66,11 +68,8 @@ export default function CampaignsPage() {
   const { t } = useTranslation()
 
   return (
-    <StyledLayout
-      // sx={{ fontWeight: '500', color: '#2196F3' }}
-      // title={t('campaigns:campaigns')}
-      metaDescription={t('campaigns:campaign.subheading')}>
-      <Container maxWidth="lg">
+    <Root>
+      <Container maxWidth={false}>
         <Typography variant="h1" component="p" className={classes.title}>
           {t('campaigns:campaigns')}
         </Typography>
@@ -79,6 +78,6 @@ export default function CampaignsPage() {
         </Typography>
         <CampaignFilter />
       </Container>
-    </StyledLayout>
+    </Root>
   )
 }

--- a/src/components/index/sections/CampaignsSection/CampaignsSection.styled.tsx
+++ b/src/components/index/sections/CampaignsSection/CampaignsSection.styled.tsx
@@ -9,6 +9,11 @@ export const Root = styled('section')(() => ({
   [theme.breakpoints.up('sm')]: {
     margin: theme.spacing(12, 4, 0, 4),
   },
+
+  [theme.breakpoints.up(2000)]: {
+    maxWidth: theme.spacing(165),
+    margin: `${theme.spacing(4)} auto`,
+  },
 }))
 
 export const UrgentCampaignsHeading = styled(Typography)(() => ({


### PR DESCRIPTION
Fix Campaigns section max width and alignment on Homepage and Campaigns page to be identical and responsive for bigger screens.

## Screenshots:
Homepage:

![Screenshot 2023-01-25 112939](https://user-images.githubusercontent.com/14351733/214527623-eed62545-2f0d-4fea-b2a6-d09f8bc31f30.png)

![Screenshot 2023-01-25 113003](https://user-images.githubusercontent.com/14351733/214527640-6b6b4a82-c2c5-46fd-aa7d-362f90b35d3c.png)

Campaigns page:

![Screenshot 2023-01-25 112759](https://user-images.githubusercontent.com/14351733/214527804-a5968a4d-d9a7-4a66-8f33-06c55cb92fdf.png)

![Screenshot 2023-01-25 112732](https://user-images.githubusercontent.com/14351733/214527826-d08620a1-858e-4fd5-8c71-f9d7c10a4e03.png)
