### PR TITLE
fix: Indent scan_manifest job correctly in yaml files

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,7 +89,7 @@ jobs:
         with:
           image: ghcr.io/podkrepi-bg/frontend:${{ env.VERSION }}
 
- scan-manifests:
+  scan-manifests:
    name: Scan k8s manifests
    runs-on: ubuntu-latest
    steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -126,7 +126,7 @@ jobs:
   release-dev:
     name: Release to dev
     runs-on: ubuntu-latest
-    needs: [build-frontend-image, build-maintenance-image, run-playwright]
+    needs: [build-frontend-image, build-maintenance-image, scan-manifests, run-playwright]
     environment:
       name: dev
       url: https://dev.podkrepi.bg

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -71,7 +71,7 @@ jobs:
         with:
           image: ghcr.io/podkrepi-bg/maintenance:pr
 
- scan-manifests:
+  scan-manifests:
    name: Scan k8s manifests
    runs-on: ubuntu-latest
    steps:


### PR DESCRIPTION
It appears after uncommenting the scan_manifest job the indentation was not done correctly, resulting in the whole job failing.

Tests:
Checked the affected yaml files, in a couple yaml validators, seems ok now.
