### PR TITLE
layout/nav: Fix text color inconsistencies in mobile navigations

### DIFF
--- a/src/components/client/layout/nav/DonationMenuMobile.tsx
+++ b/src/components/client/layout/nav/DonationMenuMobile.tsx
@@ -1,51 +1,18 @@
 import * as React from 'react'
-import { styled } from '@mui/material/styles'
-import Accordion from '@mui/material/Accordion'
+
 import AccordionSummary from '@mui/material/AccordionSummary'
 import AccordionDetails from '@mui/material/AccordionDetails'
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
 import LinkButton from 'components/common/LinkButton'
 import { useTranslation } from 'next-i18next'
 import { navItems } from './DonationMenu'
-
-const PREFIX = 'DonationMenuMobile'
-
-const classes = {
-  accordionWrapper: `${PREFIX}-accordionWrapper`,
-  accordionSummary: `${PREFIX}-accordionSummary`,
-  menuItem: `${PREFIX}-menuItem`,
-}
-
-const StyledAccordion = styled(Accordion)(({ theme }) => ({
-  [`&.${classes.accordionWrapper}`]: {
-    boxShadow: 'none',
-    borderTop: '2px solid lightgrey',
-    borderRadius: 0,
-  },
-
-  [`& .${classes.accordionSummary}`]: {
-    fontWeight: 500,
-    minHeight: theme.spacing(8),
-    padding: theme.spacing(0, 1),
-    fontSize: theme.typography.pxToRem(16),
-  },
-
-  [`& .${classes.menuItem}`]: {
-    justifyContent: 'start',
-    fontWeight: 400,
-    color: theme.palette.common.black,
-  },
-
-  '.Mui-expanded': {
-    backgroundColor: '#F0F0F0',
-  },
-}))
+import { StyledMenuAccordion, classes } from 'components/common/StyledAccordion'
 
 export default function DonationMenuMobile() {
   const { t } = useTranslation()
 
   return (
-    <StyledAccordion className={classes.accordionWrapper}>
+    <StyledMenuAccordion className={classes.accordionWrapper}>
       <AccordionSummary
         className={classes.accordionSummary}
         expandIcon={<ExpandMoreIcon />}
@@ -59,6 +26,6 @@ export default function DonationMenuMobile() {
           </LinkButton>
         ))}
       </AccordionDetails>
-    </StyledAccordion>
+    </StyledMenuAccordion>
   )
 }

--- a/src/components/client/layout/nav/ProjectMenuMobile.tsx
+++ b/src/components/client/layout/nav/ProjectMenuMobile.tsx
@@ -1,51 +1,17 @@
 import * as React from 'react'
-import { styled } from '@mui/material/styles'
-import Accordion from '@mui/material/Accordion'
+
 import AccordionSummary from '@mui/material/AccordionSummary'
 import AccordionDetails from '@mui/material/AccordionDetails'
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
 import LinkButton from 'components/common/LinkButton'
 import { useTranslation } from 'next-i18next'
 import { navItems } from './ProjectMenu'
-
-const PREFIX = 'ProfileMenuMobile'
-
-const classes = {
-  accordionWrapper: `${PREFIX}-accordionWrapper`,
-  accordionSummary: `${PREFIX}-accordionSummary`,
-  menuItem: `${PREFIX}-menuItem`,
-}
-
-const StyledAccordion = styled(Accordion)(({ theme }) => ({
-  [`&.${classes.accordionWrapper}`]: {
-    boxShadow: 'none',
-    borderTop: '2px solid lightgrey',
-    borderRadius: 0,
-  },
-
-  [`& .${classes.accordionSummary}`]: {
-    fontWeight: 500,
-    minHeight: theme.spacing(8),
-    padding: theme.spacing(0, 1),
-    fontSize: theme.typography.pxToRem(16),
-  },
-
-  [`& .${classes.menuItem}`]: {
-    justifyContent: 'start',
-    fontWeight: 400,
-    color: theme.palette.common.black,
-  },
-
-  '.Mui-expanded': {
-    backgroundColor: '#F0F0F0',
-  },
-}))
-
+import { StyledMenuAccordion, classes } from 'components/common/StyledAccordion'
 export default function ProjectMenuMobile() {
   const { t } = useTranslation()
 
   return (
-    <StyledAccordion className={classes.accordionWrapper}>
+    <StyledMenuAccordion className={classes.accordionWrapper}>
       <AccordionSummary
         expandIcon={<ExpandMoreIcon />}
         aria-controls="aboutus-panel-content"
@@ -59,6 +25,6 @@ export default function ProjectMenuMobile() {
           </LinkButton>
         ))}
       </AccordionDetails>
-    </StyledAccordion>
+    </StyledMenuAccordion>
   )
 }

--- a/src/components/common/StyledAccordion.tsx
+++ b/src/components/common/StyledAccordion.tsx
@@ -1,0 +1,35 @@
+import { Accordion, styled } from '@mui/material'
+
+const PREFIX = 'MenuMobile'
+
+export const classes = {
+  accordionWrapper: `${PREFIX}-accordionWrapper`,
+  accordionSummary: `${PREFIX}-accordionSummary`,
+  menuItem: `${PREFIX}-menuItem`,
+}
+
+export const StyledMenuAccordion = styled(Accordion)(({ theme }) => ({
+  [`&.${classes.accordionWrapper}`]: {
+    boxShadow: 'none',
+    borderTop: '2px solid lightgrey',
+    borderRadius: 0,
+  },
+
+  [`& .${classes.accordionSummary}`]: {
+    fontWeight: 500,
+    minHeight: theme.spacing(8),
+    padding: theme.spacing(0, 1),
+    fontSize: theme.typography.pxToRem(16),
+    color: theme.palette.common.black,
+  },
+
+  [`& .${classes.menuItem}`]: {
+    justifyContent: 'start',
+    fontWeight: 400,
+    color: theme.palette.common.black,
+  },
+
+  '.Mui-expanded': {
+    backgroundColor: '#F0F0F0',
+  },
+}))


### PR DESCRIPTION
Since the last commit, it was observed that there is still very minor difference in colors, between different navigations.
