### PR TITLE
MenuItems fields in manual donation are not responsive

### DIFF
--- a/src/components/admin/donations/AddBankTransactionsFileForm.tsx
+++ b/src/components/admin/donations/AddBankTransactionsFileForm.tsx
@@ -160,7 +160,7 @@ export default function BankTransactionsFileForm({
             />
           </Grid>
           <Grid item xs={12}>
-            <Link href={routes.admin.campaigns.index} passHref>
+            <Link href={routes.admin.donations.index} passHref>
               <Button fullWidth={true}>{t('donations:cta:cancel')}</Button>
             </Link>
           </Grid>

--- a/src/components/admin/donations/Form.tsx
+++ b/src/components/admin/donations/Form.tsx
@@ -145,7 +145,7 @@ export default function EditForm() {
                 label={t('donations:type')}
                 id="type"
                 name="type"
-                value={initialValues.type}
+                value={type}
                 onChange={(e) => setType(e.target.value)}
                 disabled={id ? true : false}>
                 {validDonationTypes.map((type) => {
@@ -166,7 +166,7 @@ export default function EditForm() {
                 label={t('donations:status')}
                 id="status"
                 name="status"
-                value={initialValues.status}
+                value={status}
                 onChange={(e) => {
                   setStatus(e.target.value)
                 }}>
@@ -188,7 +188,7 @@ export default function EditForm() {
                 label={t('donations:provider')}
                 id="provider"
                 name="provider"
-                value={initialValues.provider}
+                value={provider}
                 onChange={(e) => setProvider(e.target.value)}
                 disabled={id ? true : false}>
                 {validProviders.map((prov) => {
@@ -209,7 +209,7 @@ export default function EditForm() {
                 label={t('donations:vault')}
                 id="targetVaultId"
                 name="targetVaultId"
-                value={initialValues.targetVaultId}
+                value={vault}
                 onChange={(e) => setVault(e.target.value)}
                 disabled={id ? true : false}>
                 {vaults?.map((vault) => {
@@ -262,7 +262,7 @@ export default function EditForm() {
                 label={t('donations:currency')}
                 id="currency"
                 name="currency"
-                value={initialValues.currency}
+                value={currency}
                 onChange={(e) => setCurrency(e.target.value)}
                 disabled={id ? true : false}>
                 {validCurrencies.map((currency) => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
- MenuItems Fields in `admin/donations/create` page are not responsive. When button in the admin menu for manual donation page is clicked nothing happens.
- File bank uploads routes user to the campaign page instead of the donation page when it is canceled. In my opinion this is not intuitive . This PR fixes the route.
## Screenshots:

<!-- You can copy/paste screenshots directly in the editor -->
Currently, the value doesn't change when someone clicks on it:

<img width="1124" alt="Screenshot 2023-02-24 at 23 21 10" src="https://user-images.githubusercontent.com/44066540/221295441-79cc6fe5-4e97-4f7e-a88f-a701bcb0a09c.png">

<img width="1214" alt="Screenshot 2023-02-24 at 23 21 56" src="https://user-images.githubusercontent.com/44066540/221295549-de4643b8-f096-4ad9-ab61-c2917f10bcec.png">

After the change, clicking on the element now changes the value:

<img width="1391" alt="Screenshot 2023-02-24 at 23 19 23" src="https://user-images.githubusercontent.com/44066540/221295142-33f969eb-a5fe-40a6-a699-fe9cb28dec7d.png">
<img width="1380" alt="Screenshot 2023-02-24 at 23 20 16" src="https://user-images.githubusercontent.com/44066540/221295297-8cac017e-ffc5-437c-ac0e-a34be740b434.png">




