### PR TITLE
QuillStyleWrapper: Make iframe responsive when inserted via MDXEditor

### DIFF
--- a/src/components/common/QuillStyleWrapper.tsx
+++ b/src/components/common/QuillStyleWrapper.tsx
@@ -15,7 +15,8 @@ export const QuillStypeWrapper = styled(Grid)(({ theme }) => ({
   ['.ql-editor, .ql-video']: {
     maxWidth: '100%',
   },
-  ['.ql-video']: {
+
+  ['.ql-video, iframe']: {
     maxWidth: '100%',
     marginInline: 'auto',
   },


### PR DESCRIPTION
MDXEditor doesn't add the ql-video class to the iframe element, resulting in layout break on smaller viewports.