### PR TITLE
one-time-donation/Steps.tsx: Fix isAnonymous initial value

### DIFF
--- a/src/components/client/one-time-donation/Steps.tsx
+++ b/src/components/client/one-time-donation/Steps.tsx
@@ -67,7 +67,6 @@ export default function DonationStepper({ onStepChange }: DonationStepperProps) 
     return session && session.accessToken ? true : false
   }
 
-  initialValues.isAnonymous = !isLogged()
   initialValues.isRecurring = false
 
   const userEmail = session?.user?.email


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!--- If it fixes an open issue, please link to the issue here. -->
Closes #1133 

## Motivation and context
Due to the inverting the result of isLogged(), the initial value of isAnonymous is always true, when user is not logged in. 

