### PR TITLE
beneficiery without mail

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -28,7 +28,7 @@ module.exports = {
     'sentry.client.config.js',
     'sentry.server.config.js',
     'next-sitemap.config.js',
-    'e2e/*'
+    'e2e/*',
   ],
   rules: {
     'react/display-name': 'off',

--- a/.prettierignore
+++ b/.prettierignore
@@ -4,6 +4,7 @@ yarn.lock
 package-lock.json
 public/fonts
 public/img
+public/js
 manifests
 .github
 !.github/workflows

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,23 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "type": "npm",
+      "script": "build",
+      "group": {
+        "kind": "build",
+        "isDefault": true
+      },
+      "problemMatcher": [],
+      "label": "npm: build",
+      "detail": "yarn build"
+    },
+    {
+      "type": "typescript",
+      "tsconfig": "tsconfig.build.json",
+      "problemMatcher": ["$tsc"],
+      "group": "build",
+      "label": "tsc: build - tsconfig.build.json"
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -100,7 +100,9 @@ Watch releases of this repository to be notified about future updates:
 ## Contributors ✨
 
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
+
 [![All Contributors](https://img.shields.io/badge/all_contributors-72-orange.svg?style=flat-square)](#contributors-)
+
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 
 Please check [contributors guide](https://github.com/podkrepi-bg/frontend/blob/master/CONTRIBUTING.md) for:

--- a/public/locales/en/admin.json
+++ b/public/locales/en/admin.json
@@ -16,5 +16,5 @@
     "view": "View",
     "edit": "Edit",
     "delete": "Delete"
-  },
+  }
 }

--- a/src/components/client/irregularity/helpers/irregularity.types.ts
+++ b/src/components/client/irregularity/helpers/irregularity.types.ts
@@ -43,8 +43,8 @@ export enum IrregularityReason {
 export type PersonFormData = {
   firstName: string
   lastName: string
-  email: string
-  phone: string | undefined
+  email?: string
+  phone?: string
 }
 
 export type InfoFormData = {

--- a/src/components/common/person/PersonAutoCompleteFilter.ts
+++ b/src/components/common/person/PersonAutoCompleteFilter.ts
@@ -15,7 +15,7 @@ export const personFilter = (
     const name = `${option.firstName.toLowerCase()} ${option.lastName.toLowerCase()}`
     return (
       name.includes(state.inputValue.toLowerCase()) ||
-      option.email.toLowerCase().includes(state.inputValue.toLowerCase())
+      option.email?.toLowerCase().includes(state.inputValue.toLowerCase())
     )
   })
 

--- a/src/components/common/person/grid/CreateForm.tsx
+++ b/src/components/common/person/grid/CreateForm.tsx
@@ -27,6 +27,7 @@ import { useCreateBeneficiary } from 'service/beneficiary'
 import OrganizerRelationSelect from 'components/admin/beneficiary/OrganizerRelationSelect'
 import CountrySelect from 'components/admin/countries/CountrySelect'
 import CitySelect from 'components/admin/cities/CitySelect'
+import { treeItemClasses } from '@mui/lab'
 
 const validationSchema = yup
   .object()
@@ -34,7 +35,20 @@ const validationSchema = yup
   .shape({
     firstName: name.required(),
     lastName: name.required(),
-    email: email.required(),
+    email: email
+      .when('isBeneficiary', {
+        is: true,
+        then: email.notRequired(),
+        otherwise: email.required(),
+      })
+      .when('isCoordinator', {
+        is: true,
+        then: email.required(),
+      })
+      .when('isOrganizer', {
+        is: true,
+        then: email.required(),
+      }),
     phone: phone.notRequired(),
     isCoordinator: yup.bool().required(),
     isOrganizer: yup.bool().required(),
@@ -60,8 +74,8 @@ const validationSchema = yup
 const initialValues: AdminPersonFormData = {
   firstName: '',
   lastName: '',
-  email: '',
-  phone: '',
+  email: undefined,
+  phone: undefined,
   isOrganizer: false,
   isCoordinator: false,
   isBeneficiary: false,

--- a/src/components/common/person/grid/EditForm.tsx
+++ b/src/components/common/person/grid/EditForm.tsx
@@ -35,7 +35,20 @@ const validationSchema = yup
   .shape({
     firstName: name.required(),
     lastName: name.required(),
-    email: email.required(),
+    email: email
+      .when('isBeneficiary', {
+        is: true,
+        then: email.notRequired(),
+        otherwise: email.required(),
+      })
+      .when('isCoordinator', {
+        is: true,
+        then: email.required(),
+      })
+      .when('isOrganizer', {
+        is: true,
+        then: email.required(),
+      }),
     phone: phone.notRequired(),
     isCoordinator: yup.bool().required(),
     isOrganizer: yup.bool().required(),
@@ -70,8 +83,8 @@ export default function EditForm() {
   const initialValues = {
     firstName: data?.firstName ?? '',
     lastName: data?.lastName ?? '',
-    email: data?.email ?? '',
-    phone: data?.phone ?? '',
+    email: data?.email ?? undefined,
+    phone: data?.phone ?? undefined,
     isCoordinator: !!data?.coordinators,
     coordinatorId: data?.coordinators?.id,
     coordinatorCampaigns: data?.coordinators?._count?.campaigns,

--- a/src/gql/person.d.ts
+++ b/src/gql/person.d.ts
@@ -5,8 +5,8 @@ export type PersonResponse = {
   id: string
   firstName: string
   lastName: string
-  email: string
-  phone: string
+  email?: string
+  phone?: string
   address: string
   company: string
   createdAt: string
@@ -43,7 +43,7 @@ export type PersonPaginatedResponse = {
 export type PersonFormData = {
   firstName: string
   lastName: string
-  email: string
+  email?: string
   phone?: string
   legalEntity: boolean
   companyName?: string

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,11 +1,7 @@
 {
   "compilerOptions": {
     "target": "ESNext",
-    "lib": [
-      "dom",
-      "dom.iterable",
-      "esnext"
-    ],
+    "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": false,
     "checkJs": false,
     "skipLibCheck": true,
@@ -32,16 +28,6 @@
     "incremental": true,
     "outDir": ".next"
   },
-  "include": [
-    "next-env.d.ts",
-    "**/*.ts",
-    "**/*.tsx"
-  ],
-  "exclude": [
-    "node_modules",
-    ".next",
-    "e2e"
-
-  ]
-
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules", ".next", "e2e"]
 }


### PR DESCRIPTION
## Motivation and context
Closes https://github.com/podkrepi-bg/frontend/issues/1006
Depends on: https://github.com/podkrepi-bg/api/pull/555

The requirement is when adding a person through the AdminUI for the purpose of being beneficiery it should not ask for email, since not every beneficiery has email actually.

Changes:
- made email optional when creating person as Beneficiery
- added build tasks
- formatting fixes


