### PR TITLE
 Change formula to calculate Stripe's fee

### DIFF
--- a/src/test/helpers/stripe-fee-calculator.test.ts
+++ b/src/test/helpers/stripe-fee-calculator.test.ts
@@ -1,0 +1,51 @@
+import { CardRegion } from 'gql/donations.enums'
+import {
+  stripeFeeCalculator,
+  stripeIncludeFeeCalculator,
+} from 'components/one-time-donation/helpers/stripe-fee-calculator'
+
+describe("Calculating total charged amount with Stripe's fee included", () => {
+  //Total amount of donation in stotinki, BGN 1 = 100 stotinki
+  const donationAmount = 2000
+
+  test('Calculating total charge for EU issued cards', () => {
+    const totalCharge = stripeIncludeFeeCalculator(donationAmount, CardRegion.EU) / 100
+    const formattedResult = totalCharge.toFixed(2)
+    expect(formattedResult).toMatch('20.75')
+  })
+
+  test('Calculating total charge for UK issued cards', () => {
+    const totalCharge = stripeIncludeFeeCalculator(donationAmount, CardRegion.UK) / 100
+    const formattedResult = totalCharge.toFixed(2)
+    expect(formattedResult).toMatch('21.03')
+  })
+
+  test('Calculating total charge for Other issued cards', () => {
+    const totalCharge = stripeIncludeFeeCalculator(donationAmount, CardRegion.Other) / 100
+    const formattedResult = totalCharge.toFixed(2)
+    expect(formattedResult).toMatch('21.11')
+  })
+})
+
+describe("Calculating Stripe's fee for different regions", () => {
+  //Total amount of donation in stotinki, BGN 1 = 100 stotinki
+  const donationAmount = 2000
+
+  test("Calculating Stripe's fee for EU issued cards", () => {
+    const stripeFee = stripeFeeCalculator(donationAmount, CardRegion.EU) / 100
+    const formattedResult = stripeFee.toFixed(2)
+    expect(formattedResult).toMatch('0.74')
+  })
+
+  test("Calculating Stripe's fee for UK issued cards", () => {
+    const stripeFee = stripeFeeCalculator(donationAmount, CardRegion.UK) / 100
+    const formattedResult = stripeFee.toFixed(2)
+    expect(formattedResult).toMatch('1.00')
+  })
+
+  test("Calculating Stripe's fee for Other issued cards", () => {
+    const stripeFee = stripeFeeCalculator(donationAmount, CardRegion.Other) / 100
+    const formattedResult = stripeFee.toFixed(2)
+    expect(formattedResult).toMatch('1.08')
+  })
+})


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!--- If it fixes an open issue, please link to the issue here. -->
Closes #1358 

## Motivation and context
This PR closes the above mentioned issue, which results to a better user experience.


## Testing

### Steps to test
1. Switch between wanting to cover and not wanting to cover the fee. Stripe's fee should be the same.

### Affected urls
campaigns/donation/{slug}


## Note
In case of a merge the appropriate change should also be done to the [backend](https://github.com/podkrepi-bg/api/blob/f11d5223a991af47e68b953c16161ca6ccf1c3ad/apps/api/src/donations/helpers/stripe-fee-calculator.ts#L50)

