### PR TITLE
campaign-news: Fix styling according to design spec

### DIFF
--- a/src/components/client/campaign-news/CampaignNewsList.tsx
+++ b/src/components/client/campaign-news/CampaignNewsList.tsx
@@ -131,7 +131,7 @@ export default function CampaignNewsList({ articles }: Props) {
                       dangerouslySetInnerHTML={{
                         __html: sanitizedDescription,
                       }}
-                      sx={{ wordBreak: 'break-word' }}
+                      sx={{ wordBreak: 'break-word', maxWidth: 1200 }}
                     />
                   </QuillStypeWrapper>
                   <Grid container item direction={'column'} gap={0.5}>

--- a/src/components/common/QuillStyleWrapper.tsx
+++ b/src/components/common/QuillStyleWrapper.tsx
@@ -1,25 +1,15 @@
 import { Grid } from '@mui/material'
 import { styled } from '@mui/material/styles'
+
 export const QuillStypeWrapper = styled(Grid)(({ theme }) => ({
-  ['.ql-container']: {
-    fontFamily: 'Helvetica,Arial,sans-serif',
-    fontSize: 13,
-    margin: 0,
-    maxWidth: '100%',
-    boxSizing: 'border-box',
-  },
-
-  ['.ql-editor']: {
-    fontSize: theme.spacing(2),
-    fontWeight: 500,
-    lineHeight: theme.spacing(4),
-    paddingLeft: '0',
-    paddingRight: '0',
-    maxWidth: '100%',
-  },
-
   ['img']: {
     maxWidth: '100%',
+  },
+
+  ['p']: {
+    fontSize: theme.spacing(2),
+    fontWeight: 400,
+    lineHeight: theme.spacing(2.85),
   },
 
   ['.ql-editor, .ql-video']: {


### PR DESCRIPTION
-Updated the font properties according the design specs, 
-Set max-width of container to 1200px, according to design specs
-Removed redundant properties.

Reference:
https://www.figma.com/file/MmvFKzUv6yE5U2wrOpWtwS/Podkrepi.bg?type=design&node-id=18746-56853&mode=design&t=1QqRtTdJE4fNuQNI-0
