### PR TITLE
miu-DataGrid: Remove conflicting properties when using DataGrid

### DIFF
--- a/src/components/admin/AdminPage.tsx
+++ b/src/components/admin/AdminPage.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react'
 import { useRouter } from 'next/router'
 import { useTranslation } from 'next-i18next'
 import { useSession } from 'next-auth/react'
-import { Box, Card, CardActionArea, CardContent, Grid, Typography } from '@mui/material'
+import { Box, Card, CardContent, Grid, Typography } from '@mui/material'
 
 import { isAdmin } from 'common/util/roles'
 import AdminLayout from 'components/common/navigation/AdminLayout'

--- a/src/components/admin/InfoRequestGrid.tsx
+++ b/src/components/admin/InfoRequestGrid.tsx
@@ -50,7 +50,6 @@ export default function InfoRequestGrid() {
       paginationModel={paginationModel}
       onPaginationModelChange={setPaginationModel}
       autoHeight
-      autoPageSize
       disableRowSelectionOnClick
       onRowClick={(p, event) => {
         const elm = event.target as HTMLInputElement

--- a/src/components/admin/SupportersGrid.tsx
+++ b/src/components/admin/SupportersGrid.tsx
@@ -84,7 +84,6 @@ export default function SupportersGrid() {
       paginationModel={paginationModel}
       onPaginationModelChange={setPaginationModel}
       autoHeight
-      autoPageSize
       disableRowSelectionOnClick
       onRowClick={(p, event) => {
         const elm = event.target as HTMLInputElement

--- a/src/components/admin/bankaccounts/grid/BankAccountsGrid.tsx
+++ b/src/components/admin/bankaccounts/grid/BankAccountsGrid.tsx
@@ -79,8 +79,6 @@ export default observer(function BankAccountsGrid() {
         pageSizeOptions={[5, 10]}
         paginationModel={paginationModel}
         onPaginationModelChange={setPaginationModel}
-        autoHeight
-        autoPageSize
         disableRowSelectionOnClick
       />
 

--- a/src/components/admin/benefactor/grid/Grid.tsx
+++ b/src/components/admin/benefactor/grid/Grid.tsx
@@ -84,8 +84,6 @@ export default observer(function Grid() {
           pageSizeOptions={[5, 10]}
           paginationModel={paginationModel}
           onPaginationModelChange={setPaginationModel}
-          autoHeight
-          autoPageSize
           disableRowSelectionOnClick
         />
       </Box>

--- a/src/components/admin/cities/grid/CityGrid.tsx
+++ b/src/components/admin/cities/grid/CityGrid.tsx
@@ -83,8 +83,6 @@ export default observer(function CitiesGrid() {
         paginationModel={paginationModel}
         onPaginationModelChange={setPaginationModel}
         editMode="row"
-        autoHeight
-        autoPageSize
         disableRowSelectionOnClick
       />
 

--- a/src/components/admin/coordinators/grid/CoordinatorsGrid.tsx
+++ b/src/components/admin/coordinators/grid/CoordinatorsGrid.tsx
@@ -79,8 +79,6 @@ export default function CoordinatorsGrid() {
         pageSizeOptions={[5, 10]}
         paginationModel={paginationModel}
         onPaginationModelChange={setPaginationModel}
-        autoHeight
-        autoPageSize
         disableRowSelectionOnClick
       />
 

--- a/src/components/client/auth/profile/MyCampaignsTable.tsx
+++ b/src/components/client/auth/profile/MyCampaignsTable.tsx
@@ -254,7 +254,6 @@ export default function MyCampaingsTable() {
               initialState={{ pagination: { paginationModel: { pageSize: 5 } } }}
               editMode="row"
               autoHeight
-              autoPageSize
             />
           </ProfileTab>
         </>

--- a/src/components/client/auth/profile/MyDonatedToCampaignsTable.tsx
+++ b/src/components/client/auth/profile/MyDonatedToCampaignsTable.tsx
@@ -194,7 +194,6 @@ export default function MyDonatedToCampaignTable() {
           initialState={{ pagination: { paginationModel: { pageSize: 5 } } }}
           editMode="row"
           autoHeight
-          autoPageSize
         />
       ) : (
         <Box sx={{ fontSize: 20 }}>{t('profile:donations.noDonations')}</Box>

--- a/src/components/client/auth/profile/MyRecurringCampaignsTable.tsx
+++ b/src/components/client/auth/profile/MyRecurringCampaignsTable.tsx
@@ -136,7 +136,6 @@ export default function MyRecurringCampaignsTable() {
           initialState={{ pagination: { paginationModel: { pageSize: 5 } } }}
           editMode="row"
           autoHeight
-          autoPageSize
         />
       ) : (
         <Box sx={{ fontSize: 20 }}>{t('profile:donations.recurringDonations')}</Box>


### PR DESCRIPTION
autoHeight and autoPageSize shouldn't be used at the same time. By doing so this causes the data grid to constantly rerender 
ref: https://mui.com/x/react-data-grid/pagination/#automatic-page-size

Closes #1497 