### PR TITLE
Bugfix/google auth del acc

### DIFF
--- a/src/components/client/auth/profile/DisableAccountModal.tsx
+++ b/src/components/client/auth/profile/DisableAccountModal.tsx
@@ -93,7 +93,7 @@ function DisableAccountModal({
   const [loading, setLoading] = useState(false)
 
   const { data: session } = useSession()
-  const isAuthenticatedByGoogle = session?.user?.iss.includes('google')
+  const selfReg: boolean = session?.user?.selfReg ?? false
 
   const mutation = useMutation<AxiosResponse<Person>, AxiosError<ApiErrors>, UpdatePerson>({
     mutationFn: disableCurrentPerson(),
@@ -173,30 +173,7 @@ function DisableAccountModal({
           {t('profile:disableModal.irreversibleAction')}
         </Typography>
         <br />
-        {isAuthenticatedByGoogle ? (
-          <Grid container spacing={3}>
-            <Grid item xs={12} sm={6}>
-              <Button
-                fullWidth
-                variant="contained"
-                size="medium"
-                color="primary"
-                onClick={() => handleClose()}>
-                {t('profile:disableModal.saveAccount')}
-              </Button>
-            </Grid>
-            <Grid item xs={12} sm={6}>
-              <Button
-                fullWidth
-                variant="contained"
-                size="medium"
-                color="error"
-                onClick={() => handleDisableUser()}>
-                {t('profile:disableModal.disableAccount')}
-              </Button>
-            </Grid>
-          </Grid>
-        ) : (
+        {selfReg ? (
           <GenericForm
             onSubmit={onSubmit}
             initialValues={{ password: '' }}
@@ -225,6 +202,29 @@ function DisableAccountModal({
               </Grid>
             </Grid>
           </GenericForm>
+        ) : (
+          <Grid container spacing={3}>
+            <Grid item xs={12} sm={6}>
+              <Button
+                fullWidth
+                variant="contained"
+                size="medium"
+                color="primary"
+                onClick={() => handleClose()}>
+                {t('profile:disableModal.saveAccount')}
+              </Button>
+            </Grid>
+            <Grid item xs={12} sm={6}>
+              <Button
+                fullWidth
+                variant="contained"
+                size="medium"
+                color="error"
+                onClick={() => handleDisableUser()}>
+                {t('profile:disableModal.disableAccount')}
+              </Button>
+            </Grid>
+          </Grid>
         )}
       </Box>
     </StyledModal>

--- a/src/service/auth.ts
+++ b/src/service/auth.ts
@@ -50,6 +50,7 @@ export type ServerUser = ParsedToken & {
   picture?: string
   session_state: string
   'allowed-origins': string[]
+  selfReg?: boolean
   // access
   realm_access: { roles: RealmRole[] }
   resource_access: { account: { roles: ResourceRole[] } }


### PR DESCRIPTION
Fixed the issue displaying the password input field for users using Google SSO by adding a token mapper in Keycloak. Manual configuration is required for both dev and prod environments. Introduced a 'selfReg' field in the ServerUser interface to indicate if the user is registered normally. In the DisableAccountModal, this new prop is used to determine whether to display the password field. Additionally, adjusted the position of the used templates.