### PR TITLE
fix: Show company name if campaign organizer is corporation

### DIFF
--- a/src/components/admin/campaigns/grid/OrganizerSelect.tsx
+++ b/src/components/admin/campaigns/grid/OrganizerSelect.tsx
@@ -34,12 +34,16 @@ export default function OrganizerSelect({ name = 'organizerId', label = 'campaig
         options={data || []}
         getOptionLabel={(option: OrganizerResponse) => {
           if (!option.person) return ''
-          return `${option.person.firstName} ${option.person.lastName}`
+          return option.person.company
+            ? option.person.company.companyName
+            : `${option.person.firstName} ${option.person.lastName}`
         }}
         renderInput={(params) => <TextField {...params} label={t(label)} />}
         renderOption={(params, option: OrganizerResponse) => (
           <Box component="li" {...params} key={option.id}>
-            {`${option.person.firstName} ${option.person.lastName}`}
+            {option.person.company
+              ? option.person.company.companyName
+              : `${option.person.firstName} ${option.person.lastName}`}
           </Box>
         )}
         isOptionEqualToValue={(option, value) =>

--- a/src/components/admin/donations/grid/Grid.tsx
+++ b/src/components/admin/donations/grid/Grid.tsx
@@ -96,7 +96,6 @@ export default observer(function Grid() {
 
   const {
     data: { items: donations, total: allDonationsCount } = { items: [], total: 0 },
-    error: donationHistoryError,
     isLoading: isDonationHistoryLoading,
     refetch,
   }: UseQueryResult<CampaignDonationHistoryResponse> = useDonationsList(

--- a/src/components/admin/organizers/grid/Grid.tsx
+++ b/src/components/admin/organizers/grid/Grid.tsx
@@ -44,7 +44,9 @@ export default observer(function Grid() {
       editable: false,
       width: 400,
       valueGetter: (f) => {
-        return `${f.row.person.firstName} ${f.row.person.lastName}`
+        return f.row.person.company
+          ? f.row.person.company.companyName
+          : `${f.row.person.firstName} ${f.row.person.lastName}`
       },
     },
     {

--- a/src/components/client/campaigns/CampaignInfo/CampaignInfoOrganizer.tsx
+++ b/src/components/client/campaigns/CampaignInfo/CampaignInfoOrganizer.tsx
@@ -17,12 +17,16 @@ export default function CampaignInfoOrganizer({ campaign }: Props) {
   const { t } = useTranslation()
   const organizerAvatarSource = organizerCampaignPictureUrl(campaign)
 
+  const organizerName = campaign.organizer?.person.company
+    ? campaign.organizer.person.company.companyName
+    : `${campaign.organizer?.person.firstName} ${campaign.organizer?.person.lastName}`
+
   return (
     <BeneficiaryOrganizerRoot>
       <Grid>
         <Label variant="subtitle2">{t('campaigns:campaign.organizer.name')}</Label>
         <Typography variant="subtitle2" component="p">
-          {campaign.organizer?.person.firstName || ''} {campaign.organizer?.person.lastName || ''}
+          {organizerName}
         </Typography>
         <EmailButton
           startIcon={<EmailIcon color="action" />}
@@ -37,9 +41,7 @@ export default function CampaignInfoOrganizer({ campaign }: Props) {
       </Grid>
       <Avatar
         src={organizerAvatarSource}
-        alt={`${t('campaign.image-of')}  ${campaign.organizer?.person.firstName} ${
-          campaign.organizer?.person.lastName
-        }`}
+        alt={`${t('campaign.image-of')}  ${organizerName}`}
         width={100}
         height={100}
       />

--- a/src/components/common/person/PersonInfo.tsx
+++ b/src/components/common/person/PersonInfo.tsx
@@ -59,7 +59,7 @@ function PersonInfo({ person }: Props) {
             {t('person:info.createdAt')}: {formatDateString(person.createdAt, i18n?.language)}
           </Typography>
           <Typography>
-            {t('person:info.company')}: {person.company}
+            {t('person:info.company')}: {person.company.companyName}
           </Typography>
           <Typography>
             {t('person:info.confirmedEmail')}: {person.emailConfirmed ? 'Yes' : 'No'}

--- a/src/components/common/person/PersonSelect.tsx
+++ b/src/components/common/person/PersonSelect.tsx
@@ -38,7 +38,8 @@ export default function PersonSelect({
         </MenuItem>
         {personList.map((person, index) => (
           <MenuItem key={index} value={person.id}>
-            {person.firstName} {person.lastName}
+            {/* {person.firstName} {person.lastName} */}
+            {person.company ? person.company.companyName : `${person.firstName} ${person.lastName}`}
           </MenuItem>
         ))}
       </FormTextField>

--- a/src/gql/campaigns.ts
+++ b/src/gql/campaigns.ts
@@ -99,16 +99,33 @@ export type CampaignResponse = BaseCampaignResponse & {
     id: UUID
     type: BeneficiaryType
     publicData: string
-    person: { id: UUID; firstName: string; lastName: string }
+    person: {
+      id: UUID
+      firstName: string
+      lastName: string
+      company: { id: string; companyName: string }
+    }
     company: { id: UUID; companyName: string }
   }
   coordinator: {
     id: UUID
-    person: { id: UUID; firstName: string; lastName: string; email: string }
+    person: {
+      id: UUID
+      firstName: string
+      lastName: string
+      email: string
+      company: { id: string; companyName: string }
+    }
   }
   organizer?: {
     id: UUID
-    person: { id: UUID; firstName: string; lastName: string; email: string }
+    person: {
+      id: UUID
+      firstName: string
+      lastName: string
+      email: string
+      company: { id: string; companyName: string }
+    }
   }
   campaignFiles: CampaignFile[] | []
   vaults?: VaultResponse[]

--- a/src/gql/person.d.ts
+++ b/src/gql/person.d.ts
@@ -9,7 +9,6 @@ export type PersonResponse = {
   email?: string
   phone?: string
   address: string
-  company: string
   createdAt: string
   newsletter: boolean
   emailConfirmed: boolean
@@ -17,6 +16,7 @@ export type PersonResponse = {
   coordinators?: PersonRoleResponse
   organizer?: PersonRoleResponse
   profileEnabled: boolean
+  company: Pick<CompanyResponse, 'id' | 'companyName'>
 }
 
 export type PersonRoleResponse = {


### PR DESCRIPTION
It was reported, that when corporate profile is campaign's organizer, the name of the representative is shown instead of the company name.