### PR TITLE
Datagrid: Hide id fields after datagrid v6 update

### DIFF
--- a/src/components/admin/InfoRequestGrid.tsx
+++ b/src/components/admin/InfoRequestGrid.tsx
@@ -44,6 +44,9 @@ export default function InfoRequestGrid() {
     <DataGrid
       rows={data || []}
       columns={columns}
+      columnVisibilityModel={{
+        id: false,
+      }}
       paginationModel={paginationModel}
       onPaginationModelChange={setPaginationModel}
       autoHeight

--- a/src/components/admin/SupportersGrid.tsx
+++ b/src/components/admin/SupportersGrid.tsx
@@ -78,6 +78,9 @@ export default function SupportersGrid() {
     <DataGrid
       rows={data || []}
       columns={columns}
+      columnVisibilityModel={{
+        id: false,
+      }}
       paginationModel={paginationModel}
       onPaginationModelChange={setPaginationModel}
       autoHeight

--- a/src/components/admin/cities/grid/CityGrid.tsx
+++ b/src/components/admin/cities/grid/CityGrid.tsx
@@ -77,6 +77,9 @@ export default observer(function CitiesGrid() {
         }}
         rows={data || []}
         columns={columns}
+        columnVisibilityModel={{
+          id: false,
+        }}
         paginationModel={paginationModel}
         onPaginationModelChange={setPaginationModel}
         editMode="row"

--- a/src/components/admin/countries/grid/CountryGrid.tsx
+++ b/src/components/admin/countries/grid/CountryGrid.tsx
@@ -89,6 +89,9 @@ export default observer(function Grid() {
           }}
           rows={data || []}
           columns={columns}
+          columnVisibilityModel={{
+            id: false,
+          }}
           pageSizeOptions={[5, 10]}
           paginationModel={paginationModel}
           onPaginationModelChange={setPaginationModel}

--- a/src/components/admin/donations/grid/Grid.tsx
+++ b/src/components/admin/donations/grid/Grid.tsx
@@ -237,6 +237,9 @@ export default observer(function Grid() {
           }}
           rows={donations || []}
           columns={columns}
+          columnVisibilityModel={{
+            id: false,
+          }}
           pageSizeOptions={[5, 10, 20]}
           paginationModel={paginationModel}
           onPaginationModelChange={setPaginationModel}

--- a/src/components/admin/expenses/grid/Grid.tsx
+++ b/src/components/admin/expenses/grid/Grid.tsx
@@ -134,6 +134,9 @@ export default observer(function Grid() {
         className={classes.grid}
         rows={data || []}
         columns={columns}
+        columnVisibilityModel={{
+          id: false,
+        }}
         paginationModel={paginationModel}
         onPaginationModelChange={setPaginationModel}
         pageSizeOptions={[5, 10]}

--- a/src/components/admin/irregularity/admin/grid/Grid.tsx
+++ b/src/components/admin/irregularity/admin/grid/Grid.tsx
@@ -137,6 +137,9 @@ export default observer(function Grid() {
           }}
           rows={data || []}
           columns={columns}
+          columnVisibilityModel={{
+            id: false,
+          }}
           paginationModel={paginationModel}
           onPaginationModelChange={setPaginationModel}
           autoHeight

--- a/src/components/admin/organizers/grid/Grid.tsx
+++ b/src/components/admin/organizers/grid/Grid.tsx
@@ -86,6 +86,9 @@ export default observer(function Grid() {
           }}
           rows={data || []}
           columns={columns}
+          columnVisibilityModel={{
+            id: false,
+          }}
           pageSizeOptions={[5, 10]}
           paginationModel={paginationModel}
           onPaginationModelChange={setPaginationModel}

--- a/src/components/admin/transfers/grid/Grid.tsx
+++ b/src/components/admin/transfers/grid/Grid.tsx
@@ -141,6 +141,9 @@ export default observer(function Grid() {
           }}
           rows={data || []}
           columns={columns}
+          columnVisibilityModel={{
+            id: false,
+          }}
           pageSizeOptions={[5, 10]}
           paginationModel={paginationModel}
           onPaginationModelChange={setPaginationModel}

--- a/src/components/client/campaigns/CampaignPublicExpensesGrid.tsx
+++ b/src/components/client/campaigns/CampaignPublicExpensesGrid.tsx
@@ -126,6 +126,9 @@ export default observer(function CampaignPublicExpensesGrid({ slug }: Props) {
         className={classes.grid}
         rows={expensesList || []}
         columns={columns}
+        columnVisibilityModel={{
+          id: false,
+        }}
         pageSizeOptions={[20, 40, 60]}
         paginationModel={paginationModel}
         onPaginationModelChange={setPaginationModel}

--- a/src/components/common/person/grid/Grid.tsx
+++ b/src/components/common/person/grid/Grid.tsx
@@ -95,6 +95,9 @@ export default observer(function Grid() {
           }}
           rows={data || []}
           columns={columns}
+          columnVisibilityModel={{
+            id: false,
+          }}
           pageSizeOptions={[5, 10]}
           paginationModel={paginationModel}
           onPaginationModelChange={setPaginationModel}


### PR DESCRIPTION
## Motivation and context
Prior to updating the datagrid package, some tables hid the id field. This commit brings back this behavior


