### PR TITLE
Add UI fixes on campaign cards on Homepage

### DIFF
--- a/src/components/client/index/sections/ActiveCampaignsSection/ActiveCampaignCard/ActiveCampaignCard.styled.tsx
+++ b/src/components/client/index/sections/ActiveCampaignsSection/ActiveCampaignCard/ActiveCampaignCard.styled.tsx
@@ -79,8 +79,6 @@ export const CampaignProgressWrapper = styled(Grid)(() => ({
 }))
 
 export const StyledCardActions = styled(CardActions)(() => ({
-  display: 'flex',
-  justifyContent: 'space-between',
   padding: theme.spacing(1, 0),
 }))
 

--- a/src/components/client/index/sections/ActiveCampaignsSection/ActiveCampaignCard/ActiveCampaignCard.tsx
+++ b/src/components/client/index/sections/ActiveCampaignsSection/ActiveCampaignCard/ActiveCampaignCard.tsx
@@ -40,9 +40,12 @@ export default function ActiveCampaignCard({ campaign, index }: Props) {
         image={campaignImagesUrl}
         alt={title}
         sx={{
+          maxHeight: theme.spacing(42.5),
+
           [theme.breakpoints.up('lg')]: {
             aspectRatio: '2',
             height: theme.spacing(22.5),
+            maxHeight: 'inherit',
           },
         }}
       />


### PR DESCRIPTION
- Align action buttons to the left.
- Reduce campaign card height for larger mobile devices (540px).

![image](https://github.com/podkrepi-bg/frontend/assets/14351733/e2a51ba6-91a4-41ea-adb6-c6978f46368c)
