### PR TITLE
stripe-connection-bug - add retry logic to the donation mutation

### DIFF
--- a/src/common/hooks/donation.ts
+++ b/src/common/hooks/donation.ts
@@ -35,6 +35,13 @@ export function useDonationSession() {
     mutationFn: createCheckoutSession,
     onError: () => AlertStore.show(t('common:alerts.error'), 'error'),
     onSuccess: () => AlertStore.show(t('common:alerts.message-sent'), 'success'),
+    retry(failureCount, error) {
+      if (failureCount < 4) {
+        return true
+      }
+      return false
+    },
+    retryDelay: 1000,
   })
   return mutation
 }


### PR DESCRIPTION
## Motivation and context

Since there are problems with connection to Stripe and sometimes 2 or 3 requests are required before a checkout session is created successfully ([detailed issue here](https://github.com/podkrepi-bg/api/issues/463)), retry logic would be useful.

## Testing
Tested with a failed request locally and the logic works as described in the `retry` method

### Affected urls
`/campaigns/donation/{slug}`
