### PR TITLE
Mark user as Coordinator, Organizer and/or Beneficiary

### DIFF
--- a/public/locales/bg/person.json
+++ b/public/locales/bg/person.json
@@ -44,7 +44,8 @@
       "organizerRelation": "Отношения с организатор",
       "countryCode": "Държава",
       "city": "Град",
-      "description": "Описание"
+      "description": "Описание",
+      "disabled-tooltip": "Ролята не може да бъде премахната, потребителя е {{role}} в {{campaigns}} кампании"
     },
     "cta": {
       "create": "Създай",

--- a/public/locales/bg/person.json
+++ b/public/locales/bg/person.json
@@ -40,7 +40,11 @@
       "address": "Адрес",
       "organizer": "Организатор",
       "coordinator": "Координатор",
-      "beneficiary": "Бенефициент"
+      "beneficiary": "Бенефициент",
+      "organizerRelation": "Отношения с организатор",
+      "countryCode": "Държава",
+      "city": "Град",
+      "description": "Описание"
     },
     "cta": {
       "create": "Създай",

--- a/public/locales/en/person.json
+++ b/public/locales/en/person.json
@@ -41,7 +41,11 @@
       "address": "Address",
       "organizer": "Organizer",
       "coordinator": "Coordinator",
-      "beneficiary": "Beneficiary"
+      "beneficiary": "Beneficiary",
+      "organizerRelation": "Organizer relation",
+      "countryCode": "Country code",
+      "city": "City",
+      "description": "Description"
     },
     "cta": {
       "create": "Create",

--- a/public/locales/en/person.json
+++ b/public/locales/en/person.json
@@ -45,7 +45,8 @@
       "organizerRelation": "Organizer relation",
       "countryCode": "Country code",
       "city": "City",
-      "description": "Description"
+      "description": "Description",
+      "disabled-tooltip": "Cannot remove role because the user is {{role}} in {{campaigns}} campaigns"
     },
     "cta": {
       "create": "Create",

--- a/src/components/admin/organizers/grid/DeleteModal.tsx
+++ b/src/components/admin/organizers/grid/DeleteModal.tsx
@@ -23,7 +23,7 @@ export default observer(function DeleteModal() {
   const { hideDelete, selectedRecord } = ModalStore
 
   const mutation = useMutation<AxiosResponse<OrganizerResponse>, AxiosError<ApiErrors>, string>({
-    mutationFn: deleteOrganizer(selectedRecord.id),
+    mutationFn: deleteOrganizer(),
     onError: () => AlertStore.show(t('admin.alerts.delete-error'), 'error'),
     onSuccess: () => {
       hideDelete()

--- a/src/components/common/form/CheckboxField.tsx
+++ b/src/components/common/form/CheckboxField.tsx
@@ -1,3 +1,5 @@
+import { ChangeEvent } from 'react'
+
 import { useField } from 'formik'
 import { useTranslation } from 'next-i18next'
 import { Checkbox, FormControl, FormControlLabel, FormHelperText } from '@mui/material'
@@ -7,10 +9,16 @@ import { TranslatableField, translateError } from 'common/form/validation'
 export type CheckboxFieldProps = {
   name: string
   disabled?: boolean
+  onChange?: (e: ChangeEvent<HTMLInputElement>) => void
   label: string | number | React.ReactElement
 }
 
-export default function CheckboxField({ name, disabled, label }: CheckboxFieldProps) {
+export default function CheckboxField({
+  name,
+  disabled,
+  onChange: handleChange,
+  label,
+}: CheckboxFieldProps) {
   const { t } = useTranslation()
   const [field, meta] = useField(name)
   const helperText = meta.touched ? translateError(meta.error as TranslatableField, t) : ''
@@ -19,7 +27,16 @@ export default function CheckboxField({ name, disabled, label }: CheckboxFieldPr
       <FormControlLabel
         label={typeof label === 'string' ? `${t(label)}` : label}
         control={
-          <Checkbox color="primary" checked={Boolean(field.value)} disabled={disabled} {...field} />
+          <Checkbox
+            color="primary"
+            checked={Boolean(field.value)}
+            disabled={disabled}
+            {...field}
+            onChange={(e) => {
+              field.onChange(e)
+              if (handleChange) handleChange(e)
+            }}
+          />
         }
       />
       {Boolean(meta.error) && <FormHelperText error>{helperText}</FormHelperText>}

--- a/src/components/common/form/CheckboxField.tsx
+++ b/src/components/common/form/CheckboxField.tsx
@@ -2,7 +2,7 @@ import { ChangeEvent } from 'react'
 
 import { useField } from 'formik'
 import { useTranslation } from 'next-i18next'
-import { Checkbox, FormControl, FormControlLabel, FormHelperText } from '@mui/material'
+import { Checkbox, FormControl, FormControlLabel, FormHelperText, Tooltip } from '@mui/material'
 
 import { TranslatableField, translateError } from 'common/form/validation'
 
@@ -11,6 +11,7 @@ export type CheckboxFieldProps = {
   disabled?: boolean
   onChange?: (e: ChangeEvent<HTMLInputElement>) => void
   label: string | number | React.ReactElement
+  disabledTooltip?: string
 }
 
 export default function CheckboxField({
@@ -18,27 +19,30 @@ export default function CheckboxField({
   disabled,
   onChange: handleChange,
   label,
+  disabledTooltip,
 }: CheckboxFieldProps) {
   const { t } = useTranslation()
   const [field, meta] = useField(name)
   const helperText = meta.touched ? translateError(meta.error as TranslatableField, t) : ''
   return (
     <FormControl required component="fieldset" error={Boolean(meta.error) && Boolean(meta.touched)}>
-      <FormControlLabel
-        label={typeof label === 'string' ? `${t(label)}` : label}
-        control={
-          <Checkbox
-            color="primary"
-            checked={Boolean(field.value)}
-            disabled={disabled}
-            {...field}
-            onChange={(e) => {
-              field.onChange(e)
-              if (handleChange) handleChange(e)
-            }}
-          />
-        }
-      />
+      <Tooltip title={disabled && disabledTooltip} arrow>
+        <FormControlLabel
+          label={typeof label === 'string' ? `${t(label)}` : label}
+          control={
+            <Checkbox
+              color="primary"
+              checked={Boolean(field.value)}
+              disabled={disabled}
+              {...field}
+              onChange={(e) => {
+                field.onChange(e)
+                if (handleChange) handleChange(e)
+              }}
+            />
+          }
+        />
+      </Tooltip>
       {Boolean(meta.error) && <FormHelperText error>{helperText}</FormHelperText>}
     </FormControl>
   )

--- a/src/components/common/form/CheckboxField.tsx
+++ b/src/components/common/form/CheckboxField.tsx
@@ -6,10 +6,11 @@ import { TranslatableField, translateError } from 'common/form/validation'
 
 export type CheckboxFieldProps = {
   name: string
+  disabled?: boolean
   label: string | number | React.ReactElement
 }
 
-export default function CheckboxField({ name, label }: CheckboxFieldProps) {
+export default function CheckboxField({ name, disabled, label }: CheckboxFieldProps) {
   const { t } = useTranslation()
   const [field, meta] = useField(name)
   const helperText = meta.touched ? translateError(meta.error as TranslatableField, t) : ''
@@ -17,7 +18,9 @@ export default function CheckboxField({ name, label }: CheckboxFieldProps) {
     <FormControl required component="fieldset" error={Boolean(meta.error) && Boolean(meta.touched)}>
       <FormControlLabel
         label={typeof label === 'string' ? `${t(label)}` : label}
-        control={<Checkbox color="primary" checked={Boolean(field.value)} {...field} />}
+        control={
+          <Checkbox color="primary" checked={Boolean(field.value)} disabled={disabled} {...field} />
+        }
       />
       {Boolean(meta.error) && <FormHelperText error>{helperText}</FormHelperText>}
     </FormControl>

--- a/src/components/common/person/PersonForm.tsx
+++ b/src/components/common/person/PersonForm.tsx
@@ -22,6 +22,10 @@ const validationSchema: yup.SchemaOf<PersonFormData> = yup.object().defined().sh
   companyNumber: yup.string(),
   legalPersonName: name,
   address: yup.string(),
+  // Roles
+  isBeneficiary: yup.bool().notRequired(),
+  isCoordinator: yup.bool().notRequired(),
+  isOrganizer: yup.bool().notRequired(),
 })
 
 const defaults: PersonFormData = {

--- a/src/components/common/person/grid/CreateForm.tsx
+++ b/src/components/common/person/grid/CreateForm.tsx
@@ -1,0 +1,220 @@
+import React, { useState } from 'react'
+import * as yup from 'yup'
+import { Grid } from '@mui/material'
+
+import GenericForm from 'components/common/form/GenericForm'
+import { name, phone, email } from 'common/form/validation'
+import SubmitButton from 'components/common/form/SubmitButton'
+import FormTextField from 'components/common/form/FormTextField'
+import EmailField from 'components/common/form/EmailField'
+import { AdminPersonFormData, AdminPersonResponse } from 'gql/person'
+import { useMutation } from '@tanstack/react-query'
+import { AxiosError, AxiosResponse } from 'axios'
+import { ApiErrors } from 'service/apiErrors'
+import { useCreatePerson } from 'service/person'
+import { AlertStore } from 'stores/AlertStore'
+import { useRouter } from 'next/router'
+import { useTranslation } from 'next-i18next'
+import { routes } from 'common/routes'
+import CheckboxField from 'components/common/form/CheckboxField'
+import { useCreateCoordinator } from 'service/coordinator'
+import { CoordinatorResponse, CoorinatorInput } from 'gql/coordinators'
+import { createOrganizer } from 'service/organizer'
+import { OrganizerInput } from 'gql/organizer'
+import { BeneficiaryFormData, BeneficiaryListResponse } from 'gql/beneficiary'
+import { BeneficiaryType } from 'components/admin/beneficiary/BeneficiaryTypes'
+import { useCreateBeneficiary } from 'service/beneficiary'
+import OrganizerRelationSelect from 'components/admin/beneficiary/OrganizerRelationSelect'
+import CountrySelect from 'components/admin/countries/CountrySelect'
+import CitySelect from 'components/admin/cities/CitySelect'
+
+const validationSchema = yup
+  .object()
+  .defined()
+  .shape({
+    firstName: name.required(),
+    lastName: name.required(),
+    email: email.required(),
+    phone: phone.notRequired(),
+    isCoordinator: yup.bool().required(),
+    isOrganizer: yup.bool().required(),
+    isBeneficiary: yup.bool().required(),
+    description: yup.string().notRequired(),
+    cityId: yup.string().when('isBeneficiary', {
+      is: true,
+      then: yup.string().required(),
+      otherwise: yup.string().notRequired(),
+    }),
+    countryCode: yup.string().when('isBeneficiary', {
+      is: true,
+      then: yup.string().required(),
+      otherwise: yup.string().notRequired(),
+    }),
+    organizerRelation: yup.string().when('isBeneficiary', {
+      is: true,
+      then: yup.string().required(),
+      otherwise: yup.string().notRequired(),
+    }),
+  })
+
+const initialValues: AdminPersonFormData = {
+  firstName: '',
+  lastName: '',
+  email: '',
+  phone: '',
+  isOrganizer: false,
+  isCoordinator: false,
+  isBeneficiary: false,
+  countryCode: 'BG',
+  cityId: '',
+  description: '',
+  organizerRelation: 'none',
+}
+
+export default function CreateForm() {
+  const router = useRouter()
+  const { t } = useTranslation()
+  const [showBenefactor, setShowBenefactor] = useState<boolean>(false)
+
+  const mutation = useMutation<
+    AxiosResponse<AdminPersonResponse>,
+    AxiosError<ApiErrors>,
+    AdminPersonFormData
+  >({
+    mutationFn: useCreatePerson(),
+    onError: () => AlertStore.show(t('common:alerts.error'), 'error'),
+  })
+
+  const coordinatorCreateMutation = useMutation<
+    AxiosResponse<CoordinatorResponse>,
+    AxiosError<ApiErrors>,
+    CoorinatorInput
+  >({
+    mutationFn: useCreateCoordinator(),
+    onError: () => AlertStore.show(t('common:alerts.error'), 'error'),
+  })
+
+  const organizerCreateMutation = useMutation<
+    AxiosResponse<CoordinatorResponse>,
+    AxiosError<ApiErrors>,
+    OrganizerInput
+  >({
+    mutationFn: createOrganizer(),
+    onError: () => AlertStore.show(t('common:alerts.error'), 'error'),
+  })
+
+  const beneficiaryCreateMutation = useMutation<
+    AxiosResponse<BeneficiaryListResponse>,
+    AxiosError<ApiErrors>,
+    BeneficiaryFormData
+  >({
+    mutationFn: useCreateBeneficiary(),
+    onError: () => AlertStore.show(t('common:alerts.error'), 'error'),
+  })
+
+  async function handleSubmit(values: AdminPersonFormData) {
+    const { data: userResponse } = await mutation.mutateAsync(values)
+
+    if (values.isCoordinator) coordinatorCreateMutation.mutate({ personId: userResponse.id })
+
+    if (values.isOrganizer) organizerCreateMutation.mutate({ personId: userResponse.id })
+
+    if (values.isBeneficiary)
+      beneficiaryCreateMutation.mutate({
+        type: BeneficiaryType.individual,
+        personId: userResponse.id,
+        countryCode: values.countryCode,
+        cityId: values.cityId,
+        organizerRelation: values.organizerRelation,
+        description: values.description,
+        campaigns: [],
+      })
+
+    AlertStore.show(t('common:alerts.success'), 'success')
+    router.push(routes.admin.person.index)
+  }
+
+  return (
+    <Grid container direction="column" component="section">
+      <GenericForm
+        onSubmit={handleSubmit}
+        initialValues={initialValues}
+        validationSchema={validationSchema}>
+        <Grid container spacing={3}>
+          <Grid item xs={12} sm={6}>
+            <FormTextField
+              autoFocus
+              type="text"
+              label="person:admin.fields.first-name"
+              name="firstName"
+              autoComplete="first-name"
+            />
+          </Grid>
+          <Grid item xs={12} sm={6}>
+            <FormTextField
+              type="text"
+              label="person:admin.fields.last-name"
+              name="lastName"
+              autoComplete="family-name"
+            />
+          </Grid>
+          <Grid item xs={12}>
+            <EmailField label="person:admin.fields.email" name="email" />
+          </Grid>
+          <Grid item xs={12}>
+            <FormTextField
+              type="tel"
+              name="phone"
+              inputMode="tel"
+              autoComplete="tel"
+              label="person:admin.fields.phone"
+            />
+          </Grid>
+          <Grid item xs={4}>
+            <CheckboxField name="isOrganizer" label="person:admin.fields.organizer" />
+          </Grid>
+          <Grid item xs={4}>
+            <CheckboxField name="isCoordinator" label="person:admin.fields.coordinator" />
+          </Grid>
+          <Grid item xs={4}>
+            <CheckboxField
+              name="isBeneficiary"
+              label="person:admin.fields.beneficiary"
+              onChange={(e) => {
+                setShowBenefactor(e.target.checked)
+              }}
+            />
+          </Grid>
+          {showBenefactor && (
+            <>
+              <Grid item xs={12}>
+                <OrganizerRelationSelect
+                  name="organizerRelation"
+                  label="person:admin.fields.organizerRelation"
+                />
+              </Grid>
+              <Grid item xs={6}>
+                <CountrySelect />
+              </Grid>
+              <Grid item xs={6}>
+                <CitySelect name="cityId" />
+              </Grid>
+              <Grid item xs={12}>
+                <FormTextField
+                  type="text"
+                  name="description"
+                  label="person:admin.fields.description"
+                  multiline
+                  rows={2}
+                />
+              </Grid>
+            </>
+          )}
+          <Grid item xs={4} margin="auto">
+            <SubmitButton fullWidth label="person:admin.cta.create" />
+          </Grid>
+        </Grid>
+      </GenericForm>
+    </Grid>
+  )
+}

--- a/src/components/common/person/grid/CreatePage.tsx
+++ b/src/components/common/person/grid/CreatePage.tsx
@@ -4,7 +4,7 @@ import { Container } from '@mui/material'
 
 import AdminLayout from 'components/common/navigation/AdminLayout'
 import AdminContainer from 'components/common/navigation/AdminContainer'
-import PersonForm from './PersonForm'
+import CreateForm from './CreateForm'
 
 export default function CreatePage() {
   const { t } = useTranslation()
@@ -13,7 +13,7 @@ export default function CreatePage() {
     <AdminLayout>
       <AdminContainer title={t('person:admin.headings.create')}>
         <Container maxWidth="md" sx={{ py: 5 }}>
-          <PersonForm />
+          <CreateForm />
         </Container>
       </AdminContainer>
     </AdminLayout>

--- a/src/components/common/person/grid/EditForm.tsx
+++ b/src/components/common/person/grid/EditForm.tsx
@@ -74,13 +74,13 @@ export default function EditForm() {
     phone: data?.phone ?? '',
     isCoordinator: !!data?.coordinators,
     coordinatorId: data?.coordinators?.id,
-    activeCoordinator: !!data?.coordinators?._count?.campaigns,
+    coordinatorCampaigns: data?.coordinators?._count?.campaigns,
     isOrganizer: !!data?.organizer,
     organizerId: data?.organizer?.id,
-    activeOrganizer: !!data?.organizer?._count?.campaigns,
+    organizerCampaigns: data?.organizer?._count?.campaigns,
     isBeneficiary: !!data?.beneficiaries?.length,
     beneficiaryId: beneficiary?.id,
-    activeBeneficiary: !!beneficiary?._count?.campaigns,
+    beneficiaryCampaigns: beneficiary?._count?.campaigns,
     countryCode: beneficiary?.countryCode ?? 'BG',
     cityId: beneficiary?.cityId ?? '',
     description: beneficiary?.description ?? '',
@@ -219,21 +219,33 @@ export default function EditForm() {
           <Grid item xs={4}>
             <CheckboxField
               name="isOrganizer"
-              disabled={initialValues.activeOrganizer}
+              disabled={!!initialValues.organizerCampaigns}
+              disabledTooltip={t('person:admin.fields.disabled-tooltip', {
+                role: t('person:admin.fields.organizer'),
+                campaigns: initialValues.organizerCampaigns,
+              })}
               label="person:admin.fields.organizer"
             />
           </Grid>
           <Grid item xs={4}>
             <CheckboxField
               name="isCoordinator"
-              disabled={initialValues.activeCoordinator}
+              disabled={!!initialValues.coordinatorCampaigns}
+              disabledTooltip={t('person:admin.fields.disabled-tooltip', {
+                role: t('person:admin.fields.coordinator'),
+                campaigns: initialValues.coordinatorCampaigns,
+              })}
               label="person:admin.fields.coordinator"
             />
           </Grid>
           <Grid item xs={4}>
             <CheckboxField
               name="isBeneficiary"
-              disabled={initialValues.activeBeneficiary}
+              disabled={!!initialValues.beneficiaryCampaigns}
+              disabledTooltip={t('person:admin.fields.disabled-tooltip', {
+                role: t('person:admin.fields.beneficiary'),
+                campaigns: initialValues.beneficiaryCampaigns,
+              })}
               label="person:admin.fields.beneficiary"
               onChange={(e) => {
                 setShowBenefactor(e.target.checked)

--- a/src/components/common/person/grid/EditForm.tsx
+++ b/src/components/common/person/grid/EditForm.tsx
@@ -67,6 +67,9 @@ export default function EditForm() {
   const beneficiary = data?.beneficiaries?.at(0)
   const [showBenefactor, setShowBenefactor] = useState<boolean>(!!beneficiary)
 
+  console.log(data)
+  console.log('active', !!beneficiary?._count?.campaigns)
+
   const initialValues = {
     firstName: data?.firstName ?? '',
     lastName: data?.lastName ?? '',
@@ -233,6 +236,7 @@ export default function EditForm() {
           <Grid item xs={4}>
             <CheckboxField
               name="isBeneficiary"
+              disabled={initialValues.activeBeneficiary}
               label="person:admin.fields.beneficiary"
               onChange={(e) => {
                 setShowBenefactor(e.target.checked)

--- a/src/components/common/person/grid/EditForm.tsx
+++ b/src/components/common/person/grid/EditForm.tsx
@@ -67,9 +67,6 @@ export default function EditForm() {
   const beneficiary = data?.beneficiaries?.at(0)
   const [showBenefactor, setShowBenefactor] = useState<boolean>(!!beneficiary)
 
-  console.log(data)
-  console.log('active', !!beneficiary?._count?.campaigns)
-
   const initialValues = {
     firstName: data?.firstName ?? '',
     lastName: data?.lastName ?? '',

--- a/src/components/common/person/grid/EditPage.tsx
+++ b/src/components/common/person/grid/EditPage.tsx
@@ -4,7 +4,7 @@ import { Container } from '@mui/material'
 
 import AdminLayout from 'components/common/navigation/AdminLayout'
 import AdminContainer from 'components/common/navigation/AdminContainer'
-import PersonForm from './PersonForm'
+import EditForm from './EditForm'
 
 export default function CreatePage() {
   const { t } = useTranslation()
@@ -13,7 +13,7 @@ export default function CreatePage() {
     <AdminLayout>
       <AdminContainer title={t('person:admin.headings.edit')}>
         <Container maxWidth="md" sx={{ py: 5 }}>
-          <PersonForm />
+          <EditForm />
         </Container>
       </AdminContainer>
     </AdminLayout>

--- a/src/gql/beneficiary.d.ts
+++ b/src/gql/beneficiary.d.ts
@@ -31,6 +31,6 @@ export type BeneficiaryFormData = {
   description?: string
   publicData?: string
   privateData?: string
-  campaigns: []
+  campaigns?: []
   organizerRelation?: PersonRelation
 }

--- a/src/gql/person.d.ts
+++ b/src/gql/person.d.ts
@@ -38,9 +38,9 @@ export type PersonFormData = {
   companyNumber?: string
   legalPersonName?: string
   address?: string
-  isBeneficiary: boolean
-  isCoordinator: boolean
-  isOrganizer: boolean
+  isBeneficiary?: boolean
+  isCoordinator?: boolean
+  isOrganizer?: boolean
 }
 
 export type CreateBeneficiaryInput = {

--- a/src/gql/person.d.ts
+++ b/src/gql/person.d.ts
@@ -11,6 +11,16 @@ export type PersonResponse = {
   createdAt: string
   newsletter: boolean
   emailConfirmed: boolean
+  beneficiaries?: PersonRoleResponse[]
+  coordinators?: PersonRoleResponse
+  organizer?: PersonRoleResponse
+}
+
+export type PersonRoleResponse = {
+  id: string
+  _count?: {
+    campaigns: number
+  }
 }
 
 export type PersonPaginatedResponse = {
@@ -28,6 +38,9 @@ export type PersonFormData = {
   companyNumber?: string
   legalPersonName?: string
   address?: string
+  isBeneficiary: boolean
+  isCoordinator: boolean
+  isOrganizer: boolean
 }
 
 export type CreateBeneficiaryInput = {
@@ -81,7 +94,10 @@ export type UpdateUserAccount = {
   password: string
 }
 
-export type AdminPersonFormData = Pick<PersonFormData, 'firstName' | 'lastName' | 'email' | 'phone'>
+export type AdminPersonFormData = Pick<
+  PersonFormData,
+  'firstName' | 'lastName' | 'email' | 'phone' | 'isBeneficiary' | 'isCoordinator' | 'isOrganizer'
+>
 
 export type AdminPersonResponse = Pick<
   PersonResponse,

--- a/src/gql/person.d.ts
+++ b/src/gql/person.d.ts
@@ -1,4 +1,5 @@
 import { UUID } from './types'
+import { BeneficiaryFormData } from './beneficiary'
 
 export type PersonResponse = {
   id: string
@@ -11,13 +12,24 @@ export type PersonResponse = {
   createdAt: string
   newsletter: boolean
   emailConfirmed: boolean
-  beneficiaries?: PersonRoleResponse[]
+  beneficiaries?: PersonBeneficiaryResponse[]
   coordinators?: PersonRoleResponse
   organizer?: PersonRoleResponse
 }
 
 export type PersonRoleResponse = {
   id: string
+  _count?: {
+    campaigns: number
+  }
+}
+
+export type PersonBeneficiaryResponse = {
+  id: string
+  countryCode: string
+  cityId: string
+  description?: string
+  organizerRelation?: PersonRelation
   _count?: {
     campaigns: number
   }
@@ -97,7 +109,8 @@ export type UpdateUserAccount = {
 export type AdminPersonFormData = Pick<
   PersonFormData,
   'firstName' | 'lastName' | 'email' | 'phone' | 'isBeneficiary' | 'isCoordinator' | 'isOrganizer'
->
+> &
+  Pick<BeneficiaryFormData, 'countryCode' | 'cityId' | 'description' | 'organizerRelation'>
 
 export type AdminPersonResponse = Pick<
   PersonResponse,

--- a/src/service/organizer.ts
+++ b/src/service/organizer.ts
@@ -18,11 +18,11 @@ export const createOrganizer = () => {
   }
 }
 
-export const deleteOrganizer = (id: string) => {
+export const deleteOrganizer = () => {
   const { data: session } = useSession()
-  return async () => {
+  return async (data: string) => {
     return await apiClient.delete<OrganizerResponse, AxiosResponse<OrganizerResponse>>(
-      endpoints.organizer.removeOrganizer(id).url,
+      endpoints.organizer.removeOrganizer(data).url,
       authConfig(session?.accessToken),
     )
   }


### PR DESCRIPTION
Allow setting user as a coordinator, organizer and/or beneficiary from the user edit/create form.

Currently only coordinator and organizer are implemented!

Issue #1579 

## Screenshots:

Before

![Screenshot from 2023-09-18 10-02-59](https://github.com/podkrepi-bg/frontend/assets/123360440/6bb75fce-f17e-4fab-9824-e28cd7b5499e)

After

![Screenshot from 2023-09-18 10-02-37](https://github.com/podkrepi-bg/frontend/assets/123360440/6c82d1f4-b513-4c71-8456-8222772026a9)