### PR TITLE
Add createAt field for manual donation

### DIFF
--- a/src/components/admin/donations/Form.tsx
+++ b/src/components/admin/donations/Form.tsx
@@ -13,6 +13,7 @@ import {
   InputLabel,
   MenuItem,
   Select,
+  TextField,
   Typography,
 } from '@mui/material'
 
@@ -26,6 +27,9 @@ import { DonationInput, DonationResponse } from 'gql/donations'
 import { useDonation } from 'common/hooks/donation'
 import { useCreateDonation, useEditDonation } from 'service/donation'
 import { useVaultsList } from 'common/hooks/vaults'
+import { DateTimePicker, LocalizationProvider } from '@mui/x-date-pickers'
+import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns'
+import { bg, enUS } from 'date-fns/locale'
 
 const validDonationTypes = ['donation']
 const validDonationStatuses = [
@@ -48,13 +52,14 @@ const validationSchema = yup.object().defined().shape({
 })
 
 export default function EditForm() {
+  const { t, i18n } = useTranslation()
   const [type, setType] = useState('donation')
   const [status, setStatus] = useState('initial')
   const [provider, setProvider] = useState('none')
   const [currency, setCurrency] = useState('')
   const [vault, setVault] = useState('')
+  const [date, setToDate] = React.useState<Date | null>(new Date())
   const router = useRouter()
-  const { t } = useTranslation()
 
   let id = router.query.id
 
@@ -66,6 +71,7 @@ export default function EditForm() {
     provider: 'none',
     currency: '',
     amount: 0,
+    createdAt: new Date(),
     targetVaultId: '',
     extCustomerId: '',
     extPaymentIntentId: '',
@@ -81,6 +87,7 @@ export default function EditForm() {
         type: data?.type.toString(),
         status: data?.status.toString(),
         provider: data?.provider.toString(),
+        createdAt: data?.createdAt,
         currency: data?.currency.toString(),
         amount: data?.amount,
         targetVaultId: data?.targetVaultId,
@@ -202,6 +209,18 @@ export default function EditForm() {
             </FormControl>
           </Grid>
           <Grid item xs={6}>
+            <LocalizationProvider
+              adapterLocale={i18n.language === 'bg' ? bg : enUS}
+              dateAdapter={AdapterDateFns}>
+              <DateTimePicker
+                label={t('donations:created-at')}
+                value={date}
+                onChange={setToDate}
+                renderInput={(params) => <TextField size="small" {...params} />}
+              />
+            </LocalizationProvider>
+          </Grid>
+          <Grid item xs={6}>
             <FormControl fullWidth size="small">
               <InputLabel id="labelVault">{t('donations:vault')}</InputLabel>
               <Select
@@ -222,7 +241,7 @@ export default function EditForm() {
               </Select>
             </FormControl>
           </Grid>
-          <Grid item xs={12}>
+          <Grid item xs={6}>
             <FormTextField
               type="text"
               label={t('donations:ext-customer-id')}
@@ -280,7 +299,7 @@ export default function EditForm() {
           </Grid>
           <Grid item xs={6}>
             <Link passHref href={routes.admin.donations.index}>
-              <Button>{t('donations:cta:cancel')}</Button>
+              <Button fullWidth>{t('donations:cta:cancel')}</Button>
             </Link>
           </Grid>
         </Grid>

--- a/src/gql/donations.d.ts
+++ b/src/gql/donations.d.ts
@@ -64,6 +64,7 @@ export type DonationInput = {
   status: string
   provider: string
   currency: string
+  createdAt: Date
   amount: number
   targetVaultId: UUID
   extCustomerId: string


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This PR address this comment  https://github.com/podkrepi-bg/api/pull/447/files#r1114709693
In order to unify CreateBankPaymentDto and CreateManyBankPaymentsDto in the backend, I had added createdAt field in manual donation.
API change: https://github.com/podkrepi-bg/api/pull/451
Before
<img width="1698" alt="Screenshot 2023-03-04 at 9 11 24" src="https://user-images.githubusercontent.com/44066540/222881597-bfe6ebed-f8d2-4aa8-9758-1e7b7687f99d.png">

After:
<img width="1677" alt="Screenshot 2023-03-04 at 9 10 17" src="https://user-images.githubusercontent.com/44066540/222881560-159003e2-fd69-4c65-b227-08a1da23366c.png">
