### PR TITLE
DonorsAndDonations.tsx: Show updatedAt field as date instead of createdAt

### DIFF
--- a/src/components/client/campaigns/DonorsAndDonations.tsx
+++ b/src/components/client/campaigns/DonorsAndDonations.tsx
@@ -84,7 +84,7 @@ export default function DonorsAndDonations({ donations }: { donations: CampaignD
     <Root>
       <Grid item className={classes.donationsWrapper} data-testid="summary-donors-wrapper">
         {donationsToShow && donationsToShow.length !== 0 ? (
-          donationsToShow.map(({ type, metadata, person, amount, createdAt, currency }, key) => (
+          donationsToShow.map(({ type, metadata, person, amount, updatedAt, currency }, key) => (
             <Grid key={key} className={classes.donationItemWrapper}>
               <AccountCircleIcon
                 sx={{ position: 'relative', bottom: !metadata || !metadata.name ? 0 : 8 }}
@@ -120,28 +120,11 @@ export default function DonorsAndDonations({ donations }: { donations: CampaignD
                     )}
                   </>
                 )}
-                {/* {!metadata && (
-                  <Typography className={classes.donatorName}>
-                    {person
-                      ? person.company
-                        ? `${person.company.companyName}`
-                        : `${person.firstName} ${person.lastName}`
-                      : t('campaigns:donations.anonymous')}
-                  </Typography>
-                )}
-                {metadata && person && (
-                  <>
-                    <Typography className={classes.donatorName}>{metadata.name}</Typography>
-                    <Typography sx={{ fontSize: 12 }}>
-                      {t('campaigns:campaign.from')} {person.company.companyName}
-                    </Typography>
-                  </>
-                )} */}
                 <Grid className={classes.donationQuantityAndTimeWrapper}>
                   <Typography>{moneyPublic(amount, currency)}</Typography>
                   <span className={classes.separatorIcon}>|</span>
                   <Typography>
-                    {formatDistanceStrict(parseISO(createdAt), new Date(), {
+                    {formatDistanceStrict(parseISO(updatedAt), new Date(), {
                       locale: i18n?.language == 'bg' ? bg : enUS,
                       addSuffix: true,
                     })}

--- a/src/gql/campaigns.ts
+++ b/src/gql/campaigns.ts
@@ -185,7 +185,7 @@ export type CampaignDonation = {
   extPaymentIntentId: UUID
   extPaymentMethodId: UUID
   createdAt: string
-  updatedAt: string | undefined
+  updatedAt: string
   amount: number
   currency: Currency
   personId: UUID


### PR DESCRIPTION
When a bank transaction is imported from IRIS, we receive only the date of the transaction, and not the hours. Due to that it was decided that returned donations will be ordered by the updatedAt field, rather than createdAt.

In order to correctly represent, the data coming from database, we need to use updatedAt field on the front-end to show how much time has passed since donation was made, otherwise the lack of hours of bank donations makes the donation list to appear unordered.
 
Example of the mentioned problem:
![image](https://github.com/podkrepi-bg/frontend/assets/27433690/807ae359-fdca-4bed-83fa-81f57f84d2c8)

Cleaned up some commented code.

