### PR TITLE
Rounds correctly Donated money value in Statistics section

### DIFF
--- a/src/components/client/index/sections/PlatformStatisticsSection/Statistics/Statistics.tsx
+++ b/src/components/client/index/sections/PlatformStatisticsSection/Statistics/Statistics.tsx
@@ -25,7 +25,7 @@ export default function Statistics() {
 
   const donatedMoney = fromMoney(totalDonatedMoney?.total || 0)
   const unit = donatedMoney.toString().split('.')[0]
-  const fraction = donatedMoney.toString().split('.')[1]
+  const fraction = donatedMoney?.toFixed(2).toString().split('.')[1]
 
   const sections: { value?: number; message: string }[] = [
     {


### PR DESCRIPTION
Closes Issue #1614

## Motivation and context

- What problem are you trying to solve?
Donated money value in Statistics section is not rounded correctly when the value of stotinki ends with 0.
For example, if the stotinki amount is '10', the display value is '1'.

- How did you solve the problem? 
Specify the length of fractional part of 'donatedMoney' amount and padded it with zeros in order to meet the specified length, then display the fraction.

## Screenshots:

Before|After
![image](https://github.com/podkrepi-bg/frontend/assets/60223025/78baec9e-5437-4ee9-b595-9f809e6aea6c)
