### PR TITLE
fix: add translations in English for the campaign application organizer step (Epic #1842)

### DIFF
--- a/public/locales/en/campaign-application.json
+++ b/public/locales/en/campaign-application.json
@@ -1,0 +1,23 @@
+{
+  "steps": {
+    "organizer": {
+      "title": "Organizer",
+      "name": "Your First and Last Name",
+      "phone": "Contact phone",
+      "email": "Email",
+      "transparencyTerms": "I confirm that the campaign meets the basic principles for publishing on the platform: it is legal, it is moral, and it is not business-oriented."
+    }
+  },
+  "cta": {
+    "next": "Save and continue",
+    "back": "Back"
+  },
+  "remark": {
+    "part-one": "*Additional information about the application process and its stages can be found in our ",
+    "part-two": "and in the section ",
+    "links": {
+      "terms": "Terms and Conditions ",
+      "faq": "Frequently Asked Questions"
+    }
+  }
+}


### PR DESCRIPTION
Add translations in English for the campaign application organizer step as requested in this task https://github.com/users/gparlakov/projects/1/views/1?pane=issue&itemId=67658316

*Connected to [Epic #1842](https://github.com/podkrepi-bg/frontend/issues/1842)

## Screenshots:

![english](https://github.com/podkrepi-bg/frontend/assets/103574320/04b5c0e6-1392-4e6b-a329-b1a940ef0d55)

## Testing

### Steps to test

1. Login as normal user
2. Visit `http://localhost:3040/campaigns/application`