### PR TITLE
admin/donations: Add payment related fields to donation section

### DIFF
--- a/src/components/admin/donations/grid/Grid.tsx
+++ b/src/components/admin/donations/grid/Grid.tsx
@@ -113,11 +113,52 @@ export default observer(function Grid() {
       field: 'paymentId',
       //TODO:Ttranslate
       headerName: 'Плащане номер',
-      width: 300,
+      width: 150,
       renderCell: (params: GridRenderCellParams) => {
         return (
           <Link href={`/admin/payments?id=${params.row.paymentId}`}>{params.row.paymentId}</Link>
         )
+      },
+    },
+    {
+      field: 'payment.status',
+      //TODO:Ttranslate
+      headerName: 'Статус на плащане',
+      renderCell(params) {
+        return params.row.payment.status
+      },
+    },
+    {
+      field: 'payment.provider',
+      //TODO:Ttranslate
+      headerName: 'Разплащателна система',
+      renderCell(params) {
+        return params.row.payment.provider
+      },
+    },
+    {
+      field: 'amount',
+      headerName: t('donations:amount'),
+      renderCell: (params: GridRenderCellParams) => {
+        return <RenderMoneyCell params={params} />
+      },
+    },
+    {
+      field: 'payment.billingName',
+      //TODO:Ttranslate
+      headerName: 'billingName',
+      width: 250,
+      renderCell(params) {
+        return params.row.payment.billingName
+      },
+    },
+    {
+      field: 'payment.billingEmail',
+      //TODO:Ttranslate
+      headerName: 'billingEmail',
+      width: 300,
+      renderCell(params) {
+        return params.row.payment.billingEmail
       },
     },
     {
@@ -130,17 +171,13 @@ export default observer(function Grid() {
       },
     },
     {
-      field: 'amount',
-      headerName: t('donations:amount'),
-      renderCell: (params: GridRenderCellParams) => {
-        return <RenderMoneyCell params={params} />
-      },
-    },
-    {
       field: 'currency',
       headerName: t('donations:currency'),
       ...commonProps,
       width: 100,
+      renderCell(params) {
+        return params.row.payment.currency
+      },
     },
     {
       field: 'person',

--- a/src/components/admin/payments/grid/Grid.tsx
+++ b/src/components/admin/payments/grid/Grid.tsx
@@ -165,10 +165,14 @@ export default observer(function Grid() {
       },
     },
     {
+      field: 'type',
+      headerName: t('donations:type'),
+    },
+    {
       field: 'createdAt',
       headerName: t('donations:date'),
       ...commonProps,
-      width: 250,
+      width: 200,
       renderCell: (params: GridRenderCellParams) => {
         return getExactDateTime(params?.row.createdAt)
       },
@@ -176,6 +180,17 @@ export default observer(function Grid() {
     {
       field: 'status',
       headerName: t('donations:status'),
+    },
+    {
+      field: 'id',
+      headerName: 'ID',
+      width: 320,
+    },
+    {
+      field: 'provider',
+      headerName: t('donations:provider'),
+      ...commonProps,
+      width: 100,
     },
     {
       field: 'amount',
@@ -209,21 +224,6 @@ export default observer(function Grid() {
           <RenderEditBillingEmailCell params={params} personList={personList} onUpdate={refetch} />
         )
       },
-    },
-    {
-      field: 'id',
-      headerName: 'ID',
-      width: 320,
-    },
-    {
-      field: 'type',
-      headerName: t('donations:type'),
-    },
-    {
-      field: 'provider',
-      headerName: t('donations:provider'),
-      ...commonProps,
-      width: 200,
     },
     {
       field: 'donations',

--- a/src/components/admin/payments/grid/GridFilters.tsx
+++ b/src/components/admin/payments/grid/GridFilters.tsx
@@ -91,12 +91,6 @@ export default observer(function GridFilters() {
         menuItems={donationStatusMenuItems}
       />
       <Filter
-        value={donationStore.donationFilters.status}
-        options={donationStatusOptions}
-        onChange={handleChange}
-        menuItems={donationStatusMenuItems}
-      />
-      <Filter
         value={donationStore.donationFilters.provider}
         options={paymentProviderOptions}
         onChange={handleChange}

--- a/src/gql/campaigns.ts
+++ b/src/gql/campaigns.ts
@@ -7,6 +7,7 @@ import { CampaignState } from 'components/client/campaigns/helpers/campaign.enum
 import { BeneficiaryType } from '../components/admin/beneficiary/BeneficiaryTypes'
 import { VaultResponse } from './vault'
 import { CampaignNewsResponse } from './campaign-news'
+import { TPaymentResponse } from './donations'
 
 export type CampaignType = {
   id: UUID
@@ -178,12 +179,8 @@ export type CampaignUploadImage = {
 export type CampaignDonation = {
   id: UUID
   type: string
-  status: string
-  provider: PaymentProvider
+  payment: TPaymentResponse
   targetVaultId: UUID
-  extCustomerId: UUID
-  extPaymentIntentId: UUID
-  extPaymentMethodId: UUID
   createdAt: string
   updatedAt: string
   amount: number


### PR DESCRIPTION
**admin/donations: Add payment related to donation section** 
- Includes payment data such as provider, billingName, billingEmail. Requested by the finance team for easier referencing.
Requires  [#609](https://github.com/podkrepi-bg/api/pull/609) to be merged, as it changes the API response to include the necessary payment data, referenced by the table
 
**admin/payments: Remove duplicate of status filter dropdown**

**admin/payments:  Reordered payments field**
Moved payment type, and payment provider as to first spots..