### PR TITLE
hooks/campaigns.ts: Disable useCampaignList on client

### DIFF
--- a/src/common/hooks/campaigns.ts
+++ b/src/common/hooks/campaigns.ts
@@ -43,6 +43,7 @@ export function useCampaignList() {
   return useQuery<CampaignResponse[]>(
     [endpoints.campaign.listCampaigns.url],
     campaignsOrderQueryFunction,
+    { enabled: false },
   )
 }
 


### PR DESCRIPTION
Necessary data is prefetched on the server, and since campaign's data is no longer considered stale, it results in 2 queries to the server being made.
 Due to the call of useCampaignList, the campaigns are being reordered twice - once on the server, once on client load, which makes it unpleasant for the users.

