### PR TITLE
pdf/Certificate: Get donor's names from session token

### DIFF
--- a/src/components/client/pdf/Certificate.tsx
+++ b/src/components/client/pdf/Certificate.tsx
@@ -6,6 +6,7 @@ import { formatDateString } from 'common/util/date'
 import { money } from 'common/util/money'
 import theme from 'common/theme'
 import { DonationType } from 'gql/donations.enums'
+import { ServerUser } from 'service/auth'
 
 Font.register({
   family: 'Arial',
@@ -122,11 +123,12 @@ const styles = StyleSheet.create({
 
 type Props = {
   donation: DonationResponse
+  user: ServerUser | null | undefined
 }
-export default function Certificate({ donation }: Props) {
-  const companyName = donation.person?.company
-    ? donation.person.company.companyName
-    : donation.affiliate.company.companyName
+export default function Certificate({ donation, user }: Props) {
+  const userName = `${user?.given_name} ${user?.family_name}` ?? ''
+  const companyName = `${user?.company}` ?? ''
+
   return (
     <Document title="Дарение">
       <Page size="LETTER" style={styles.page}>
@@ -143,8 +145,7 @@ export default function Certificate({ donation }: Props) {
           <Text style={styles.text1}>С този сертификат Управителният съвет на</Text>
           <Text style={styles.text2}>Сдружение „Подкрепи БГ“ удостоверява, че:</Text>
           <Text style={styles.name}>
-            {donation.type === DonationType.donation &&
-              `${donation.person?.firstName} ${donation.person?.lastName}`}
+            {donation.type === DonationType.donation && userName}
             {donation.type === DonationType.corporate && companyName}
           </Text>
         </View>

--- a/src/pages/api/pdf/certificate/[donationId].tsx
+++ b/src/pages/api/pdf/certificate/[donationId].tsx
@@ -24,7 +24,7 @@ const Handler: NextApiHandler = async (req: NextApiRequest, res: NextApiResponse
   if (!donation) {
     res.status(404).json({ notFound: true })
   } else {
-    const pdfStream = await renderToStream(<Certificate donation={donation} />)
+    const pdfStream = await renderToStream(<Certificate donation={donation} user={jwt?.user} />)
     res.setHeader('Content-Type', 'application/pdf')
     pdfStream.pipe(res)
   }

--- a/src/service/auth.ts
+++ b/src/service/auth.ts
@@ -51,6 +51,7 @@ export type ServerUser = ParsedToken & {
   session_state: string
   'allowed-origins': string[]
   selfReg?: boolean
+  company: string
   // access
   realm_access: { roles: RealmRole[] }
   resource_access: { account: { roles: ResourceRole[] } }


### PR DESCRIPTION
Anonymous donations don't have personId to find them by users, thus get donor's names from session token.

REQUIRED keycloak changes:
Go to keycloak->webapp->Client scopes -> profile -> mappers -> Create 
Fill the fields with the following values:
Name: company
Mapper Type: User Attribute
User Attribute: companyName
Token Claim Name: company
Claim JSON type: String
Save
