### PR TITLE
feat: create a protected route for campaign applications (Epic #1842)

### DIFF
--- a/src/common/routes.ts
+++ b/src/common/routes.ts
@@ -91,6 +91,7 @@ export const routes = {
   campaigns: {
     index: '/campaigns',
     create: '/campaigns/create',
+    application: 'campaigns/application',
     viewCampaignBySlug: (slug: string) => `/campaigns/${slug}`,
     viewExpenses: (slug: string) => `/campaigns/${slug}/expenses`,
     oneTimeDonation: (slug: string) => `/campaigns/donation/${slug}`,

--- a/src/components/client/campaign-application/CampaignApplicationPage.tsx
+++ b/src/components/client/campaign-application/CampaignApplicationPage.tsx
@@ -1,0 +1,5 @@
+import Layout from '../layout/Layout'
+
+export default function CampaignApplicationPage() {
+  return <Layout></Layout>
+}

--- a/src/components/client/campaign-application/CampaignApplicationPage.tsx
+++ b/src/components/client/campaign-application/CampaignApplicationPage.tsx
@@ -1,5 +1,5 @@
 import Layout from '../layout/Layout'
 
 export default function CampaignApplicationPage() {
-  return <Layout></Layout>
+  return <Layout />
 }

--- a/src/pages/campaigns/application.tsx
+++ b/src/pages/campaigns/application.tsx
@@ -1,0 +1,11 @@
+import { GetServerSideProps } from 'next'
+import { securedPropsWithTranslation } from 'middleware/auth/securedProps'
+import { routes } from 'common/routes'
+import CampaignApplicationPage from 'components/client/campaign-application/CampaignApplicationPage'
+
+export const getServerSideProps: GetServerSideProps = securedPropsWithTranslation(
+  ['common', 'auth', 'validation', 'campaigns'],
+  routes.campaigns.application,
+)
+
+export default CampaignApplicationPage


### PR DESCRIPTION
Create a new protected route for campaign applications connected to [Epic #1842](https://github.com/podkrepi-bg/frontend/issues/1842)

## Testing

### Steps to test

1. Login as normal user
2. Visit `http://localhost:3040/campaigns/application`