### PR TITLE
notificationClient: Establish ws connection only on client render

### DIFF
--- a/src/common/util/notificationClient.ts
+++ b/src/common/util/notificationClient.ts
@@ -4,6 +4,7 @@ import { io } from 'socket.io-client'
 const { publicRuntimeConfig } = getConfig()
 const notificationClient = io(publicRuntimeConfig.API_URL, {
   transports: ['websocket'],
+  autoConnect: false,
 })
 
 export default notificationClient

--- a/src/components/client/layout/NotificationSnackBar/NotificationSnackBar.tsx
+++ b/src/components/client/layout/NotificationSnackBar/NotificationSnackBar.tsx
@@ -21,6 +21,7 @@ function NotificationSnackBar({
   const [notifications, setNotifications] = useState<NotificationLayoutData[]>([])
 
   useEffect(() => {
+    if (!notificationClient.connected) notificationClient.connect()
     notificationClient.on('successfulDonation', (notificationData: NotificationLayoutData) => {
       setNotifications((prevState) => [...prevState, notificationData])
     })

--- a/src/components/client/layout/NotificationSnackBar/NotificationSnackBar.tsx
+++ b/src/components/client/layout/NotificationSnackBar/NotificationSnackBar.tsx
@@ -9,6 +9,7 @@ import {
 import DonationNotificationLayout from './DonationNotificationLayout'
 import { NotificationLayoutData } from 'components/client/layout/NotificationSnackBar/DonationNotificationLayout'
 import notificationClient from 'common/util/notificationClient'
+import { useIsWindowInFocus } from 'service/visibilityApi'
 
 function NotificationSnackBar({
   mainProps,
@@ -19,9 +20,14 @@ function NotificationSnackBar({
 }) {
   const [open, setOpen] = useState(true)
   const [notifications, setNotifications] = useState<NotificationLayoutData[]>([])
+  const isWindowInFocus = useIsWindowInFocus()
 
   useEffect(() => {
-    if (!notificationClient.connected) notificationClient.connect()
+    if (isWindowInFocus && !notificationClient.connected) notificationClient.connect()
+    if (!isWindowInFocus && notificationClient.connected) {
+      notificationClient.disconnect()
+      return
+    }
     notificationClient.on('successfulDonation', (notificationData: NotificationLayoutData) => {
       setNotifications((prevState) => [...prevState, notificationData])
     })
@@ -29,7 +35,7 @@ function NotificationSnackBar({
     return () => {
       notificationClient.off('successfulDonation')
     }
-  }, [])
+  }, [isWindowInFocus])
 
   const handleSnackBarClose = (
     _event: React.SyntheticEvent | Event,

--- a/src/service/visibilityApi.ts
+++ b/src/service/visibilityApi.ts
@@ -1,0 +1,18 @@
+import { useState, useEffect } from 'react'
+export function useIsWindowInFocus() {
+  const [isWindowInFocus, setIsWindowInFocus] = useState(true)
+
+  function handleVisibilityChange() {
+    setIsWindowInFocus(!document.hidden)
+  }
+
+  useEffect(() => {
+    document.addEventListener('visibilitychange', handleVisibilityChange)
+
+    return () => {
+      document.removeEventListener('visibilitychange', handleVisibilityChange)
+    }
+  }, [])
+
+  return isWindowInFocus
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!--- If it fixes an open issue, please link to the issue here. -->
Closes #1454 

## Motivation and context

The current websocket configuration, creates a new websocket client, for every SSR generated page. Since those clients are technically active, they are never cleaned up, thus resulting in memory leak. This change makes it so, a new web socket connection is created only on first render of the component.


## Testing

### Steps to test
1. Start visiting different pages randomly
2. Observe the current websocket clients, in the Socket object _(you can console.log the client arg from [handleConnection](https://github.com/podkrepi-bg/api/blob/master/apps/api/src/sockets/notifications/gateway.ts#L21))_ . The total amount of active clients can be found in Socket.adapters.sids
3. The size of sids should remain 1, per browser window


