### PR TITLE
temporary switched off donation notification popups

### DIFF
--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -19,11 +19,12 @@ import 'styles/global.scss'
 
 import { Provider } from 'mobx-react'
 import { stores } from 'stores/DomainStores/stores'
-import NotificationSnackBar from 'components/client/layout/NotificationSnackBar/NotificationSnackBar'
-import {
-  globalSnackbarProps,
-  globalSnackbarContentProps,
-} from 'components/client/layout/NotificationSnackBar/props/global'
+// switching off the Donation notification popups temporarily to compare memory use with and without them
+// import NotificationSnackBar from 'components/client/layout/NotificationSnackBar/NotificationSnackBar'
+// import {
+//   globalSnackbarProps,
+//   globalSnackbarContentProps,
+// } from 'components/client/layout/NotificationSnackBar/props/global'
 
 // Client-side cache, shared for the whole session of the user in the browser.
 const clientSideEmotionCache = createEmotionCache()
@@ -99,10 +100,11 @@ function CustomApp({
             <Hydrate state={dehydratedState}>
               <Provider {...stores}>
                 <Component {...pageProps} />
+                {/* Switching off the Donation notification popups temporarily to compare memory use
                 <NotificationSnackBar
                   mainProps={globalSnackbarProps}
                   contentProps={globalSnackbarContentProps}
-                />
+                /> */}
               </Provider>
             </Hydrate>
           </QueryClientProvider>


### PR DESCRIPTION
## Motivation and context
We want to measure the memory use of the donation notification popups when using socket io.
Switching them off now. 

