### PR TITLE
DonorsAndDonations.tsx: Use createdAt field, to show when donation was created

### DIFF
--- a/src/components/client/campaigns/DonorsAndDonations.tsx
+++ b/src/components/client/campaigns/DonorsAndDonations.tsx
@@ -84,7 +84,7 @@ export default function DonorsAndDonations({ donations }: { donations: CampaignD
     <Root>
       <Grid item className={classes.donationsWrapper} data-testid="summary-donors-wrapper">
         {donationsToShow && donationsToShow.length !== 0 ? (
-          donationsToShow.map(({ type, metadata, person, amount, updatedAt, currency }, key) => (
+          donationsToShow.map(({ type, metadata, person, amount, createdAt, currency }, key) => (
             <Grid key={key} className={classes.donationItemWrapper}>
               <AccountCircleIcon
                 sx={{ position: 'relative', bottom: !metadata || !metadata.name ? 0 : 8 }}
@@ -124,7 +124,7 @@ export default function DonorsAndDonations({ donations }: { donations: CampaignD
                   <Typography>{moneyPublic(amount, currency)}</Typography>
                   <span className={classes.separatorIcon}>|</span>
                   <Typography>
-                    {formatDistanceStrict(parseISO(updatedAt), new Date(), {
+                    {formatDistanceStrict(parseISO(createdAt), new Date(), {
                       locale: i18n?.language == 'bg' ? bg : enUS,
                       addSuffix: true,
                     })}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
The order of public donation has changed, back to the value of createdAt field in descending order.[#api620](https://github.com/podkrepi-bg/api/commit/3089a38184bb87701d2c450020d24fd8192c08bd). This change is necessary to prevent any confusion, due to mismatch between the order of a donation, and the shown date of a donation to the end user.
