### PR TITLE
Admin user not treated as such on the frontend

### DIFF
--- a/src/common/util/roles.ts
+++ b/src/common/util/roles.ts
@@ -53,7 +53,7 @@ export const canViewSupporters = (sessionRoles: SessionRoles): boolean => {
 }
 
 export const isAdmin = (session: Session | JWT | null): boolean => {
-  if (session && session.user && session.user.resource_access && session.user.realm_access) {
+  if (session && session.user) {
     const sessionRoles: SessionRoles = {
       realmRoles: session.user?.realm_access.roles ?? [],
       resourceRoles: session.user?.resource_access?.account.roles ?? [],


### PR DESCRIPTION
The restrictions were too tight and we were not considering an admin user as such in some cases.
We can have resource_access OR realm_access and still be an admin.
