### PR TITLE
[TEMP] Don't show successfull tag if campaign has not reached 100%

### DIFF
--- a/src/components/client/campaigns/CampaignCard.tsx
+++ b/src/components/client/campaigns/CampaignCard.tsx
@@ -22,6 +22,7 @@ import Link from 'next/link'
 import CampaignProgress from './CampaignProgress'
 import SuccessfullCampaignTag from './SuccessfullCampaignTag'
 import { CampaignState } from './helpers/campaign.enums'
+import { useMemo } from 'react'
 
 const PREFIX = 'CampaignCard'
 
@@ -120,6 +121,7 @@ export default function CampaignCard({ campaign, index }: Props) {
 
   const pictureUrl = campaignListPictureUrl(campaign)
   const reached = summary ? summary.reachedAmount : 0
+  const percentage = useMemo(() => (reached / target) * 100, [reached, target])
 
   return (
     <StyledCard variant="outlined" className={classes.cardWrapper}>
@@ -131,7 +133,11 @@ export default function CampaignCard({ campaign, index }: Props) {
           <div
             style={{ position: 'relative', width: '100%', minHeight: '100%', maxHeight: '100%' }}>
             <Image alt={title} src={pictureUrl} fill style={{ objectFit: 'contain' }} />
-            {campaignState === CampaignState.complete ? <SuccessfullCampaignTag /> : ''}
+            {campaignState === CampaignState.complete && percentage >= 100 ? (
+              <SuccessfullCampaignTag />
+            ) : (
+              ''
+            )}
           </div>
         </CardMedia>
         <CardContent className={classes.cardContent}>

--- a/src/components/client/index/sections/CompletedCampaignsSection/CompletedCampaignsSection.tsx
+++ b/src/components/client/index/sections/CompletedCampaignsSection/CompletedCampaignsSection.tsx
@@ -31,7 +31,9 @@ export default function CompletedCampaignsSection() {
   const { data } = useCampaignList()
 
   const completedCampaigns = data?.filter(
-    (campaign: CampaignResponse) => campaign.state === CampaignState.complete,
+    (campaign: CampaignResponse) =>
+      campaign.state === CampaignState.complete &&
+      (campaign.summary.reachedAmount / campaign.targetAmount) * 100 >= 100,
   )
 
   const onLinkMouseDown = (e: React.ChangeEvent<unknown>) => {


### PR DESCRIPTION
## Motivation and context
In some cases campaigns are marked as completed, due to their end date being reached, while the target amount has not been raised. 
This commit checks if the target amount has been raised, before showing the successfull tag.

Note:
This is a temporary solution until, a more descriptive campaign statuses are implemented.
