### PR TITLE
Adding translation for Compaign Details Financial Reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,9 @@ Watch releases of this repository to be notified about future updates:
 ## Contributors ✨
 
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
+
 [![All Contributors](https://img.shields.io/badge/all_contributors-79-orange.svg?style=flat-square)](#contributors-)
+
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 
 Please check [contributors guide](https://github.com/podkrepi-bg/frontend/blob/master/CONTRIBUTING.md) for:

--- a/public/locales/bg/campaigns.json
+++ b/public/locales/bg/campaigns.json
@@ -207,5 +207,12 @@
     "nature": "Природа",
     "art": "Изкуство",
     "others": "Други"
+  },
+  "campaign-details-report": {
+    "amount-collected": "Събрана сума",
+    "available": "Налични",
+    "guaranteed": "Гарантирани",
+    "translated": "Преведени",
+    "accounted": "Отчетени"
   }
 }

--- a/public/locales/en/campaigns.json
+++ b/public/locales/en/campaigns.json
@@ -207,5 +207,12 @@
     "nature": "Nature",
     "art": "Art",
     "others": "others"
+  },
+  "campaign-details-report": {
+    "amount-collected": "Amount Collected",
+    "available": "Аvailable",
+    "guaranteed": "Guaranteed",
+    "translated": "Translated",
+    "accounted": "Accounted"
   }
 }

--- a/src/components/client/campaigns/CampaignDetails.tsx
+++ b/src/components/client/campaigns/CampaignDetails.tsx
@@ -249,13 +249,15 @@ type CampaignFinanceProps = Props & {
 const CampaignFinanceSummary = ({ campaign, expenses }: CampaignFinanceProps) => {
   const total = (campaign.summary.guaranteedAmount ?? 0) + campaign.summary.reachedAmount
   const transferred = campaign.summary.blockedAmount + campaign.summary.withdrawnAmount
+  const { t } = useTranslation()
   return (
     <StyledGrid item>
       <Typography variant="h5" fontWeight={500}>
-        Събрана сума: {moneyPublic(total)}
+        {t('campaigns:campaign-details-report.amount-collected')}: {moneyPublic(total)}
       </Typography>
       <Typography className={classes.financeSummary}>
-        Налични: {moneyPublic(campaign.summary.currentAmount)}
+        {t('campaigns:campaign-details-report.available')}:{' '}
+        {moneyPublic(campaign.summary.currentAmount)}
         <Tooltip enterTouchDelay={0} title="Средства налични по сметката на Podkrepi.bg">
           <IconButton size="small" color="primary">
             <InfoOutlined fontSize="small" />
@@ -263,7 +265,8 @@ const CampaignFinanceSummary = ({ campaign, expenses }: CampaignFinanceProps) =>
         </Tooltip>
       </Typography>
       <Typography className={classes.financeSummary}>
-        Гарантирани: {moneyPublic(campaign.summary.guaranteedAmount ?? 0)}
+        {t('campaigns:campaign-details-report.guaranteed')}:{' '}
+        {moneyPublic(campaign.summary.guaranteedAmount ?? 0)}
         <Tooltip
           enterTouchDelay={0}
           title={
@@ -275,7 +278,7 @@ const CampaignFinanceSummary = ({ campaign, expenses }: CampaignFinanceProps) =>
         </Tooltip>
       </Typography>
       <Typography className={classes.financeSummary} fontWeight={600}>
-        Преведени: {moneyPublic(transferred)}
+        {t('campaigns:campaign-details-report.translated')}: {moneyPublic(transferred)}
         <Tooltip
           enterTouchDelay={0}
           title="Средства преведени от сметката на Podkrepi.bg към организатора на кампанията">
@@ -285,7 +288,7 @@ const CampaignFinanceSummary = ({ campaign, expenses }: CampaignFinanceProps) =>
         </Tooltip>
       </Typography>
       <Typography className={classes.financeSummary}>
-        Отчетени: {moneyPublic(expenses)}
+        {t('campaigns:campaign-details-report.accounted')}: {moneyPublic(expenses)}
         <Tooltip enterTouchDelay={0} title="Отчетени разходи">
           <IconButton size="small" color="primary">
             <InfoOutlined fontSize="small" />


### PR DESCRIPTION
Translation for Financial Reports

## Motivation and context

There no translation for financial reports

## Screenshots:
before : 
![before](https://github.com/podkrepi-bg/frontend/assets/74927065/da584ee4-d22b-41a2-a246-c2f5c98e5f72)
after : 
![after](https://github.com/podkrepi-bg/frontend/assets/74927065/a69981e1-3278-45ee-a039-2204802b08dc)
