### PR TITLE
Added startupProbe for Kubernetes

### DIFF
--- a/manifests/base/deployment.yaml
+++ b/manifests/base/deployment.yaml
@@ -143,3 +143,11 @@ spec:
               port: 3040
             initialDelaySeconds: 5
             periodSeconds: 5
+          startupProbe:
+            httpGet:
+              path: /api/healthcheck
+              port: 3040
+            failureThreshold: 12
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 1


### PR DESCRIPTION
## Motivation and context
Recently some deployments were failing on readiness healthcheck with 503 service not available.
To give more time to start, this PR adds startupProbe with up to 2min (12 attempts per 10sec) before enabling the readiness and startup probes.

