### PR TITLE
client/notifications: Fix crash when selecting profile's email

### DIFF
--- a/src/components/client/index/sections/TeamMembersSection/TeamMembersSection.tsx
+++ b/src/components/client/index/sections/TeamMembersSection/TeamMembersSection.tsx
@@ -1,13 +1,12 @@
-import React, { useState } from 'react'
+import React from 'react'
 import Image from 'next/image'
 import { useTranslation } from 'next-i18next'
 import ChevronRightIcon from '@mui/icons-material/ChevronRight'
-import { Box, Grid } from '@mui/material'
+import { Box } from '@mui/material'
 import { routes } from 'common/routes'
 
 import { Heading, InfoText, OutlinedButton } from '../../IndexPage.styled'
 import { Root } from './TeamMembersSection.styled'
-import { SectionGridWrapper } from '../PlatformStatisticsSection/PlatformStatisticsSection.styled'
 
 export default function TeamMembersSection() {
   const { t } = useTranslation('index')

--- a/src/components/client/notifications/CampaignSubscribeModal.tsx
+++ b/src/components/client/notifications/CampaignSubscribeModal.tsx
@@ -55,7 +55,7 @@ const validationSchema: yup.SchemaOf<SubscribeToNotificationsInput> = yup
 
 export default function RenderCampaignSubscribeModal({ campaign, setOpen }: ModalProps) {
   const { t } = useTranslation()
-  const { status } = useSession()
+  const { status, data } = useSession()
   const [loading, setLoading] = useState(false)
   const [isSuccess, setIsSuccess] = useState(false)
   const [isGuest, setIsGuest] = useState(false)
@@ -75,13 +75,10 @@ export default function RenderCampaignSubscribeModal({ campaign, setOpen }: Moda
   >({
     mutationFn: useSubscribeToCampaign(campaign.id),
     onError: (error) => {
-      console.log(error.message)
-
       handleError(error)
     },
     onSuccess: () => {
       AlertStore.show(t('common:alerts.message-sent'), 'success')
-
       setIsSuccess(true)
     },
   })
@@ -137,10 +134,11 @@ export default function RenderCampaignSubscribeModal({ campaign, setOpen }: Moda
   }
 
   const sendOnProfileEmail = (status: string) => {
+    const userData = data?.user
     if (status !== 'authenticated') {
       router.push(routes.login)
     } else {
-      onSubmit({ email: email || '', consent: consent || true })
+      onSubmit({ email: userData?.email || '', consent: consent || true })
       handleClose()
     }
   }

--- a/src/components/client/notifications/GeneralSubscribeModal.tsx
+++ b/src/components/client/notifications/GeneralSubscribeModal.tsx
@@ -62,7 +62,7 @@ const validationSchema: yup.SchemaOf<SubscribeToNotificationsInput> = yup
 
 export default function RenderSubscribeModal({ setOpen }: ModalProps) {
   const { t } = useTranslation()
-  const { status } = useSession()
+  const { status, data } = useSession()
 
   const [loading, setLoading] = useState(false)
   const [isSuccess, setIsSuccess] = useState(false)
@@ -139,10 +139,11 @@ export default function RenderSubscribeModal({ setOpen }: ModalProps) {
   }
 
   const sendOnProfileEmail = (status: string) => {
+    const userData = data?.user
     if (status !== 'authenticated') {
       router.push(routes.login)
     } else {
-      onSubmit({ email: email || '' })
+      onSubmit({ email: userData?.email || '' })
       handleClose()
     }
   }

--- a/src/components/client/notifications/SubscriptionPage.tsx
+++ b/src/components/client/notifications/SubscriptionPage.tsx
@@ -97,8 +97,16 @@ export default function SubscriptionPage(data: Props) {
   }, [])
 
   const handleError = (e: AxiosError<ApiError>) => {
+    const error = e.response?.data?.message
+    AlertStore.show(error ? error : t('common:alerts.error'), 'error')
     setLoading(false)
     setIsSuccess(false)
+  }
+
+  const handleSuccess = () => {
+    AlertStore.show(t('common:alerts.message-sent'), 'success')
+    setIsSuccess(true)
+    setLoading(false)
   }
 
   const mutation = useMutation<
@@ -108,11 +116,7 @@ export default function SubscriptionPage(data: Props) {
   >({
     mutationFn: useSubscribePublicEmail(),
     onError: (error) => handleError(error),
-    onSuccess: () => {
-      AlertStore.show(t('common:alerts.message-sent'), 'success')
-      setIsSuccess(true)
-      setLoading(false)
-    },
+    onSuccess: () => handleSuccess,
   })
 
   async function callSubscribeApiRoute(values: {


### PR DESCRIPTION
When selecting `On the profile one` button from the notifications modal, crash occurs, due to email not being provided to the backend. Use logged in user's email from the session token, when `On the profile one` button is clicked.

Removed some unused imports.
