### PR TITLE
reduce statistics size by asking only one donation from history

### DIFF
--- a/src/components/client/index/sections/PlatformStatisticsSection/Statistics/Statistics.tsx
+++ b/src/components/client/index/sections/PlatformStatisticsSection/Statistics/Statistics.tsx
@@ -17,7 +17,7 @@ import {
 export default function Statistics() {
   const { t } = useTranslation('index')
   const { data: campaigns } = useCampaignList()
-  const { data: totalDonations } = useCampaignDonationHistory()
+  const { data: totalDonations } = useCampaignDonationHistory(undefined, 0, 1) //ask only for 1 item to get the total count
   const { data: donorsCount } = useDonatedUsersCount()
   const { data: totalDonatedMoney } = getTotalDonatedMoney()
 


### PR DESCRIPTION
## Motivation and context
Getting total count of donation was loading all of them on frontend.
Now optimized by asking only for 1 donation, which still returns totals.



