### PR TITLE
campaign-news: Remove sourceLink field

### DIFF
--- a/src/components/client/campaign-news/secured/CreateForm.tsx
+++ b/src/components/client/campaign-news/secured/CreateForm.tsx
@@ -206,7 +206,7 @@ export default function CreateForm({ campaignId = '', isAdmin = true }: Campaign
               }}
             />
           </Grid>
-          <Grid item xs={12}>
+          {/* <Grid item xs={12}>
             <FormTextField
               type="text"
               label="news:article.source-link.label"
@@ -223,7 +223,7 @@ export default function CreateForm({ campaignId = '', isAdmin = true }: Campaign
                 ),
               }}
             />
-          </Grid>
+          </Grid> */}
           <Grid item xs={12} sm={4}>
             {isAdmin && <ArticleStatusSelect />}
           </Grid>

--- a/src/components/client/campaign-news/secured/EditForm.tsx
+++ b/src/components/client/campaign-news/secured/EditForm.tsx
@@ -237,7 +237,7 @@ export default function EditForm({ article, campaignId = '', isAdmin = true }: P
               }}
             />
           </Grid>
-          <Grid item xs={12}>
+          {/* <Grid item xs={12}>
             <FormTextField
               type="text"
               label="news:article.source-link.label"
@@ -254,7 +254,7 @@ export default function EditForm({ article, campaignId = '', isAdmin = true }: P
                 ),
               }}
             />
-          </Grid>
+          </Grid> */}
           <Grid item xs={12} sm={4}>
             {isAdmin && <ArticleStatusSelect />}
           </Grid>


### PR DESCRIPTION
Not currently used, and causes confusion
