### PR TITLE
Add check to refund stripe donations only

### DIFF
--- a/src/components/admin/donations/grid/Grid.tsx
+++ b/src/components/admin/donations/grid/Grid.tsx
@@ -155,7 +155,8 @@ export default observer(function Grid() {
       width: 120,
       resizable: false,
       renderCell: (params: GridRenderCellParams) => {
-        return params.row?.status === DonationStatus.succeeded && params.row?.provider === PaymentProvider.stripe ? (
+        return params.row?.status === DonationStatus.succeeded &&
+          params.row?.provider === PaymentProvider.stripe ? (
           <>
             <Tooltip title={t('donations:refund.icon')}>
               <IconButton

--- a/src/components/admin/donations/grid/Grid.tsx
+++ b/src/components/admin/donations/grid/Grid.tsx
@@ -154,7 +154,7 @@ export default observer(function Grid() {
       width: 120,
       resizable: false,
       renderCell: (params: GridRenderCellParams) => {
-        return params.row?.status === 'succeeded' ? (
+        return params.row?.status === 'succeeded' && params.row?.provider === 'stripe' ? (
           <>
             <Tooltip title={t('donations:refund.icon')}>
               <IconButton

--- a/src/components/admin/donations/grid/Grid.tsx
+++ b/src/components/admin/donations/grid/Grid.tsx
@@ -27,6 +27,7 @@ import { useStores } from '../../../../common/hooks/useStores'
 import RenderEditBillingEmailCell from './RenderEditBillingEmailCell'
 import RestoreIcon from '@mui/icons-material/Restore'
 import RefundModal from '../modals/RefundModal'
+import { DonationStatus, PaymentProvider } from '../../../../gql/donations.enums'
 
 interface RenderCellProps {
   params: GridRenderCellParams
@@ -154,7 +155,7 @@ export default observer(function Grid() {
       width: 120,
       resizable: false,
       renderCell: (params: GridRenderCellParams) => {
-        return params.row?.status === 'succeeded' && params.row?.provider === 'stripe' ? (
+        return params.row?.status === DonationStatus.succeeded && params.row?.provider === PaymentProvider.stripe ? (
           <>
             <Tooltip title={t('donations:refund.icon')}>
               <IconButton


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
With https://github.com/podkrepi-bg/frontend/pull/1635 refund functionality was introduced. This functionality is only available for stripe donations. This PR improves UI experience  and shows  refund button only for the successful stripe donations.
<img width="1668" alt="Screenshot 2023-11-04 at 18 49 05" src="https://github.com/podkrepi-bg/frontend/assets/44066540/1613a2f8-5e5f-4004-ac11-634ff1c1b455">



