### PR TITLE
chore: add devcontainer.json

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,25 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/alpine
+{
+	"name": "NodeJS",  
+ 	"image": "ghcr.io/podkrepi-bg/nodejs-devcontainer:v1.2.0",
+	"forwardPorts": [], // Forward ports
+	"containerEnv": {
+		"DATABASE_URL": "postgres://postgres:postgrespass@host.docker.internal:5432/postgres?schema=api" // Custom env vars
+	},
+	"postStartCommand": "yarn", // Install dependencies
+	"customizations":{
+		"vscode": {
+			"extensions": [
+				"ms-azuretools.vscode-docker",
+				"nrwl.angular-console",
+				"esbenp.prettier-vscode",
+				"firsttris.vscode-jest-runner",
+				"dbaeumer.vscode-eslint"
+			]
+		}
+	},
+	"mounts": [
+		"source=/var/run/docker.sock,target=/var/run/docker.sock,type=bind"
+	]
+}


### PR DESCRIPTION
## Motivation and context

- to enable vscode users to just open the dev container and have them be ready to go in minutes
- the config follows https://github.com/podkrepi-bg/dev-containers/blob/main/nodejs/README.md
- and pushes to the next version 1.2.0 which fixes the vscode unsupported alpine image error

