### PR TITLE
Sort bank transactions by descening date

### DIFF
--- a/src/components/admin/bank-transactions/grid/Grid.tsx
+++ b/src/components/admin/bank-transactions/grid/Grid.tsx
@@ -151,6 +151,11 @@ export default observer(function Grid() {
           rowCount={all_rows}
           disableRowSelectionOnClick
           isCellEditable={() => true}
+          initialState={{
+            sorting: {
+              sortModel: [{ field: 'transactionDate', sort: 'desc' }],
+            },
+          }}
         />
       </Box>
     </>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!--- If it fixes an open issue, please link to the issue here. -->
Closes #1588 

## Motivation and context

* Bank transactions are now sorted in descending order (by transaction date).

## Screenshots:

<!-- You can copy/paste screenshots directly in the editor -->


### Before

![image](https://github.com/podkrepi-bg/frontend/assets/76788928/e6636168-8e13-460c-8290-5c98c216cd6b)

### After

![image](https://github.com/podkrepi-bg/frontend/assets/76788928/f12d96ca-1aab-476f-83ab-cdc73760c319)
