### PR TITLE
Fix image path of crossRoad partner

### DIFF
--- a/src/components/admin/partners/helpers/partnersData.ts
+++ b/src/components/admin/partners/helpers/partnersData.ts
@@ -126,7 +126,7 @@ export const allPartners = [
   },
   {
     name: 'crossroadsBulgaria',
-    image: '/img/partners/crossroads.svg',
+    image: '/img/partners/crossRoads.svg',
     website: partnerUrls.crossroadsBulgaria,
   },
 ]


### PR DESCRIPTION
Closes https://github.com/podkrepi-bg/frontend/issues/1501 

The image was not displayed correctly due to a wrong path.

https://podkrepi.bg/img/partners/crossroads.svg - unavailable
https://podkrepi.bg/img/partners/crossRoads.svg - available