### PR TITLE
Use next/image component for campaign images

### DIFF
--- a/src/components/client/campaigns/CampaignCard/CampaignCard.tsx
+++ b/src/components/client/campaigns/CampaignCard/CampaignCard.tsx
@@ -53,8 +53,8 @@ export default function ActiveCampaignCard({ campaign, index }: Props) {
           position={'relative'}
           sx={{
             width: '100%',
-            aspectRatio:1.5,
-            maxHeight: theme.spacing(27.9)
+            aspectRatio: 1.5,
+            maxHeight: theme.spacing(27.9),
           }}>
           <Image
             priority
@@ -63,7 +63,7 @@ export default function ActiveCampaignCard({ campaign, index }: Props) {
             fill
             sizes="(min-width: 2000px) 312px, (min-width: 1200px) calc(30vw - 38px), (min-width: 900px) calc(40.57vw - 29px), (min-width: 600px) calc(50vw - 28px), calc(100vw - 32px)"
             quality={index === 0 ? 100 : 75}
-            style={{objectFit: 'cover'}}
+            style={{ objectFit: 'cover' }}
           />
         </Box>
         {campaignState === CampaignState.complete && percentage >= 100 ? (

--- a/src/components/client/campaigns/CampaignCard/CampaignCard.tsx
+++ b/src/components/client/campaigns/CampaignCard/CampaignCard.tsx
@@ -2,7 +2,7 @@ import { useMemo } from 'react'
 import { useTranslation, i18n } from 'next-i18next'
 import { CampaignResponse } from 'gql/campaigns'
 
-import { CardMedia } from '@mui/material'
+import { Box, CardMedia } from '@mui/material'
 
 import { routes } from 'common/routes'
 import { campaignListPictureUrl } from 'common/util/campaignImageUrls'
@@ -23,6 +23,7 @@ import {
   SumNumber,
   SumWrapper,
 } from '../../index/sections/ActiveCampaignsSection/ActiveCampaignCard/ActiveCampaignCard.styled'
+import Image from 'next/image'
 
 type Props = { campaign: CampaignResponse; index: number }
 
@@ -47,26 +48,24 @@ export default function ActiveCampaignCard({ campaign, index }: Props) {
 
   return (
     <Root data-testid={`campaign-card-${index}`}>
-      <Link href={routes.campaigns.viewCampaignBySlug(slug)} sx={{ position: 'relative' }}>
-        <CardMedia
-          component="img"
-          height="100%"
-          image={campaignImagesUrl}
-          alt={title}
+      <Link href={routes.campaigns.viewCampaignBySlug(slug)}>
+        <Box
+          position={'relative'}
           sx={{
-            maxHeight: theme.spacing(42.5),
-
-            [theme.breakpoints.up('lg')]: {
-              aspectRatio: '2',
-              height: theme.spacing(22.3),
-              maxHeight: 'inherit',
-            },
-
-            [theme.breakpoints.up(1430)]: {
-              height: theme.spacing(27.9),
-            },
-          }}
-        />
+            width: '100%',
+            aspectRatio:1.5,
+            maxHeight: theme.spacing(27.9)
+          }}>
+          <Image
+            priority
+            src={campaignImagesUrl}
+            alt={title}
+            fill
+            sizes="(min-width: 2000px) 312px, (min-width: 1200px) calc(30vw - 38px), (min-width: 900px) calc(40.57vw - 29px), (min-width: 600px) calc(50vw - 28px), calc(100vw - 32px)"
+            quality={index === 0 ? 100 : 75}
+            style={{objectFit: 'cover'}}
+          />
+        </Box>
         {campaignState === CampaignState.complete && percentage >= 100 ? (
           <SuccessfullCampaignTag />
         ) : (

--- a/src/components/client/index/sections/ActiveCampaignsSection/ActiveCampaignCard/ActiveCampaignCard.tsx
+++ b/src/components/client/index/sections/ActiveCampaignsSection/ActiveCampaignCard/ActiveCampaignCard.tsx
@@ -45,8 +45,11 @@ export default function ActiveCampaignCard({ campaign, index }: Props) {
             //   height: index === 0 ? theme.spacing(71.6) : theme.spacing(27.85),
             // },
             width: '100%',
+            aspectRatio:1.5,
+            [theme.breakpoints.up('lg')]: {
             maxHeight: index === 0 ? theme.spacing(71.6) : theme.spacing(27.85),
-            aspectRatio: index === 0 ? 1.24 : 1.54
+            aspectRatio: index === 0 ? 1.24 : 1.55
+            }
           }}>
           <Image
             priority

--- a/src/components/client/index/sections/ActiveCampaignsSection/ActiveCampaignCard/ActiveCampaignCard.tsx
+++ b/src/components/client/index/sections/ActiveCampaignsSection/ActiveCampaignCard/ActiveCampaignCard.tsx
@@ -1,7 +1,7 @@
 import { useTranslation, i18n } from 'next-i18next'
 import { CampaignResponse } from 'gql/campaigns'
 
-import { CardMedia } from '@mui/material'
+import { Box, CardMedia } from '@mui/material'
 
 import Link from 'components/common/Link'
 import CampaignProgress from 'components/client/campaigns/CampaignProgress'
@@ -9,6 +9,7 @@ import theme from 'common/theme'
 import { routes } from 'common/routes'
 import { campaignListPictureUrl } from 'common/util/campaignImageUrls'
 import { moneyPublic } from 'common/util/money'
+import Image from 'next/image'
 
 import {
   CampaignTitle,
@@ -34,26 +35,29 @@ export default function ActiveCampaignCard({ campaign, index }: Props) {
 
   return (
     <Root data-testid={`completed-campaign-${index}`}>
-      <Link href={routes.campaigns.viewCampaignBySlug(slug)} sx={{ position: 'relative' }}>
-        <CardMedia
-          component="img"
-          height="100%"
-          image={campaignImagesUrl}
-          alt={title}
+      <Link href={routes.campaigns.viewCampaignBySlug(slug)}>
+        <Box
+          position={'relative'}
           sx={{
-            maxHeight: theme.spacing(42.5),
-
-            [theme.breakpoints.up('lg')]: {
-              aspectRatio: '2',
-              height: theme.spacing(22.3),
-              maxHeight: 'inherit',
-            },
-
-            [theme.breakpoints.up(1430)]: {
-              height: theme.spacing(27.9),
-            },
-          }}
-        />
+            // aspectRatio: 4 / 3,
+            // [theme.breakpoints.up('lg')]: {
+            //   aspectRatio: 0,
+            //   height: index === 0 ? theme.spacing(71.6) : theme.spacing(27.85),
+            // },
+            width: '100%',
+            maxHeight: index === 0 ? theme.spacing(71.6) : theme.spacing(27.85),
+            aspectRatio: index === 0 ? 1.24 : 1.54
+          }}>
+          <Image
+            priority
+            src={campaignImagesUrl}
+            alt={title}
+            fill
+            sizes="(min-width: 2000px) 312px, (min-width: 1200px) calc(30vw - 38px), (min-width: 900px) calc(40.57vw - 29px), (min-width: 600px) calc(50vw - 28px), calc(100vw - 32px)"
+            quality={index === 0 ? 100 : 75}
+            style={{ objectFit: 'cover' }}
+          />
+        </Box>
         <StyledContent>
           <SumWrapper>
             <Sum>

--- a/src/components/client/index/sections/ActiveCampaignsSection/ActiveCampaignCard/ActiveCampaignCard.tsx
+++ b/src/components/client/index/sections/ActiveCampaignsSection/ActiveCampaignCard/ActiveCampaignCard.tsx
@@ -45,11 +45,11 @@ export default function ActiveCampaignCard({ campaign, index }: Props) {
             //   height: index === 0 ? theme.spacing(71.6) : theme.spacing(27.85),
             // },
             width: '100%',
-            aspectRatio:1.5,
+            aspectRatio: 1.5,
             [theme.breakpoints.up('lg')]: {
-            maxHeight: index === 0 ? theme.spacing(71.6) : theme.spacing(27.85),
-            aspectRatio: index === 0 ? 1.24 : 1.55
-            }
+              maxHeight: index === 0 ? theme.spacing(71.6) : theme.spacing(27.85),
+              aspectRatio: index === 0 ? 1.24 : 1.55,
+            },
           }}>
           <Image
             priority

--- a/src/components/client/index/sections/CompletedCampaignsSection/CompletedCampaignsSection.tsx
+++ b/src/components/client/index/sections/CompletedCampaignsSection/CompletedCampaignsSection.tsx
@@ -53,15 +53,15 @@ export default function CompletedCampaignsSection() {
             <CompletedCampaignLink
               onMouseDown={onLinkMouseDown}
               href={routes.campaigns.viewCampaignBySlug(campaign.slug)}
-              sx={{position: 'relative', aspectRatio:1, height: (theme) => theme.spacing(37.5)}}
-            >
-              <Image 
-              fill 
-              alt={campaign.title} 
-              src={campaignListPictureUrl(campaign)}
-              sizes="(min-width: 2000px) 312px, (min-width: 1200px) calc(30vw - 38px), (min-width: 900px) calc(40.57vw - 29px), (min-width: 600px) calc(50vw - 28px), calc(100vw - 32px)" 
-              style={{objectFit: 'cover'}}  />
-              </CompletedCampaignLink>
+              sx={{ position: 'relative', aspectRatio: 1, height: (theme) => theme.spacing(37.5) }}>
+              <Image
+                fill
+                alt={campaign.title}
+                src={campaignListPictureUrl(campaign)}
+                sizes="(min-width: 2000px) 312px, (min-width: 1200px) calc(30vw - 38px), (min-width: 900px) calc(40.57vw - 29px), (min-width: 600px) calc(50vw - 28px), calc(100vw - 32px)"
+                style={{ objectFit: 'cover' }}
+              />
+            </CompletedCampaignLink>
             <CompletedSumWrapper>
               <Sum>
                 {i18n.language === 'bg'

--- a/src/components/client/index/sections/CompletedCampaignsSection/CompletedCampaignsSection.tsx
+++ b/src/components/client/index/sections/CompletedCampaignsSection/CompletedCampaignsSection.tsx
@@ -26,6 +26,8 @@ import {
   SuccessfullCampiagnText,
 } from './CompletedCampaignsSection.styled'
 
+import Image from 'next/image'
+
 export default function CompletedCampaignsSection() {
   const { t } = useTranslation('campaigns')
   const { data } = useCampaignList()
@@ -51,10 +53,15 @@ export default function CompletedCampaignsSection() {
             <CompletedCampaignLink
               onMouseDown={onLinkMouseDown}
               href={routes.campaigns.viewCampaignBySlug(campaign.slug)}
-              sx={{
-                background: `url(${campaignListPictureUrl(campaign)})`,
-              }}
-            />
+              sx={{position: 'relative', aspectRatio:1, height: (theme) => theme.spacing(37.5)}}
+            >
+              <Image 
+              fill 
+              alt={campaign.title} 
+              src={campaignListPictureUrl(campaign)}
+              sizes="(min-width: 2000px) 312px, (min-width: 1200px) calc(30vw - 38px), (min-width: 900px) calc(40.57vw - 29px), (min-width: 600px) calc(50vw - 28px), calc(100vw - 32px)" 
+              style={{objectFit: 'cover'}}  />
+              </CompletedCampaignLink>
             <CompletedSumWrapper>
               <Sum>
                 {i18n.language === 'bg'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Use next/image component for campaign card images.

<!--- If it fixes an open issue, please link to the issue here. -->
Closes #{issue number}

## Motivation and context
As of now we don't have a strict policy on image sizes for campaign's cards. This result in scenarios where a 1MB images are used, which affects both the user experience, and web vitals stats tremendously, as it takes some time before they are downloaded by the client.

The easiest way to solve this, is to use Next's Image component which provides, out of the box optimizations to reduce image size(such as automatically converting it to webp, and compressing it). 
