### PR TITLE
Update the year in the Footer

### DIFF
--- a/public/locales/bg/common.json
+++ b/public/locales/bg/common.json
@@ -73,7 +73,7 @@
       "faq": "Често задавани въпроси",
       "privacy-policy": "Защита на лични данни",
       "terms-of-service": "Общи условия",
-      "copyrights": "Podkrepi.bg ©2022 Всички права запазени.",
+      "copyrights": "Podkrepi.bg ©2023 Всички права запазени.",
       "hosting-partner": "Хостинг партньор:",
       "social": {
         "facebook": "Facebook",

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -72,7 +72,7 @@
       "faq": "Frequently asked questions",
       "privacy-policy": "Privacy Policy",
       "terms-of-service": "Terms of Service",
-      "copyrights": "Podkrepi.bg ©2022 All rights reserved.",
+      "copyrights": "Podkrepi.bg ©2023 All rights reserved.",
       "hosting-partner": "Hosting partner:",
       "partners": "Partners",
       "social": {


### PR DESCRIPTION
Updated the year in the Footer from 2022 to 2023 for BG and EN:

## Screenshots:

<!-- You can copy/paste screenshots directly in the editor -->

Before|After
---|---
![image](https://user-images.githubusercontent.com/14351733/223762293-5b21217b-ddc2-4080-8678-cb2a85d88c6a.png)|![Screenshot 2023-03-08 175101](https://user-images.githubusercontent.com/14351733/223761705-95bf7585-232e-4566-9b0c-96240d0d1793.png)

