### PR TITLE
fix: Admin ui accessible by normal user

### DIFF
--- a/src/components/common/navigation/AdminLayout.tsx
+++ b/src/components/common/navigation/AdminLayout.tsx
@@ -16,6 +16,10 @@ import Link from 'next/link'
 import { routes } from 'common/routes'
 import PictureLogo from '/public/android-chrome-192x192.png'
 import Image from 'next/image'
+import { useSession } from 'next-auth/react'
+import { isAdmin } from 'common/util/roles'
+
+import NotFoundPage from '../errors/NotFoundPage/NotFoundPage'
 
 const PREFIX = 'AdminLayout'
 const drawerWidth = 200
@@ -97,7 +101,10 @@ type Props = {
 
 export default function AdminLayout({ children }: Props) {
   const theme = useTheme()
-
+  const session = useSession()
+  if (!isAdmin(session.data)) {
+    return <NotFoundPage />
+  }
   const initialOpen = useMemo<boolean>(() => {
     const item = typeof window !== 'undefined' ? window.localStorage.getItem('menu-open') : false
     if (item) {


### PR DESCRIPTION
Fix Admin panel being accessible by normal users. Renders NotFoundPage whenever non-admin user attempts to visit /admin/*  URL.


<!--- Provide a general summary of your changes in the Title above -->

<!--- If it fixes an open issue, please link to the issue here. -->
Closes [api#642](https://github.com/podkrepi-bg/api/issues/642)


## Testing

### Steps to test
1. Login as normal user
2. Attempt to visit any admin 
3. Should see 404 page not found.
### Affected urls
https://podkrepi.bg/admin/*

