### PR TITLE
[Campaign page] Aligns campaignType translation

### DIFF
--- a/public/locales/bg/campaigns.json
+++ b/public/locales/bg/campaigns.json
@@ -220,5 +220,25 @@
     "disabled": "Деактивирана",
     "error": "Грешна",
     "deleted": "Изтрита"
+  },
+  "campaignTypesFields": {
+    "treatment": "Лечение и рехабилитация",
+    "transplatation": "Трансплантация",
+    "cancer": "Рак",
+    "leukemia": "Левкемия",
+    "geneticDiseases": "Генетични заболявания",
+    "rehabilitation": "Рехабилитация",
+    "helping": "Помогни на нуждаещ се",
+    "kidsInRisk": "Деца в риск",
+    "thirdAge": "Трета възраст",
+    "homesForChildren": "Домове за деца",
+    "nursingHomes": "Старчески домове",
+    "betterSociety": "По-добро общество",
+    "education": "Обучение",
+    "culture": "Култура",
+    "nature": "Природа",
+    "human-rights": "Човешки права",
+    "animals": "Животни",
+    "disasters": "Бедствия"
   }
 }

--- a/public/locales/en/campaigns.json
+++ b/public/locales/en/campaigns.json
@@ -223,7 +223,7 @@
     "education": "Education",
     "culture": "Culture",
     "nature": "Nature",
-    "humanRights": "Human rights",
+    "human-rights": "Human rights",
     "animals": "Animals",
     "disasters": "Disasters"
   }

--- a/src/components/client/campaigns/CampaignInfo/CampaignInfoStatus.tsx
+++ b/src/components/client/campaigns/CampaignInfo/CampaignInfoStatus.tsx
@@ -58,7 +58,9 @@ export default function CampaignInfoStatus({ campaign, showExpensesLink }: Props
       </Box>
       <InfoStatusWrapper>
         <Grid item xs={12} md={6}>
-          <StatusLabel>{campaign.campaignType.name}</StatusLabel>
+          <StatusLabel>
+            {t(`campaigns:campaignTypesFields.${campaign.campaignType.slug}`)}
+          </StatusLabel>
           <RowWrapper>
             <StatusLabel variant="body2">{t('campaigns:campaign.status')}</StatusLabel>
             <StatusText>{t(`campaigns:campaign-status.${campaign.state}`)}</StatusText>


### PR DESCRIPTION
## A general summary of changes
Translate accurately the campaign type when a campaign page is opened.

## Motivation and context

### Why is this change required?
The campaign type does not translate on language change.

### How did you solve the problem?
- Additional Bulgarian translations has been added.
- Uses different prop (campaignType.slug instead of campaignType.name) to display a campaign type.

## Screenshots:
![image](https://github.com/podkrepi-bg/frontend/assets/60223025/13e2fe08-dabb-4d41-8e0e-999fefc9ca56)

## List of pages that are affected by the changes
Campaign page