### PR TITLE
Open Partners' websites and Articles in new tabs

### DIFF
--- a/src/components/client/index/sections/MediaSection/MediaSection.styled.tsx
+++ b/src/components/client/index/sections/MediaSection/MediaSection.styled.tsx
@@ -1,5 +1,5 @@
 import theme from 'common/theme'
-import Link from 'components/common/Link'
+import ExternalLink from 'components/common/ExternalLink'
 import Slider from 'react-slick'
 
 import { styled } from '@mui/material/styles'
@@ -34,7 +34,7 @@ export const CarouselWrapper = styled(Slider)(() => ({
   },
 }))
 
-export const ArticleLink = styled(Link)(() => ({
+export const ArticleLink = styled(ExternalLink)(() => ({
   display: 'flex',
   alignItems: 'center',
   background: theme.palette.background.default,

--- a/src/components/client/index/sections/PartnersSection/PartnersSection.styled.tsx
+++ b/src/components/client/index/sections/PartnersSection/PartnersSection.styled.tsx
@@ -1,5 +1,5 @@
 import theme from 'common/theme'
-import Link from 'components/common/Link'
+import ExternalLink from 'components/common/ExternalLink'
 
 import { styled } from '@mui/material/styles'
 
@@ -9,7 +9,7 @@ export const Root = styled('section')(() => ({
   marginTop: theme.spacing(12),
 }))
 
-export const PartnerLink = styled(Link)(() => ({
+export const PartnerLink = styled(ExternalLink)(() => ({
   display: 'flex',
   alignItems: 'center',
   filter: 'grayscale(80%)',


### PR DESCRIPTION
Replaced Link with ExternalLink in order to open in new tabs partners' websites on Partners carousel and articles on Media carousel.