### PR TITLE
1638 - remove disabled filters on the campaign list page

### DIFF
--- a/e2e/tests/smoke/smoke-campaigns.spec.ts
+++ b/e2e/tests/smoke/smoke-campaigns.spec.ts
@@ -46,7 +46,7 @@ test.describe('Campaigns page smoke tests - BG language version', async () => {
     expect(
       await campaignsPage.getFilterButtonsCount(),
       'Filter buttons count is not correct!',
-    ).toEqual(12)
+    ).toEqual(4)
   })
 
   test('Support Now action button navigates to the Donation page for particular campaign', async () => {

--- a/e2e/tests/smoke/smoke-campaigns.spec.ts
+++ b/e2e/tests/smoke/smoke-campaigns.spec.ts
@@ -46,7 +46,7 @@ test.describe('Campaigns page smoke tests - BG language version', async () => {
     expect(
       await campaignsPage.getFilterButtonsCount(),
       'Filter buttons count is not correct!',
-    ).toEqual(3)
+    ).toEqual(4)
   })
 
   test('Support Now action button navigates to the Donation page for particular campaign', async () => {

--- a/e2e/tests/smoke/smoke-campaigns.spec.ts
+++ b/e2e/tests/smoke/smoke-campaigns.spec.ts
@@ -46,7 +46,7 @@ test.describe('Campaigns page smoke tests - BG language version', async () => {
     expect(
       await campaignsPage.getFilterButtonsCount(),
       'Filter buttons count is not correct!',
-    ).toEqual(4)
+    ).toEqual(3)
   })
 
   test('Support Now action button navigates to the Donation page for particular campaign', async () => {

--- a/src/components/client/campaigns/CampaignFilter.tsx
+++ b/src/components/client/campaigns/CampaignFilter.tsx
@@ -57,6 +57,11 @@ const Root = styled('div')(() => ({
       color: theme.palette.primary.light,
       borderBottom: `5px solid ${theme.palette.primary.light}`,
     },
+
+    '&[aria-selected="true"]': {
+      color: theme.palette.primary.light,
+      borderBottom: `5px solid ${theme.palette.primary.light}`,
+    },
   },
 }))
 
@@ -103,10 +108,12 @@ export default function CampaignFilter() {
         {Object.values(CampaignTypeCategory).map((category) => {
           const count =
             campaigns?.filter((campaign) => campaign.campaignType.category === category).length ?? 0
+          if (count === 0) return
           return (
             <IconButton
               key={category}
               disabled={count === 0}
+              aria-selected={selectedCategory === category}
               className={classes.filterButtons}
               onClick={() => setSelectedCategory(category)}>
               {categories[category].icon ?? <Category fontSize="small" />}
@@ -116,7 +123,10 @@ export default function CampaignFilter() {
             </IconButton>
           )
         })}
-        <IconButton className={classes.filterButtons} onClick={() => setSelectedCategory('ALL')}>
+        <IconButton
+          aria-selected={selectedCategory === 'ALL'}
+          className={classes.filterButtons}
+          onClick={() => setSelectedCategory('ALL')}>
           <FilterNone fontSize="small" />
           <Typography>
             {t(`campaigns:filters.all`)} ({campaigns?.length ?? 0})


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!--- If it fixes an open issue, please link to the issue here. -->
Closes #1638 

## Motivation and context

- Removes the campaign categories filter in the campaigns page for categories that have 0 campaigns in (previously they were all disabled).
- Adds an `aria-selected` to the currently selected filter and styles based on that.

## Screenshots:

<!-- You can copy/paste screenshots directly in the editor -->

Before|After
---|---
<img width="1161" alt="image" src="https://github.com/podkrepi-bg/frontend/assets/61479393/10e6ffeb-6e29-4010-8811-df06a6c38dd5">|<img width="1007" alt="image" src="https://github.com/podkrepi-bg/frontend/assets/61479393/d99db6cb-9e8f-470e-b5f0-c21f3453f10b">

<!-- List of pages that are affected by the changes -->

## Testing

### Steps to test
Go to the `/campaigns` page and see the selected "All" category and the removed empty categories. Click around to filter and see the changes.
### Affected urls
`/campaigns`

