### PR TITLE
SubscriptionPage.tsx: Fix showing error on successful subscription

### DIFF
--- a/src/components/client/notifications/SubscriptionPage.tsx
+++ b/src/components/client/notifications/SubscriptionPage.tsx
@@ -116,7 +116,7 @@ export default function SubscriptionPage(data: Props) {
   >({
     mutationFn: useSubscribePublicEmail(),
     onError: (error) => handleError(error),
-    onSuccess: () => handleSuccess,
+    onSuccess: () => handleSuccess(),
   })
 
   async function callSubscribeApiRoute(values: {


### PR DESCRIPTION
The issue was caused by handleSuccess not being called, on successful response.

