### PR TITLE
Update Statistics styles (Homepage)

### DIFF
--- a/src/components/client/index/sections/PlatformStatisticsSection/Statistics/Statistics.styled.tsx
+++ b/src/components/client/index/sections/PlatformStatisticsSection/Statistics/Statistics.styled.tsx
@@ -51,6 +51,7 @@ export const StatisticsWrapper = styled(Stack)(() => ({
 export const SubtitleSectionText = styled(Typography)(() => ({
   display: 'inline-block',
   marginLeft: theme.spacing(2),
+  fontSize: theme.typography.pxToRem(16),
 }))
 
 export const SectionDivider = styled(Divider)(() => ({

--- a/src/components/client/index/sections/PlatformStatisticsSection/Statistics/Statistics.styled.tsx
+++ b/src/components/client/index/sections/PlatformStatisticsSection/Statistics/Statistics.styled.tsx
@@ -38,8 +38,27 @@ export const StatisticsWrapper = styled(Stack)(() => ({
   flexDirection: 'row',
   alignItems: 'center',
   padding: theme.spacing(1.87, 0),
+  whiteSpace: 'nowrap',
 
-  '&:last-of-type': { flexDirection: 'column' },
+  '&:last-of-type': {
+    flexDirection: 'column',
+    alignItems: 'flex-start',
+
+    [theme.breakpoints.up('md')]: {
+      alignItems: 'center',
+    },
+
+    '> p': {
+      width: '100%',
+      margin: 0,
+      textAlign: 'center',
+
+      [theme.breakpoints.up('md')]: {
+        alignItems: 'center',
+        marginLeft: theme.spacing(2),
+      },
+    },
+  },
 
   [theme.breakpoints.up('md')]: {
     padding: theme.spacing(1.87),


### PR DESCRIPTION
- Updated the font size of 'дарени лева' (from 14px to 16px) to be identical to 'кампании', 'дарения' and 'дарители'.
- Removed the spacing at the beginning of 'дарени лева'.

Before|After
---|---
![image](https://github.com/podkrepi-bg/frontend/assets/14351733/afb3ba72-ff74-4947-94c0-021146464af6)|![image](https://github.com/podkrepi-bg/frontend/assets/14351733/38b3eb14-75fe-428e-975a-b2f129b18cc6)
