### PR TITLE
put campaigns with status different than active at the bottom of the …

### DIFF
--- a/src/components/campaigns/CampaignFilter.tsx
+++ b/src/components/campaigns/CampaignFilter.tsx
@@ -76,7 +76,6 @@ export default function CampaignFilter() {
   const { mobile } = useMobile()
   const { data: campaigns, isLoading } = useCampaignList()
   const [selectedCategory, setSelectedCategory] = useState<string>('ALL')
-
   // TODO: add filters&sorting of campaigns so people can select based on personal preferences
   const campaignToShow = useMemo<CampaignResponse[]>(() => {
     const filteredCampaigns =

--- a/src/components/index/sections/CampaignsSection/CampaignsSection.tsx
+++ b/src/components/index/sections/CampaignsSection/CampaignsSection.tsx
@@ -12,7 +12,7 @@ import { Root, UrgentCampaignsHeading } from './CampaignsSection.styled'
 export default function CampaignsSection() {
   const { data } = useCampaignList()
   const { t } = useTranslation('index')
-
+  console.log(data)
   if (data === undefined) {
     return null
   } else {

--- a/src/components/index/sections/CampaignsSection/CampaignsSection.tsx
+++ b/src/components/index/sections/CampaignsSection/CampaignsSection.tsx
@@ -12,7 +12,6 @@ import { Root, UrgentCampaignsHeading } from './CampaignsSection.styled'
 export default function CampaignsSection() {
   const { data } = useCampaignList()
   const { t } = useTranslation('index')
-  console.log(data)
   if (data === undefined) {
     return null
   } else {

--- a/src/pages/campaigns/index.tsx
+++ b/src/pages/campaigns/index.tsx
@@ -3,16 +3,16 @@ import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
 import { dehydrate, QueryClient } from '@tanstack/react-query'
 
 import CampaignsPage from 'components/campaigns/CampaignsPage'
+import { campaignsOrderQueryFunction } from 'common/hooks/campaigns'
 import { prefetchCampaignTypesList } from 'service/campaignTypes'
 import { endpoints } from 'service/apiEndpoints'
-import { queryFnFactory } from 'service/restRequests'
 import { CampaignResponse } from 'gql/campaigns'
 
 export const getServerSideProps: GetServerSideProps = async (params) => {
   const client = new QueryClient()
   await client.prefetchQuery<CampaignResponse[]>(
     [endpoints.campaign.listCampaigns.url],
-    queryFnFactory<CampaignResponse[]>(),
+    campaignsOrderQueryFunction,
   )
   await prefetchCampaignTypesList(client)
   return {

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -3,12 +3,12 @@ import { GetServerSideProps } from 'next'
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
 import { QueryClient } from '@tanstack/react-query'
 
+import IndexPage from 'components/index/IndexPage'
+import { campaignsOrderQueryFunction } from 'common/hooks/campaigns'
 import { CampaignResponse } from 'gql/campaigns'
 import { endpoints } from 'service/apiEndpoints'
-import IndexPage from 'components/index/IndexPage'
 
 import { authOptions } from './api/auth/[...nextauth]'
-import { queryFnFactory } from 'service/restRequests'
 
 export const getServerSideProps: GetServerSideProps<{
   session: Session | null
@@ -16,7 +16,7 @@ export const getServerSideProps: GetServerSideProps<{
   const client = new QueryClient()
   await client.prefetchQuery<CampaignResponse[]>(
     [endpoints.campaign.listCampaigns.url],
-    queryFnFactory<CampaignResponse[]>(),
+    campaignsOrderQueryFunction,
   )
 
   //For getting session on server side the docs recommend using unstable_getServerSession as per


### PR DESCRIPTION
## Motivation and context

We had requests from people that it's confusing to shuffle in the closed campaigns with the active ones.

I kept the logic of the shuffling, but put everything that is with state !== active to the bottom of the list.

<img width="1076" alt="image" src="https://user-images.githubusercontent.com/61479393/214651514-3afd95f2-1722-4a19-9066-73b2ebedec95.png">


