### PR TITLE
[TEMP] Signout user on unauthorized response

### DIFF
--- a/src/common/util/useCurrentPerson.ts
+++ b/src/common/util/useCurrentPerson.ts
@@ -20,13 +20,14 @@ export function getCurrentPerson(isNew = false) {
   return useQuery<CurrentPerson, AxiosError>(
     [isNew ? endpoints.account.new.url : endpoints.account.me.url],
     authQueryFnFactory<CurrentPerson>(session?.accessToken),
-    {retry: (count, err) => {
-      if(err.isAxiosError && err.response?.status === 401) {
-        return false
-      }
-      return true
-    }}
-    
+    {
+      retry: (count, err) => {
+        if (err.isAxiosError && err.response?.status === 401) {
+          return false
+        }
+        return true
+      },
+    },
   )
 }
 

--- a/src/common/util/useCurrentPerson.ts
+++ b/src/common/util/useCurrentPerson.ts
@@ -1,4 +1,4 @@
-import { AxiosResponse } from 'axios'
+import { AxiosError, AxiosResponse } from 'axios'
 import { useQuery } from '@tanstack/react-query'
 import { useSession } from 'next-auth/react'
 
@@ -17,9 +17,16 @@ type CurrentPerson = {
 
 export function getCurrentPerson(isNew = false) {
   const { data: session } = useSession()
-  return useQuery<CurrentPerson>(
+  return useQuery<CurrentPerson, AxiosError>(
     [isNew ? endpoints.account.new.url : endpoints.account.me.url],
     authQueryFnFactory<CurrentPerson>(session?.accessToken),
+    {retry: (count, err) => {
+      if(err.isAxiosError && err.response?.status === 401) {
+        return false
+      }
+      return true
+    }}
+    
   )
 }
 

--- a/src/components/client/auth/profile/ProfilePage.tsx
+++ b/src/components/client/auth/profile/ProfilePage.tsx
@@ -2,7 +2,7 @@ import { Box, LinearProgress, useMediaQuery } from '@mui/material'
 import { styled } from '@mui/material/styles'
 import Tab from '@mui/material/Tab'
 import Tabs from '@mui/material/Tabs'
-import React, { useEffect, useMemo, useRef } from 'react'
+import React, { useMemo } from 'react'
 import { useRouter } from 'next/router'
 import { useTranslation } from 'next-i18next'
 import {
@@ -47,16 +47,13 @@ const StyledLayout = styled(Layout)({
 export default function ProfilePage() {
   const { t } = useTranslation()
   const { status } = useSession()
-  const timeoutRef = useRef<null | ReturnType<typeof setTimeout>>(null);
 
   const router = useRouter()
   const matches = useMediaQuery(theme.breakpoints.down('sm'))
   const currentTab = router.query.slug ?? ProfileTabs.donations
 
-  const { data: user, error:userError, isError } = getCurrentPerson(!!router.query?.register)
+  const { error: userError, isError } = getCurrentPerson(!!router.query?.register)
 
-
-  
   const tab = useMemo<ProfileTab>(() => {
     return tabs.find((tab) => tab.slug === currentTab) ?? tabs[0]
   }, [currentTab])
@@ -69,10 +66,13 @@ export default function ProfilePage() {
     return <StyledLayout title={t('nav.profile')}>Not authenticated</StyledLayout>
   }
 
-
-  if(isError && (userError.response && userError.response.status === 401)){
+  if (isError && userError.response && userError.response.status === 401) {
     signOut()
-    return <StyledLayout title={t('nav.profile')}>The user session has expired. Redirecting to login page</StyledLayout>
+    return (
+      <StyledLayout title={t('nav.profile')}>
+        The user session has expired. Redirecting to login page
+      </StyledLayout>
+    )
   }
 
   const { Component: SelectedTab } = tab

--- a/src/components/client/auth/profile/ProfilePage.tsx
+++ b/src/components/client/auth/profile/ProfilePage.tsx
@@ -12,7 +12,7 @@ import {
   AccountBalance as CampaignIcon,
   EventRepeat as RecurringDonationIcon,
 } from '@mui/icons-material'
-import { signOut, useSession } from 'next-auth/react'
+import { useSession } from 'next-auth/react'
 
 import theme from 'common/theme'
 import { routes } from 'common/routes'
@@ -67,7 +67,6 @@ export default function ProfilePage() {
   }
 
   if (isError && userError.response && userError.response.status === 401) {
-    signOut()
     return (
       <StyledLayout title={t('nav.profile')}>
         The user session has expired. Redirecting to login page


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
In some cases the keycloak session expires before the client session, which results in user not being able to access account's data such as donations and profile information.

Note: 
We should probably re-think how to handle the client sessions better, but until then this should do.

Closes Reported in discord

## Testing


### Steps to test
1.Login in the [local enviroment](http://localhost:3040/login)
2. Go to [local keycloak server](http://localhost:8180/auth/) -> Administration Console ->Credentials should be user:admin, pw:admin ->webapp
3. Go to Session and click Logout All
4. Return to the logged user in [podkrepi.bg local enviroment](http://localhost:3040)
5. User should be logged out, due to session expiration

