### PR TITLE
hooks/campaigns: Disable useCampaignList only if data is prefetched

### DIFF
--- a/src/common/hooks/campaigns.ts
+++ b/src/common/hooks/campaigns.ts
@@ -43,11 +43,11 @@ export const campaignsOrderQueryFunction: QueryFunction<CampaignResponse[]> = as
   return shuffledActiveCampaigns.concat(shuffledInactiveCampaigns)
 }
 
-export function useCampaignList() {
+export function useCampaignList(prefetched = false) {
   return useQuery<CampaignResponse[]>(
     [endpoints.campaign.listCampaigns.url],
     campaignsOrderQueryFunction,
-    { enabled: false },
+    { enabled: !prefetched },
   )
 }
 

--- a/src/components/client/campaigns/CampaignFilter.tsx
+++ b/src/components/client/campaigns/CampaignFilter.tsx
@@ -79,7 +79,7 @@ const categories: {
 export default function CampaignFilter() {
   const { t } = useTranslation()
   const { mobile } = useMobile()
-  const { data: campaigns, isLoading } = useCampaignList()
+  const { data: campaigns, isLoading } = useCampaignList(true)
   const [selectedCategory, setSelectedCategory] = useState<string>('ALL')
   // TODO: add filters&sorting of campaigns so people can select based on personal preferences
   const campaignToShow = useMemo<CampaignResponse[]>(() => {

--- a/src/components/client/index/sections/ActiveCampaignsSection/ActiveCampaignsSection.tsx
+++ b/src/components/client/index/sections/ActiveCampaignsSection/ActiveCampaignsSection.tsx
@@ -14,7 +14,7 @@ import {
 
 export default function ActiveCampaignsSection() {
   const { t } = useTranslation('index')
-  const { data } = useCampaignList()
+  const { data } = useCampaignList(true)
   const activeCampaigns = data
     ?.filter((campaign) => campaign.state === CampaignState.active)
     .slice(0, 5)

--- a/src/components/client/index/sections/CompletedCampaignsSection/CompletedCampaignsSection.tsx
+++ b/src/components/client/index/sections/CompletedCampaignsSection/CompletedCampaignsSection.tsx
@@ -30,7 +30,7 @@ import {
 
 export default function CompletedCampaignsSection() {
   const { t } = useTranslation('campaigns')
-  const { data } = useCampaignList()
+  const { data } = useCampaignList(true)
 
   const completedCampaigns = data?.filter(
     (campaign: CampaignResponse) =>

--- a/src/components/client/index/sections/PlatformStatisticsSection/Statistics/Statistics.tsx
+++ b/src/components/client/index/sections/PlatformStatisticsSection/Statistics/Statistics.tsx
@@ -18,7 +18,7 @@ import { Stack } from '@mui/material'
 
 export default function Statistics() {
   const { t } = useTranslation('index')
-  const { data: campaigns } = useCampaignList()
+  const { data: campaigns } = useCampaignList(true)
   const { data: totalDonations } = useCampaignDonationHistory(undefined, 0, 1) //ask only for 1 item to get the total count
   const { data: donorsCount } = useDonatedUsersCount()
   const { data: totalDonatedMoney } = getTotalDonatedMoney()


### PR DESCRIPTION
When useCampaignList is called in the admin panel it uses cached value, and when the cached value expires, users won't be able to see the list of campaigns.