### PR TITLE
SQUASH: Campaign news layout improvements

### DIFF
--- a/src/common/util/htmlSanitizer.ts
+++ b/src/common/util/htmlSanitizer.ts
@@ -1,5 +1,0 @@
-import DOMPurify from 'dompurify'
-
-export function sanitizeHTML(htmlContent: string): string {
-  return DOMPurify.sanitize(htmlContent)
-}

--- a/src/common/util/htmlUtils.ts
+++ b/src/common/util/htmlUtils.ts
@@ -1,7 +1,7 @@
 import DOMPurify from 'dompurify'
 
 export function sanitizeHTML(htmlContent: string): string {
-  return DOMPurify.sanitize(htmlContent, {ADD_TAGS:['iframe']})
+  return DOMPurify.sanitize(htmlContent, { ADD_TAGS: ['iframe'] })
 }
 
 /**
@@ -9,18 +9,17 @@ export function sanitizeHTML(htmlContent: string): string {
  * @param htmlContent The html content as string
  * @returns iframe HTML as string, sanitized HTML content as a string
  */
-export function HTMLContentSeparator(htmlContent: string, separateIframe:boolean = false) {
+export function HTMLContentSeparator(htmlContent: string, separateIframe = false) {
   const parser = new DOMParser()
-  const articleDescription = sanitizeHTML(htmlContent);
+  const articleDescription = sanitizeHTML(htmlContent)
   const html = parser.parseFromString(articleDescription, 'text/html')
   const articleVideo = html.body.querySelector('.ql-video')
-  articleVideo?.setAttribute('loading', "lazy");
+  articleVideo?.setAttribute('loading', 'lazy')
 
-  if(separateIframe && articleVideo) {
+  if (separateIframe && articleVideo) {
     html.body.removeChild(articleVideo)
     return [articleVideo.outerHTML, html.body.outerHTML]
   }
-  
-  return ['', html.body.outerHTML]
 
+  return ['', html.body.outerHTML]
 }

--- a/src/common/util/htmlUtils.ts
+++ b/src/common/util/htmlUtils.ts
@@ -1,0 +1,26 @@
+import DOMPurify from 'dompurify'
+
+export function sanitizeHTML(htmlContent: string): string {
+  return DOMPurify.sanitize(htmlContent, {ADD_TAGS:['iframe']})
+}
+
+/**
+ * Extracts the iframe video, sanitizes the HTML input
+ * @param htmlContent The html content as string
+ * @returns iframe HTML as string, sanitized HTML content as a string
+ */
+export function HTMLContentSeparator(htmlContent: string, separateIframe:boolean = false) {
+  const parser = new DOMParser()
+  const articleDescription = sanitizeHTML(htmlContent);
+  const html = parser.parseFromString(articleDescription, 'text/html')
+  const articleVideo = html.body.querySelector('.ql-video')
+  articleVideo?.setAttribute('loading', "lazy");
+
+  if(separateIframe && articleVideo) {
+    html.body.removeChild(articleVideo)
+    return [articleVideo.outerHTML, html.body.outerHTML]
+  }
+  
+  return ['', html.body.outerHTML]
+
+}

--- a/src/components/client/campaign-news/CampaignNewsList.tsx
+++ b/src/components/client/campaign-news/CampaignNewsList.tsx
@@ -81,7 +81,7 @@ type Props = {
 
 export default function CampaignNewsList({ articles }: Props) {
   const { t, i18n } = useTranslation('news')
-  const INITIAL_HEIGHT_LIMIT = 300
+  const INITIAL_HEIGHT_LIMIT = 400
   const [isExpanded, expandContent] = useShowMoreContent()
 
   return (

--- a/src/components/client/campaign-news/CampaignNewsList.tsx
+++ b/src/components/client/campaign-news/CampaignNewsList.tsx
@@ -15,6 +15,7 @@ import { GetArticleDocuments, GetArticleGalleryPhotos } from 'common/util/newsFi
 import { useShowMoreContent } from './hooks/useShowMoreContent'
 import { HTMLContentSeparator } from 'common/util/htmlUtils'
 import { QuillStypeWrapper } from 'components/common/QuillStyleWrapper'
+import { scrollToTop } from './utils/scrollToTop'
 
 const PREFIX = 'CampaignNewsSection'
 const classes = {
@@ -81,10 +82,9 @@ export default function CampaignNewsList({ articles }: Props) {
   const { t, i18n } = useTranslation('news')
   const CHARACTER_LIMIT = 400
   const [isExpanded, expandContent] = useShowMoreContent()
-
   return (
     <>
-      {articles?.map((article, index) => {
+      {articles?.map((article, index: number) => {
         const documents = GetArticleDocuments(article.newsFiles)
         const images = GetArticleGalleryPhotos(article.newsFiles)
         const [, sanitizedDescription] = HTMLContentSeparator(article.description)
@@ -97,7 +97,7 @@ export default function CampaignNewsList({ articles }: Props) {
               borderBottom: 1,
               borderColor: index % 2 === 0 ? '#FFFFFF' : '#C4C4C4',
             }}>
-            <ArticleSection>
+            <ArticleSection id={article.id}>
               <Grid container columnGap={2} rowGap={1} className={classes.dateAndAuthorContainer}>
                 <Grid container item gap={1} xs="auto">
                   <AvTimerIcon color="primary" />
@@ -153,7 +153,10 @@ export default function CampaignNewsList({ articles }: Props) {
                 <Button
                   key={article.id}
                   className={classes.readMoreButton}
-                  onClick={() => expandContent(article.id)}
+                  onClick={(e) => {
+                    expandContent(article.id)
+                    scrollToTop(article.id)
+                  }}
                   sx={{ background: 'transperent', width: '100%' }}>
                   {!isExpanded[article.id] ? `${t('read-more')} >` : `${t('read-less')} <`}
                 </Button>

--- a/src/components/client/campaign-news/CampaignNewsList.tsx
+++ b/src/components/client/campaign-news/CampaignNewsList.tsx
@@ -1,7 +1,5 @@
 import { Button, Grid, Link, Typography } from '@mui/material'
 
-import 'react-quill/dist/quill.bubble.css'
-
 import { CampaignNewsResponse } from 'gql/campaign-news'
 
 import { styled } from '@mui/material/styles'

--- a/src/components/client/campaign-news/CampaignNewsList.tsx
+++ b/src/components/client/campaign-news/CampaignNewsList.tsx
@@ -14,6 +14,7 @@ import Image from 'next/image'
 import { GetArticleDocuments, GetArticleGalleryPhotos } from 'common/util/newsFilesUrls'
 import { useShowMoreContent } from './hooks/useShowMoreContent'
 import { sanitizeHTML } from 'common/util/htmlSanitizer'
+import { QuillStypeWrapper } from 'components/common/QuillStyleWrapper'
 
 const PREFIX = 'CampaignNewsSection'
 const classes = {
@@ -75,7 +76,7 @@ const ArticleSection = styled(Grid)(({ theme }) => ({
     margin: 0,
   },
 
-  [`div.${classes.articleDescription} > p`]: {
+  [`& .${classes.articleDescription}`]: {
     margin: 0,
   },
 }))
@@ -127,7 +128,7 @@ export default function CampaignNewsList({ articles }: Props) {
                   xs={'auto'}
                   style={{ maxWidth: '100%' }}>
                   <Typography className={classes.articleHeader}>{article.title}</Typography>
-                  <Grid container item>
+                  <QuillStypeWrapper>
                     {!isExpanded[article.id] && sanitizedDescription.length > CHARACTER_LIMIT ? (
                       <Typography
                         component={'div'}
@@ -150,7 +151,7 @@ export default function CampaignNewsList({ articles }: Props) {
                         {!isExpanded[article.id] ? `${t('read-more')} >` : `${t('read-less')} <`}
                       </Button>
                     )}
-                  </Grid>
+                  </QuillStypeWrapper>
                   <Grid container item direction={'column'} gap={0.5}>
                     {documents.map((file) => (
                       <Grid item key={file.id}>

--- a/src/components/client/campaign-news/CampaignNewsList.tsx
+++ b/src/components/client/campaign-news/CampaignNewsList.tsx
@@ -58,7 +58,6 @@ const ArticleSection = styled(Grid)(({ theme }) => ({
     fontWeight: 700,
   },
 
-
   [`& .${classes.dateAndAuthorContainer}`]: {
     marginBottom: theme.spacing(2),
   },
@@ -70,7 +69,7 @@ const ArticleSection = styled(Grid)(({ theme }) => ({
     padding: 0,
     margin: 0,
     position: 'relative',
-    bottom:5
+    bottom: 5,
   },
 }))
 
@@ -88,7 +87,7 @@ export default function CampaignNewsList({ articles }: Props) {
       {articles?.map((article, index) => {
         const documents = GetArticleDocuments(article.newsFiles)
         const images = GetArticleGalleryPhotos(article.newsFiles)
-        const [,sanitizedDescription] = HTMLContentSeparator(article.description)
+        const [, sanitizedDescription] = HTMLContentSeparator(article.description)
         return (
           <Grid
             container
@@ -97,8 +96,7 @@ export default function CampaignNewsList({ articles }: Props) {
               backgroundColor: index % 2 === 0 ? '#FFFFFF' : '#E3E3E3',
               borderBottom: 1,
               borderColor: index % 2 === 0 ? '#FFFFFF' : '#C4C4C4',
-            }}
-            >
+            }}>
             <ArticleSection>
               <Grid container columnGap={2} rowGap={1} className={classes.dateAndAuthorContainer}>
                 <Grid container item gap={1} xs="auto">
@@ -114,20 +112,20 @@ export default function CampaignNewsList({ articles }: Props) {
                 </Grid>
               </Grid>
               <Grid container rowGap={1} columnGap={4}>
-                <Grid
-                  container
-                  item
-                  direction={'column'}
-                  gap={1}
-                  >
+                <Grid container item direction={'column'} gap={1}>
                   <Typography className={classes.articleHeader}>{article.title}</Typography>
                   <QuillStypeWrapper>
-                      <Typography
-                        component={'div'}                 
-                        className={classes.articleDescription}
-                        dangerouslySetInnerHTML={{ __html: !isExpanded[article.id] && sanitizedDescription.length > CHARACTER_LIMIT ? sanitizedDescription.slice(0, CHARACTER_LIMIT) + "..." : sanitizedDescription }}
-                        sx={{wordBreak: 'break-word'}}
-                        />
+                    <Typography
+                      component={'div'}
+                      className={classes.articleDescription}
+                      dangerouslySetInnerHTML={{
+                        __html:
+                          !isExpanded[article.id] && sanitizedDescription.length > CHARACTER_LIMIT
+                            ? sanitizedDescription.slice(0, CHARACTER_LIMIT) + '...'
+                            : sanitizedDescription,
+                      }}
+                      sx={{ wordBreak: 'break-word' }}
+                    />
                   </QuillStypeWrapper>
                   <Grid container item direction={'column'} gap={0.5}>
                     {documents.map((file) => (
@@ -151,15 +149,15 @@ export default function CampaignNewsList({ articles }: Props) {
                   </Grid>
                 )}
               </Grid>
-                {sanitizedDescription.length > CHARACTER_LIMIT && (
-                  <Button
+              {sanitizedDescription.length > CHARACTER_LIMIT && (
+                <Button
                   key={article.id}
-                    className={classes.readMoreButton}
-                    onClick={(e) => expandContent(article.id)}
-                    sx={{background: 'transperent',width: '100%'}}>
-                    {!isExpanded[article.id] ? `${t('read-more')} >` : `${t('read-less')} <`}
-                  </Button>
-                )}
+                  className={classes.readMoreButton}
+                  onClick={() => expandContent(article.id)}
+                  sx={{ background: 'transperent', width: '100%' }}>
+                  {!isExpanded[article.id] ? `${t('read-more')} >` : `${t('read-less')} <`}
+                </Button>
+              )}
             </ArticleSection>
           </Grid>
         )

--- a/src/components/client/campaign-news/CampaignNewsList.tsx
+++ b/src/components/client/campaign-news/CampaignNewsList.tsx
@@ -13,7 +13,7 @@ import { useTranslation } from 'react-i18next'
 import Image from 'next/image'
 import { GetArticleDocuments, GetArticleGalleryPhotos } from 'common/util/newsFilesUrls'
 import { useShowMoreContent } from './hooks/useShowMoreContent'
-import { sanitizeHTML } from 'common/util/htmlSanitizer'
+import { HTMLContentSeparator } from 'common/util/htmlUtils'
 import { QuillStypeWrapper } from 'components/common/QuillStyleWrapper'
 
 const PREFIX = 'CampaignNewsSection'
@@ -32,7 +32,6 @@ const ArticleSection = styled(Grid)(({ theme }) => ({
   paddingRight: theme.spacing(7),
   paddingTop: theme.spacing(2),
   paddingBottom: theme.spacing(2),
-
   [`& .${classes.articlepublishedDate}`]: {
     fontSize: theme.typography.pxToRem(14),
     fontWeight: 400,
@@ -59,10 +58,6 @@ const ArticleSection = styled(Grid)(({ theme }) => ({
     fontWeight: 700,
   },
 
-  [`& .${classes.articleDescription}`]: {
-    fontSize: theme.typography.pxToRem(16),
-    fontFamily: theme.typography.fontFamily,
-  },
 
   [`& .${classes.dateAndAuthorContainer}`]: {
     marginBottom: theme.spacing(2),
@@ -74,10 +69,8 @@ const ArticleSection = styled(Grid)(({ theme }) => ({
     textDecoration: 'underline',
     padding: 0,
     margin: 0,
-  },
-
-  [`& .${classes.articleDescription}`]: {
-    margin: 0,
+    position: 'relative',
+    bottom:5
   },
 }))
 
@@ -95,7 +88,7 @@ export default function CampaignNewsList({ articles }: Props) {
       {articles?.map((article, index) => {
         const documents = GetArticleDocuments(article.newsFiles)
         const images = GetArticleGalleryPhotos(article.newsFiles)
-        const sanitizedDescription = sanitizeHTML(article.description)
+        const [,sanitizedDescription] = HTMLContentSeparator(article.description)
         return (
           <Grid
             container
@@ -104,7 +97,8 @@ export default function CampaignNewsList({ articles }: Props) {
               backgroundColor: index % 2 === 0 ? '#FFFFFF' : '#E3E3E3',
               borderBottom: 1,
               borderColor: index % 2 === 0 ? '#FFFFFF' : '#C4C4C4',
-            }}>
+            }}
+            >
             <ArticleSection>
               <Grid container columnGap={2} rowGap={1} className={classes.dateAndAuthorContainer}>
                 <Grid container item gap={1} xs="auto">
@@ -125,32 +119,15 @@ export default function CampaignNewsList({ articles }: Props) {
                   item
                   direction={'column'}
                   gap={1}
-                  xs={'auto'}
-                  style={{ maxWidth: '100%' }}>
+                  >
                   <Typography className={classes.articleHeader}>{article.title}</Typography>
                   <QuillStypeWrapper>
-                    {!isExpanded[article.id] && sanitizedDescription.length > CHARACTER_LIMIT ? (
                       <Typography
-                        component={'div'}
+                        component={'div'}                 
                         className={classes.articleDescription}
-                        dangerouslySetInnerHTML={{
-                          __html: sanitizedDescription.slice(0, CHARACTER_LIMIT) + '...',
-                        }}
-                      />
-                    ) : (
-                      <Typography
-                        component={'div'}
-                        className={classes.articleDescription}
-                        dangerouslySetInnerHTML={{ __html: sanitizedDescription }}
-                      />
-                    )}
-                    {sanitizedDescription.length > CHARACTER_LIMIT && (
-                      <Button
-                        className={classes.readMoreButton}
-                        onClick={() => expandContent(article.id)}>
-                        {!isExpanded[article.id] ? `${t('read-more')} >` : `${t('read-less')} <`}
-                      </Button>
-                    )}
+                        dangerouslySetInnerHTML={{ __html: !isExpanded[article.id] && sanitizedDescription.length > CHARACTER_LIMIT ? sanitizedDescription.slice(0, CHARACTER_LIMIT) + "..." : sanitizedDescription }}
+                        sx={{wordBreak: 'break-word'}}
+                        />
                   </QuillStypeWrapper>
                   <Grid container item direction={'column'} gap={0.5}>
                     {documents.map((file) => (
@@ -174,6 +151,15 @@ export default function CampaignNewsList({ articles }: Props) {
                   </Grid>
                 )}
               </Grid>
+                {sanitizedDescription.length > CHARACTER_LIMIT && (
+                  <Button
+                  key={article.id}
+                    className={classes.readMoreButton}
+                    onClick={(e) => expandContent(article.id)}
+                    sx={{background: 'transperent',width: '100%'}}>
+                    {!isExpanded[article.id] ? `${t('read-more')} >` : `${t('read-less')} <`}
+                  </Button>
+                )}
             </ArticleSection>
           </Grid>
         )

--- a/src/components/client/campaign-news/CampaignNewsList.tsx
+++ b/src/components/client/campaign-news/CampaignNewsList.tsx
@@ -79,7 +79,7 @@ type Props = {
 
 export default function CampaignNewsList({ articles }: Props) {
   const { t, i18n } = useTranslation('news')
-  const CHARACTER_LIMIT = 350
+  const CHARACTER_LIMIT = 400
   const [isExpanded, expandContent] = useShowMoreContent()
 
   return (

--- a/src/components/client/campaign-news/CampaignNewsList.tsx
+++ b/src/components/client/campaign-news/CampaignNewsList.tsx
@@ -16,6 +16,7 @@ import { useShowMoreContent } from './hooks/useShowMoreContent'
 import { HTMLContentSeparator } from 'common/util/htmlUtils'
 import { QuillStypeWrapper } from 'components/common/QuillStyleWrapper'
 import { scrollToTop } from './utils/scrollToTop'
+import { getArticleHeight } from './utils/getArticleHeight'
 
 const PREFIX = 'CampaignNewsSection'
 const classes = {
@@ -80,8 +81,9 @@ type Props = {
 
 export default function CampaignNewsList({ articles }: Props) {
   const { t, i18n } = useTranslation('news')
-  const CHARACTER_LIMIT = 400
+  const INITIAL_HEIGHT_LIMIT = 300
   const [isExpanded, expandContent] = useShowMoreContent()
+
   return (
     <>
       {articles?.map((article, index: number) => {
@@ -111,7 +113,17 @@ export default function CampaignNewsList({ articles }: Props) {
                   <Typography className={classes.articleAuthor}>{article.author}</Typography>
                 </Grid>
               </Grid>
-              <Grid container rowGap={1} columnGap={4}>
+              <Grid
+                container
+                rowGap={1}
+                columnGap={4}
+                sx={{
+                  height:
+                    getArticleHeight(article.id) > INITIAL_HEIGHT_LIMIT && !isExpanded[article.id]
+                      ? INITIAL_HEIGHT_LIMIT
+                      : 'auto',
+                  overflow: 'hidden',
+                }}>
                 <Grid container item direction={'column'} gap={1}>
                   <Typography className={classes.articleHeader}>{article.title}</Typography>
                   <QuillStypeWrapper>
@@ -119,10 +131,7 @@ export default function CampaignNewsList({ articles }: Props) {
                       component={'div'}
                       className={classes.articleDescription}
                       dangerouslySetInnerHTML={{
-                        __html:
-                          !isExpanded[article.id] && sanitizedDescription.length > CHARACTER_LIMIT
-                            ? sanitizedDescription.slice(0, CHARACTER_LIMIT) + '...'
-                            : sanitizedDescription,
+                        __html: sanitizedDescription,
                       }}
                       sx={{ wordBreak: 'break-word' }}
                     />
@@ -149,11 +158,11 @@ export default function CampaignNewsList({ articles }: Props) {
                   </Grid>
                 )}
               </Grid>
-              {sanitizedDescription.length > CHARACTER_LIMIT && (
+              {getArticleHeight(article.id) > INITIAL_HEIGHT_LIMIT && (
                 <Button
                   key={article.id}
                   className={classes.readMoreButton}
-                  onClick={(e) => {
+                  onClick={() => {
                     expandContent(article.id)
                     scrollToTop(article.id)
                   }}

--- a/src/components/client/campaign-news/SingleArticlePage.tsx
+++ b/src/components/client/campaign-news/SingleArticlePage.tsx
@@ -8,10 +8,11 @@ import { useTranslation } from 'react-i18next'
 
 import Image from 'next/image'
 import { GetArticleDocuments, GetArticleGalleryPhotos } from 'common/util/newsFilesUrls'
-import { sanitizeHTML } from 'common/util/htmlSanitizer'
+import { HTMLContentSeparator } from 'common/util/htmlUtils'
 import { useFindArticleBySlug } from 'common/hooks/campaign-news'
 import Layout from '../layout/Layout'
 import Link from 'next/link'
+import { QuillStypeWrapper } from 'components/common/QuillStyleWrapper'
 
 const PREFIX = 'CampaignNewsSection'
 const classes = {
@@ -86,7 +87,7 @@ export default function SingleArticlePage({ slug }: Props) {
 
   const documents = GetArticleDocuments(article.newsFiles)
   const images = GetArticleGalleryPhotos(article.newsFiles)
-  const sanitizedDescription = sanitizeHTML(article.description)
+  const[,sanitizedDescription] = HTMLContentSeparator(article.description)
   return (
     <Layout>
       <Grid container item xs={12}>
@@ -113,11 +114,14 @@ export default function SingleArticlePage({ slug }: Props) {
               style={{ maxWidth: '100%' }}>
               <Typography className={classes.articleHeader}>{article.title}</Typography>
               <Grid container item>
+                <QuillStypeWrapper>
                 <Typography
                   component={'div'}
                   className={classes.articleDescription}
                   dangerouslySetInnerHTML={{ __html: sanitizedDescription }}
+                  sx={{wordBreak: 'break-word'}}
                 />
+                </QuillStypeWrapper>
               </Grid>
               <Grid container item direction={'column'} gap={0.5}>
                 {documents.map((file) => (

--- a/src/components/client/campaign-news/SingleArticlePage.tsx
+++ b/src/components/client/campaign-news/SingleArticlePage.tsx
@@ -87,7 +87,7 @@ export default function SingleArticlePage({ slug }: Props) {
 
   const documents = GetArticleDocuments(article.newsFiles)
   const images = GetArticleGalleryPhotos(article.newsFiles)
-  const[,sanitizedDescription] = HTMLContentSeparator(article.description)
+  const [, sanitizedDescription] = HTMLContentSeparator(article.description)
   return (
     <Layout>
       <Grid container item xs={12}>
@@ -115,12 +115,12 @@ export default function SingleArticlePage({ slug }: Props) {
               <Typography className={classes.articleHeader}>{article.title}</Typography>
               <Grid container item>
                 <QuillStypeWrapper>
-                <Typography
-                  component={'div'}
-                  className={classes.articleDescription}
-                  dangerouslySetInnerHTML={{ __html: sanitizedDescription }}
-                  sx={{wordBreak: 'break-word'}}
-                />
+                  <Typography
+                    component={'div'}
+                    className={classes.articleDescription}
+                    dangerouslySetInnerHTML={{ __html: sanitizedDescription }}
+                    sx={{ wordBreak: 'break-word' }}
+                  />
                 </QuillStypeWrapper>
               </Grid>
               <Grid container item direction={'column'} gap={0.5}>

--- a/src/components/client/campaign-news/utils/getArticleHeight.ts
+++ b/src/components/client/campaign-news/utils/getArticleHeight.ts
@@ -1,0 +1,5 @@
+export const getArticleHeight = (articleId: string) => {
+  const elem = document.getElementById(articleId)
+  if (!elem) return 0
+  return elem.offsetHeight
+}

--- a/src/components/client/campaign-news/utils/scrollToTop.ts
+++ b/src/components/client/campaign-news/utils/scrollToTop.ts
@@ -1,0 +1,16 @@
+/**
+ * For keeping focus on the element, which is expanded/ not expanded
+ * @param elementId - id of the element to scroll to
+ */
+export const scrollToTop = (elementId: string) => {
+  const elem = document.getElementById(elementId)
+  const headerOffset = 100
+  const elementPosition = elem?.getBoundingClientRect().top
+  let offset = 0
+  if (elementPosition) {
+    offset = elementPosition + window.scrollY - headerOffset
+  }
+  window.scrollTo({
+    top: offset,
+  })
+}

--- a/src/components/client/campaigns/CampaignNewsSection.tsx
+++ b/src/components/client/campaigns/CampaignNewsSection.tsx
@@ -156,7 +156,7 @@ export default function CampaignNewsSection({ campaign, canCreateArticle }: Prop
   const { t, i18n } = useTranslation('news')
   const { small }: { small: boolean } = useMobile()
 
-  const INITIAL_HEIGHT_LIMIT = 100
+  const INITIAL_HEIGHT_LIMIT = 200
   const [isExpanded, expandContent] = useShowMoreContent()
 
   return (

--- a/src/components/client/campaigns/CampaignNewsSection.tsx
+++ b/src/components/client/campaigns/CampaignNewsSection.tsx
@@ -24,6 +24,7 @@ import useMobile from 'common/hooks/useMobile'
 import { GetArticleDocuments, GetArticleGalleryPhotos } from 'common/util/newsFilesUrls'
 import { useShowMoreContent } from '../campaign-news/hooks/useShowMoreContent'
 import { sanitizeHTML } from 'common/util/htmlUtils'
+import { QuillStypeWrapper } from 'components/common/QuillStyleWrapper'
 
 const PREFIX = 'NewsTimeline'
 
@@ -240,22 +241,20 @@ export default function CampaignNewsSection({ campaign, canCreateArticle }: Prop
                         <Typography className={classes.articleHeader}>{article.title}</Typography>
                       </Grid>
                       <Grid container item direction={'row'}>
-                        {!isExpanded[article.id] &&
-                        sanitizedDescription.length > CHARACTER_LIMIT ? (
+                        <QuillStypeWrapper>
                           <Typography
                             component={'div'}
                             className={classes.articleDescription}
                             dangerouslySetInnerHTML={{
-                              __html: sanitizedDescription.slice(0, CHARACTER_LIMIT) + '...',
+                              __html:
+                                !isExpanded[article.id] &&
+                                sanitizedDescription.length > CHARACTER_LIMIT
+                                  ? sanitizedDescription.slice(0, CHARACTER_LIMIT) + '...'
+                                  : sanitizedDescription,
                             }}
+                            sx={{ wordBreak: 'break-word' }}
                           />
-                        ) : (
-                          <Typography
-                            component={'div'}
-                            className={classes.articleDescription}
-                            dangerouslySetInnerHTML={{ __html: sanitizedDescription }}
-                          />
-                        )}
+                        </QuillStypeWrapper>
                         {sanitizedDescription.length > CHARACTER_LIMIT && (
                           <Button
                             className={classes.readMoreButton}

--- a/src/components/client/campaigns/CampaignNewsSection.tsx
+++ b/src/components/client/campaigns/CampaignNewsSection.tsx
@@ -26,6 +26,7 @@ import { useShowMoreContent } from '../campaign-news/hooks/useShowMoreContent'
 import { sanitizeHTML } from 'common/util/htmlUtils'
 import { QuillStypeWrapper } from 'components/common/QuillStyleWrapper'
 import { scrollToTop } from '../campaign-news/utils/scrollToTop'
+import { getArticleHeight } from '../campaign-news/utils/getArticleHeight'
 
 const PREFIX = 'NewsTimeline'
 
@@ -119,6 +120,9 @@ const StyledTimeline = styled(Timeline)(({ theme }) => ({
     color: theme.palette.primary.light,
     textDecoration: 'underline',
     padding: 0,
+    margin: 0,
+    position: 'relative',
+    bottom: 3,
   },
 
   [`& .${classes.readAllButton}`]: {
@@ -152,7 +156,7 @@ export default function CampaignNewsSection({ campaign, canCreateArticle }: Prop
   const { t, i18n } = useTranslation('news')
   const { small }: { small: boolean } = useMobile()
 
-  const CHARACTER_LIMIT = 120
+  const INITIAL_HEIGHT_LIMIT = 100
   const [isExpanded, expandContent] = useShowMoreContent()
 
   return (
@@ -241,34 +245,39 @@ export default function CampaignNewsSection({ campaign, canCreateArticle }: Prop
                       <Grid item>
                         <Typography className={classes.articleHeader}>{article.title}</Typography>
                       </Grid>
-                      <Grid container item direction={'row'}>
+                      <Grid
+                        container
+                        item
+                        direction={'row'}
+                        sx={{
+                          height:
+                            getArticleHeight(article.id) > INITIAL_HEIGHT_LIMIT &&
+                            !isExpanded[article.id]
+                              ? INITIAL_HEIGHT_LIMIT
+                              : 'auto',
+                          overflow: 'hidden',
+                        }}>
                         <QuillStypeWrapper>
                           <Typography
                             component={'div'}
                             className={classes.articleDescription}
                             dangerouslySetInnerHTML={{
-                              __html:
-                                !isExpanded[article.id] &&
-                                sanitizedDescription.length > CHARACTER_LIMIT
-                                  ? sanitizedDescription.slice(0, CHARACTER_LIMIT) + '...'
-                                  : sanitizedDescription,
+                              __html: sanitizedDescription,
                             }}
                             sx={{ wordBreak: 'break-word' }}
                           />
                         </QuillStypeWrapper>
-                        {sanitizedDescription.length > CHARACTER_LIMIT && (
-                          <Button
-                            className={classes.readMoreButton}
-                            onClick={() => {
-                              expandContent(article.id)
-                              scrollToTop(article.id)
-                            }}>
-                            {!isExpanded[article.id]
-                              ? `${t('read-more')} >`
-                              : `${t('read-less')} <`}
-                          </Button>
-                        )}
                       </Grid>
+                      {getArticleHeight(article.id) >= INITIAL_HEIGHT_LIMIT && (
+                        <Button
+                          className={classes.readMoreButton}
+                          onClick={() => {
+                            expandContent(article.id)
+                            scrollToTop(article.id)
+                          }}>
+                          {!isExpanded[article.id] ? `${t('read-more')} >` : `${t('read-less')} <`}
+                        </Button>
+                      )}
                       {article.newsFiles.length > 0 && (
                         <Grid container gap={1}>
                           <Grid container item direction={'column'} gap={0.5}>

--- a/src/components/client/campaigns/CampaignNewsSection.tsx
+++ b/src/components/client/campaigns/CampaignNewsSection.tsx
@@ -25,6 +25,7 @@ import { GetArticleDocuments, GetArticleGalleryPhotos } from 'common/util/newsFi
 import { useShowMoreContent } from '../campaign-news/hooks/useShowMoreContent'
 import { sanitizeHTML } from 'common/util/htmlUtils'
 import { QuillStypeWrapper } from 'components/common/QuillStyleWrapper'
+import { scrollToTop } from '../campaign-news/utils/scrollToTop'
 
 const PREFIX = 'NewsTimeline'
 
@@ -180,7 +181,7 @@ export default function CampaignNewsSection({ campaign, canCreateArticle }: Prop
               const images = GetArticleGalleryPhotos(article.newsFiles)
               const sanitizedDescription = sanitizeHTML(article.description)
               return (
-                <TimelineItem key={article.id} className={classes.timelineItem}>
+                <TimelineItem key={article.id} className={classes.timelineItem} id={article.id}>
                   {!small && (
                     <TimelineOppositeContent className={classes.timelineOppositeContent}>
                       <Grid container flexDirection={'column'} wrap="nowrap" gap={2}>
@@ -258,7 +259,10 @@ export default function CampaignNewsSection({ campaign, canCreateArticle }: Prop
                         {sanitizedDescription.length > CHARACTER_LIMIT && (
                           <Button
                             className={classes.readMoreButton}
-                            onClick={() => expandContent(article.id)}>
+                            onClick={() => {
+                              expandContent(article.id)
+                              scrollToTop(article.id)
+                            }}>
                             {!isExpanded[article.id]
                               ? `${t('read-more')} >`
                               : `${t('read-less')} <`}

--- a/src/components/client/campaigns/CampaignNewsSection.tsx
+++ b/src/components/client/campaigns/CampaignNewsSection.tsx
@@ -23,7 +23,7 @@ import Image from 'next/image'
 import useMobile from 'common/hooks/useMobile'
 import { GetArticleDocuments, GetArticleGalleryPhotos } from 'common/util/newsFilesUrls'
 import { useShowMoreContent } from '../campaign-news/hooks/useShowMoreContent'
-import { sanitizeHTML } from 'common/util/htmlSanitizer'
+import { sanitizeHTML } from 'common/util/htmlUtils'
 
 const PREFIX = 'NewsTimeline'
 

--- a/src/components/common/QuillStyleWrapper.tsx
+++ b/src/components/common/QuillStyleWrapper.tsx
@@ -52,7 +52,7 @@ export const QuillStypeWrapper = styled(Grid)(({ theme }) => ({
   ['.ql-editor, .ql-align-right']: {
     textAlign: 'right',
   },
-  
+
   ['blockquote']: {
     borderLeft: '4px solid #ccc',
     marginBottom: 5,

--- a/src/components/common/QuillStyleWrapper.tsx
+++ b/src/components/common/QuillStyleWrapper.tsx
@@ -1,0 +1,94 @@
+import { Grid } from '@mui/material'
+import { styled } from '@mui/material/styles'
+export const QuillStypeWrapper = styled(Grid)(({theme}) => ({
+  ['.ql-container']: {
+    fontFamily: 'Helvetica,Arial,sans-serif',
+    fontSize: 13,
+    margin: 0,
+    maxWidth: '100%',
+    boxSizing: 'border-box',
+  },
+
+
+  ['.ql-editor']: {
+    fontSize: theme.spacing(2),
+    fontWeight: 500,
+    lineHeight: theme.spacing(4),
+    paddingLeft: '0',
+    paddingRight: '0',
+    maxWidth: '100%'
+  },
+
+  ['p > *']:{
+    maxWidth: '100%',
+    overflowWrap: 'break-word'
+  },
+  ['img']: {
+    maxWidth: '100%',
+    objectFit: 'scale-down'
+  },
+
+  ['.ql-editor, .ql-video']: {
+    maxWidth: '100%',
+  },
+
+  ['.ql-editor, blockquote, .ql-editor h1, .ql-editor h2, .ql-editor h3, .ql-editor h4, .ql-editor h5, .ql-editor h6, .ql-editor ol, .ql-editor p, .ql-editor pre, .ql-editor ul']:
+    {
+      margin: 0,
+      padding: 0,
+      counterReset: 'list-1 list-2 list-3 list-4 list-5 list-6 list-7 list-8 list-9',
+    },
+
+  ['.ql-editor ol, .ql-editor ul']: {
+    paddingLeft: '1.5em',
+  },
+
+  ['.ql-editor, .ql-align-left']: {
+    textAlign: 'left',
+  },
+
+    ['.ql-editor, .ql-align-center']: {
+    textAlign: 'center',
+
+},
+
+  ['.ql-editor, .ql-align-justify']: {
+    textAlign: 'justify',
+  },
+
+  ['.ql-editor, .ql-align-right']: {
+    textAlign: 'right',
+  },
+  ['blockquote']: {
+    borderLeft: '4px solid #ccc',
+    marginBottom: 5,
+    marginTop: 5,
+    paddingLeft: 16,
+  },
+
+  ['.ql-editor, .ql-size-small']: {
+    fontSize: '.75em',
+  },
+
+  ['.ql-editor, .ql-size-large']: {
+    fontSize: '1.5em',
+  },
+
+  ['.ql-editor, .ql-size-huge']: {
+    fontSize: '2.5em',
+  },
+
+  ['.ql-bubble, ql-editor h1']: {
+    position: 'relative',
+    width: '100%',
+    fontSize: '1em',
+  },
+
+  ['.ql-bubble, ql-editor h2']: {
+    fontSize: '1.5em',
+  },
+
+['.ql-bubble .ql-editor a '] : {
+    textDecoration: 'none'
+}
+}))

--- a/src/components/common/QuillStyleWrapper.tsx
+++ b/src/components/common/QuillStyleWrapper.tsx
@@ -1,6 +1,6 @@
 import { Grid } from '@mui/material'
 import { styled } from '@mui/material/styles'
-export const QuillStypeWrapper = styled(Grid)(({theme}) => ({
+export const QuillStypeWrapper = styled(Grid)(({ theme }) => ({
   ['.ql-container']: {
     fontFamily: 'Helvetica,Arial,sans-serif',
     fontSize: 13,
@@ -9,23 +9,17 @@ export const QuillStypeWrapper = styled(Grid)(({theme}) => ({
     boxSizing: 'border-box',
   },
 
-
   ['.ql-editor']: {
     fontSize: theme.spacing(2),
     fontWeight: 500,
     lineHeight: theme.spacing(4),
     paddingLeft: '0',
     paddingRight: '0',
-    maxWidth: '100%'
+    maxWidth: '100%',
   },
 
-  ['p > *']:{
-    maxWidth: '100%',
-    overflowWrap: 'break-word'
-  },
   ['img']: {
     maxWidth: '100%',
-    objectFit: 'scale-down'
   },
 
   ['.ql-editor, .ql-video']: {
@@ -47,10 +41,9 @@ export const QuillStypeWrapper = styled(Grid)(({theme}) => ({
     textAlign: 'left',
   },
 
-    ['.ql-editor, .ql-align-center']: {
+  ['.ql-editor, .ql-align-center']: {
     textAlign: 'center',
-
-},
+  },
 
   ['.ql-editor, .ql-align-justify']: {
     textAlign: 'justify',
@@ -59,6 +52,7 @@ export const QuillStypeWrapper = styled(Grid)(({theme}) => ({
   ['.ql-editor, .ql-align-right']: {
     textAlign: 'right',
   },
+  
   ['blockquote']: {
     borderLeft: '4px solid #ccc',
     marginBottom: 5,
@@ -88,7 +82,7 @@ export const QuillStypeWrapper = styled(Grid)(({theme}) => ({
     fontSize: '1.5em',
   },
 
-['.ql-bubble .ql-editor a '] : {
-    textDecoration: 'none'
-}
+  ['.ql-bubble .ql-editor a ']: {
+    textDecoration: 'none',
+  },
 }))

--- a/src/components/common/form/FormRichTextField.tsx
+++ b/src/components/common/form/FormRichTextField.tsx
@@ -14,7 +14,6 @@ import BlotFormatter from 'quill-blot-formatter/'
 
 import htmlEditButton from 'quill-html-edit-button'
 
-
 export type FormRichTextFieldProps = {
   name: string
 }
@@ -37,7 +36,7 @@ class ImageFormat extends BaseImageFormat {
       return formats
     }, {})
   }
-  
+
   format(name: string, value: string) {
     if (ImageFormatAttributesList.indexOf(name) > -1) {
       if (value) {
@@ -60,7 +59,7 @@ class VideoFormat extends BaseVideoFormat {
       return formats
     }, {})
   }
-  
+
   format(name: string, value: string) {
     if (ImageFormatAttributesList.indexOf(name) > -1) {
       if (value) {

--- a/src/components/common/form/FormRichTextField.tsx
+++ b/src/components/common/form/FormRichTextField.tsx
@@ -11,21 +11,79 @@ import 'react-quill/dist/quill.snow.css'
 import ReactQuill, { Quill } from 'react-quill'
 
 import BlotFormatter from 'quill-blot-formatter/'
-Quill.register('modules/blotFormatter', BlotFormatter)
 
 import htmlEditButton from 'quill-html-edit-button'
 
-Quill.register({
-  'modules/htmlEditButton': htmlEditButton,
-})
-
-Quill.register({
-  'modules/htmlEditButton': htmlEditButton,
-})
 
 export type FormRichTextFieldProps = {
   name: string
 }
+
+const ImageFormatAttributesList = ['alt', 'height', 'width', 'style']
+
+const BaseImageFormat = Quill.import('formats/image')
+const BaseVideoFormat = Quill.import('formats/video')
+
+type ImageProp = {
+  [key: string]: string | null
+}
+
+class ImageFormat extends BaseImageFormat {
+  static formats(domNode: HTMLElement) {
+    return ImageFormatAttributesList.reduce(function (formats: ImageProp, attribute: string) {
+      if (domNode.hasAttribute(attribute)) {
+        formats[attribute] = domNode.getAttribute(attribute)
+      }
+      return formats
+    }, {})
+  }
+  
+  format(name: string, value: string) {
+    if (ImageFormatAttributesList.indexOf(name) > -1) {
+      if (value) {
+        this.domNode.setAttribute(name, value)
+      } else {
+        this.domNode.removeAttribute(name)
+      }
+    } else {
+      super.format(name, value)
+    }
+  }
+}
+
+class VideoFormat extends BaseVideoFormat {
+  static formats(domNode: HTMLElement) {
+    return ImageFormatAttributesList.reduce(function (formats: ImageProp, attribute: string) {
+      if (domNode.hasAttribute(attribute)) {
+        formats[attribute] = domNode.getAttribute(attribute)
+      }
+      return formats
+    }, {})
+  }
+  
+  format(name: string, value: string) {
+    if (ImageFormatAttributesList.indexOf(name) > -1) {
+      if (value) {
+        this.domNode.setAttribute(name, value)
+      } else {
+        this.domNode.removeAttribute(name)
+      }
+    } else {
+      super.format(name, value)
+    }
+  }
+}
+
+Quill.register(ImageFormat, true)
+Quill.register(VideoFormat, true)
+Quill.register('modules/blotFormatter', BlotFormatter)
+Quill.register({
+  'modules/htmlEditButton': htmlEditButton,
+})
+
+Quill.register({
+  'modules/htmlEditButton': htmlEditButton,
+})
 
 const StyledGrid = styled('div')(() => ({
   ['& .ql-toolbar.ql-snow']: {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
List of changes:
1. Quill Editor: Fixed alignment of video and image being removed, when submitting .
2. CampaignNewsList: Fixed news layout being unresponsive.
3. Extracted the current Quill styling into separate component. This will be necessary, in order to keep the formatting of the currently added campaigns/campaign news, in case we drop the React Quill(issue #1503).
4. Whitelisted the iframe tag from DOMPurify. 
5. Implemented a function, which adds the `loading="lazy"` attribute to the iframe. This function, also allows to separate the iframe from, the rest of the HTML content, which might be needed in the future, when implementing the new campaign page ([ref](https://cdn.discordapp.com/attachments/779339122556796979/1133760880635564193/Screenshot_2023-07-26-14-59-15-817_com.figma.mirror.jpg))
6. CampaignNewsList: Fixed an issue, where the news article, was losing focus, when expanding/shrinking content.
7. CampaignNewsList: News' content is now being clipped based on height of container, rather than character limit.

<!--- If it fixes an open issue, please link to the issue here. -->
Closes #1522 

## Motivation and context

