### PR TITLE
fix: disable source editor to avoid SWC bug

### DIFF
--- a/src/components/common/form/MDXEditor.tsx
+++ b/src/components/common/form/MDXEditor.tsx
@@ -1,6 +1,5 @@
 import { markdownShortcutPlugin } from '@mdxeditor/editor/plugins/markdown-shortcut'
 import { MDXEditor } from '@mdxeditor/editor/MDXEditor'
-import { diffSourcePlugin } from '@mdxeditor/editor/plugins/diff-source'
 import {
   DirectiveDescriptor,
   directivesPlugin,
@@ -16,7 +15,6 @@ import { toolbarPlugin } from '@mdxeditor/editor/plugins/toolbar'
 import { BlockTypeSelect } from '@mdxeditor/editor/plugins/toolbar/components/BlockTypeSelect'
 import { BoldItalicUnderlineToggles } from '@mdxeditor/editor/plugins/toolbar/components/BoldItalicUnderlineToggles'
 import { CreateLink } from '@mdxeditor/editor/plugins/toolbar/components/CreateLink'
-import { DiffSourceToggleWrapper } from '@mdxeditor/editor/plugins/toolbar/components/DiffSourceToggleWrapper'
 import { InsertImage } from '@mdxeditor/editor/plugins/toolbar/components/InsertImage'
 import { ListsToggle } from '@mdxeditor/editor/plugins/toolbar/components/ListsToggle'
 import { UndoRedo } from '@mdxeditor/editor/plugins/toolbar/components/UndoRedo'
@@ -165,24 +163,22 @@ export const ModernEditor: React.FC<ModernEditorProps> = ({ html, onChange }) =>
           toolbarPlugin({
             toolbarContents: () => (
               <>
-                <DiffSourceToggleWrapper>
-                  <UndoRedo />
-                  <BoldItalicUnderlineToggles />
-                  <ListsToggle />
-                  <Separator />
-                  <BlockTypeSelect />
-                  <CreateLink />
-                  <InsertImage />
-                  <YoutubeButton />
-                  <Separator />
-                </DiffSourceToggleWrapper>
+                <UndoRedo />
+                <BoldItalicUnderlineToggles />
+                <ListsToggle />
+                <Separator />
+                <BlockTypeSelect />
+                <CreateLink />
+                <InsertImage />
+                <YoutubeButton />
+                <Separator />
               </>
             ),
           }),
           linkPlugin(),
           listsPlugin(),
           headingsPlugin(),
-          diffSourcePlugin({ diffMarkdown: markdown }),
+          // diffSourcePlugin({ diffMarkdown: markdown }),
           linkDialogPlugin(),
           imagePlugin(),
           quotePlugin(),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Due to https://github.com/swc-project/swc/issues/7640, the editor fails in production. The change here removes the plugin that causes the error.

There are two other alternatives: 
- disable the swc minification
- upgrade to the latest Next.js version

Given the non-technical audience, I think that disabling the diff/source feature is the best option. Let me know if you think otherwise, though. 