### PR TITLE
Remove horizontal scroll on Campaign details page on mobile

### DIFF
--- a/src/components/client/campaigns/CampaignInfo/CampaignInfoStatus.tsx
+++ b/src/components/client/campaigns/CampaignInfo/CampaignInfoStatus.tsx
@@ -25,8 +25,9 @@ export default function CampaignInfoStatus({ campaign, showExpensesLink }: Props
       <Box
         component="span"
         sx={{
-          display: 'flex',
+          display: 'block',
           gap: theme.spacing(1),
+          flexWrap: 'wrap',
           margin: theme.spacing(3, 0, 6),
           alignItems: 'center',
         }}>

--- a/src/components/client/campaigns/CampaignInfo/CampaignInfoStatus.tsx
+++ b/src/components/client/campaigns/CampaignInfo/CampaignInfoStatus.tsx
@@ -25,7 +25,7 @@ export default function CampaignInfoStatus({ campaign, showExpensesLink }: Props
       <Box
         component="span"
         sx={{
-          display: 'block',
+          display: 'flex',
           gap: theme.spacing(1),
           flexWrap: 'wrap',
           margin: theme.spacing(3, 0, 6),


### PR DESCRIPTION
The chips on Campaign details page were not responsive which caused a horizontal scroll on mobile devices. Adding 
flexWrap: 'wrap' fixes this issue:

Before|After
---|---
![image](https://github.com/podkrepi-bg/frontend/assets/14351733/dbabb098-6103-4134-a77c-60fdd6f7ff60)|![image](https://github.com/podkrepi-bg/frontend/assets/14351733/145da563-955e-4269-9812-c77bd70a1000)