### PR TITLE
Campaign expenses improvement

### DIFF
--- a/src/common/util/expenseFileUrls.ts
+++ b/src/common/util/expenseFileUrls.ts
@@ -1,0 +1,7 @@
+import getConfig from 'next/config'
+
+const { publicRuntimeConfig } = getConfig()
+
+export function expenseFileUrl(fileId:string) {
+  return `${publicRuntimeConfig.API_URL}/expenses/download-file/${fileId}`
+}

--- a/src/common/util/expenseFileUrls.ts
+++ b/src/common/util/expenseFileUrls.ts
@@ -2,6 +2,6 @@ import getConfig from 'next/config'
 
 const { publicRuntimeConfig } = getConfig()
 
-export function expenseFileUrl(fileId:string) {
+export function expenseFileUrl(fileId: string) {
   return `${publicRuntimeConfig.API_URL}/expenses/download-file/${fileId}`
 }

--- a/src/components/client/campaigns/CampaignPublicExpensesGrid.tsx
+++ b/src/components/client/campaigns/CampaignPublicExpensesGrid.tsx
@@ -8,9 +8,7 @@ import { useCampaignApprovedExpensesList } from 'common/hooks/expenses'
 import { moneyPublic } from 'common/util/money'
 import { ModalStoreImpl } from 'stores/dashboard/ModalStore'
 import { ExpenseFile } from 'gql/expenses'
-import { Button, Tooltip } from '@mui/material'
-import { downloadCampaignExpenseFile } from 'service/expense'
-import { useSession } from 'next-auth/react'
+import { Button, Grid, Tooltip } from '@mui/material'
 import FilePresentIcon from '@mui/icons-material/FilePresent'
 import Link from 'next/link'
 import { expenseFileUrl } from 'common/util/expenseFileUrls'
@@ -27,22 +25,18 @@ const classes = {
 export const ModalStore = new ModalStoreImpl()
 
 // TODO jss-to-styled codemod: The Fragment root was replaced by div. Change the tag if needed.
-const Root = styled('div')({
+const Root = styled(Grid)({
   [`& .${classes.grid}`]: {
-    marginBottom: 15,
+    fontSize: 14,
     border: 'none',
-    '& .MuiDataGrid-virtualScroller': {
-      overflow: 'hidden',
-    },
     '& .MuiDataGrid-footerContainer': {
       marginTop: '30px',
       marginRight: '40px',
     },
-    fontSize: '12px',
   },
   [`& .${classes.gridColumn}`]: {
     '& .MuiDataGrid-columnHeaderTitle': {
-      fontSize: '14px',
+      fontSize: 14,
       fontWeight: '700',
     },
   },
@@ -53,20 +47,6 @@ export default observer(function CampaignPublicExpensesGrid({ slug }: Props) {
   const { data: expensesList } = useCampaignApprovedExpensesList(slug)
 
   const [pageSize, setPageSize] = React.useState<number>(20)
-  const { data: session } = useSession()
-
-  const downloadExpenseFileHandler = async (file: ExpenseFile) => {
-    downloadCampaignExpenseFile(file.id, session)
-      .then((response) => {
-        const url = window.URL.createObjectURL(new Blob([response.data]))
-        const link = document.createElement('a')
-        link.href = url
-        link.target = '_blank'
-        link.download = file.filename
-        link.click()
-      })
-      .catch((error) => console.error(error))
-  }
 
   const columns: GridColumns = [
     { field: 'id', headerName: 'ID', hide: true },
@@ -74,7 +54,7 @@ export default observer(function CampaignPublicExpensesGrid({ slug }: Props) {
       field: 'type',
       headerName: t('expenses:fields.type'),
       headerClassName: classes.gridColumn,
-      width: 120,
+      minWidth: 120,
       renderCell: (params: GridRenderCellParams): React.ReactNode => {
         return t('expenses:field-types.' + params.row.type)
       },
@@ -84,7 +64,8 @@ export default observer(function CampaignPublicExpensesGrid({ slug }: Props) {
       headerName: t('expenses:fields.amount'),
       headerClassName: classes.gridColumn,
       align: 'right',
-      width: 120,
+      flex: 1,
+      minWidth: 115,
       renderCell: (params: GridRenderCellParams): React.ReactNode => {
         if (!params.row.amount) {
           return '0'
@@ -98,13 +79,14 @@ export default observer(function CampaignPublicExpensesGrid({ slug }: Props) {
       headerName: t('expenses:fields.description'),
       headerClassName: classes.gridColumn,
       flex: 2,
+      minWidth: 300,
     },
     {
       field: 'spentAt',
       headerName: t('expenses:fields.date'),
       headerClassName: classes.gridColumn,
-      width: 30,
       flex: 1,
+      minWidth: 80,
       renderCell: (params: GridRenderCellParams): React.ReactNode => {
         if (!params.row.spentAt) {
           return ''
@@ -118,19 +100,20 @@ export default observer(function CampaignPublicExpensesGrid({ slug }: Props) {
       headerName: t('expenses:fields.attached-files'),
       headerClassName: classes.gridColumn,
       flex: 1,
+      minWidth: 180,
       renderCell: (params: GridRenderCellParams) => {
         const rows = params.row.expenseFiles.map((file: ExpenseFile) => {
           return (
             <Tooltip key={file.id} title={file.filename}>
-              <Link href={expenseFileUrl(file.id)} target='_blank' passHref>
-                <Button>
-                <FilePresentIcon />
+              <Link href={expenseFileUrl(file.id)} target="_blank" passHref>
+                <Button sx={{ minWidth: 0, py: 0, px: 1, paddingBottom: 1 }}>
+                  <FilePresentIcon />
                 </Button>
               </Link>
             </Tooltip>
           )
         })
-        return <div>{rows}</div>
+        return <Grid>{rows}</Grid>
       },
     },
   ]
@@ -148,6 +131,20 @@ export default observer(function CampaignPublicExpensesGrid({ slug }: Props) {
         autoHeight
         disableSelectionOnClick
         getRowHeight={() => 'auto'}
+        sx={{
+          '.MuiDataGrid-cell': {
+            alignItems: 'flex-start',
+          },
+          '&.MuiDataGrid-root--densityCompact .MuiDataGrid-cell': {
+            py: '8px',
+          },
+          '&.MuiDataGrid-root--densityStandard .MuiDataGrid-cell': {
+            paddingTop: '17px',
+          },
+          '&.MuiDataGrid-root--densityComfortable .MuiDataGrid-cell': {
+            py: '22px',
+          },
+        }}
       />
     </Root>
   )

--- a/src/components/client/campaigns/CampaignPublicExpensesGrid.tsx
+++ b/src/components/client/campaigns/CampaignPublicExpensesGrid.tsx
@@ -12,6 +12,8 @@ import { Button, Tooltip } from '@mui/material'
 import { downloadCampaignExpenseFile } from 'service/expense'
 import { useSession } from 'next-auth/react'
 import FilePresentIcon from '@mui/icons-material/FilePresent'
+import Link from 'next/link'
+import { expenseFileUrl } from 'common/util/expenseFileUrls'
 
 const PREFIX = 'Grid'
 
@@ -120,9 +122,11 @@ export default observer(function CampaignPublicExpensesGrid({ slug }: Props) {
         const rows = params.row.expenseFiles.map((file: ExpenseFile) => {
           return (
             <Tooltip key={file.id} title={file.filename}>
-              <Button onClick={() => downloadExpenseFileHandler(file)}>
+              <Link href={expenseFileUrl(file.id)} target='_blank' passHref>
+                <Button>
                 <FilePresentIcon />
-              </Button>
+                </Button>
+              </Link>
             </Tooltip>
           )
         })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!--- If it fixes an open issue, please link to the issue here. -->
Closes #1417 

## Motivation and context
This PR contains changes which would allow to open the expense file in new tab, rather than download it, as well as:
-Significantly improves the the overall expense grid layout.
-Fixes an issue on smaller viewports which makes the cell's overlapping with one another.
-Fixes an issue where the expense description is clipped, on smaller viewports.

## Screenshots:

<!-- You can copy/paste screenshots directly in the editor -->

Before|After
---|---
![image](https://github.com/podkrepi-bg/frontend/assets/27433690/d970ab1a-3f3a-4554-b3fa-9566bbe18555)|![image](https://github.com/podkrepi-bg/frontend/assets/27433690/6a0bc6da-4cea-455f-a661-792b0ffa2f20)


<!-- List of pages that are affected by the changes -->

## Testing

### Steps to test

### Affected urls

<!--- Specify test requirements (environment, dependencies, design reviews) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include links to the related pages -->
<!--- Include details of your testing environment -->
<!--- Impact of your change to other areas of the code -->

## Environment

### New environment variables:

<!-- Mark with [x] when variable is added to `.env.local.example`  -->

- [ ] `NEW_ENV_VAR`: env var details

### New or updated dependencies:

<!-- including dev dependencies -->

Dependency name|Previous version|Updated version|Details
---|---|---|---
`dependency/name`|`v1.0.0`|`v2.0.0`|

