### PR TITLE
feat: prefill campaign application organizer form values from current user (Epic #1842)

### DIFF
--- a/src/components/client/campaign-application/CampaignApplicationForm.tsx
+++ b/src/components/client/campaign-application/CampaignApplicationForm.tsx
@@ -1,6 +1,6 @@
-import { useCallback, useMemo, useState } from 'react'
+import { useCallback, useState } from 'react'
 import { Grid, StepLabel } from '@mui/material'
-import { PersonResponse } from 'gql/person'
+import { Person } from 'gql/person'
 
 import {
   CampaignApplicationFormData,
@@ -41,7 +41,7 @@ const steps: StepType[] = [
 ]
 
 type Props = {
-  person: PersonResponse
+  person?: Person
 }
 
 export default function CampaignApplicationForm({ person }: Props) {

--- a/src/components/client/campaign-application/CampaignApplicationForm.tsx
+++ b/src/components/client/campaign-application/CampaignApplicationForm.tsx
@@ -1,6 +1,6 @@
-import { useCallback, useState } from 'react'
-
+import { useCallback, useMemo, useState } from 'react'
 import { Grid, StepLabel } from '@mui/material'
+import { PersonResponse } from 'gql/person'
 
 import {
   CampaignApplicationFormData,
@@ -25,17 +25,6 @@ import {
   StyledStepConnector,
 } from './helpers/campaignApplication.styled'
 
-const initialValues: CampaignApplicationFormData = {
-  organizer: {
-    name: '',
-    phone: '',
-    email: '',
-    acceptTermsAndConditions: false,
-    transparencyTermsAccepted: false,
-    personalInformationProcessingAccepted: false,
-  },
-}
-
 const steps: StepType[] = [
   {
     title: 'campaign-application:steps.organizer.title',
@@ -51,8 +40,26 @@ const steps: StepType[] = [
   },
 ]
 
-export default function CampaignApplicationForm() {
+type Props = {
+  person: PersonResponse
+}
+
+export default function CampaignApplicationForm({ person }: Props) {
   const [activeStep, setActiveStep] = useState<Steps>(Steps.ORGANIZER)
+
+  const initialValues: CampaignApplicationFormData = useMemo(
+    () => ({
+      organizer: {
+        name: `${person?.firstName} ${person?.lastName}` ?? '',
+        phone: person?.phone ?? '',
+        email: person?.email ?? '',
+        acceptTermsAndConditions: false,
+        transparencyTermsAccepted: false,
+        personalInformationProcessingAccepted: false,
+      },
+    }),
+    [person],
+  )
 
   const handleSubmit = () => {
     stepsHandler({ activeStep, setActiveStep })

--- a/src/components/client/campaign-application/CampaignApplicationForm.tsx
+++ b/src/components/client/campaign-application/CampaignApplicationForm.tsx
@@ -47,19 +47,16 @@ type Props = {
 export default function CampaignApplicationForm({ person }: Props) {
   const [activeStep, setActiveStep] = useState<Steps>(Steps.ORGANIZER)
 
-  const initialValues: CampaignApplicationFormData = useMemo(
-    () => ({
-      organizer: {
-        name: `${person?.firstName} ${person?.lastName}` ?? '',
-        phone: person?.phone ?? '',
-        email: person?.email ?? '',
-        acceptTermsAndConditions: false,
-        transparencyTermsAccepted: false,
-        personalInformationProcessingAccepted: false,
-      },
-    }),
-    [person],
-  )
+  const initialValues: CampaignApplicationFormData = {
+    organizer: {
+      name: `${person?.firstName} ${person?.lastName}` ?? '',
+      phone: person?.phone ?? '',
+      email: person?.email ?? '',
+      acceptTermsAndConditions: false,
+      transparencyTermsAccepted: false,
+      personalInformationProcessingAccepted: false,
+    },
+  }
 
   const handleSubmit = () => {
     stepsHandler({ activeStep, setActiveStep })

--- a/src/components/client/campaign-application/CampaignApplicationPage.tsx
+++ b/src/components/client/campaign-application/CampaignApplicationPage.tsx
@@ -1,10 +1,24 @@
+import { CircularProgress, Grid } from '@mui/material'
+import { useSession } from 'next-auth/react'
+import { useViewPersonByKeylockId } from 'common/hooks/person'
 import Layout from '../layout/Layout'
 import CampaignApplicationForm from './CampaignApplicationForm'
 
 export default function CampaignApplicationPage() {
+  const { data: session } = useSession()
+  const { data: person, isLoading } = useViewPersonByKeylockId(session?.user?.sub as string)
+
+  if (isLoading) {
+    return (
+      <Grid container justifyContent="center" alignContent="center" sx={{ height: '100vh' }}>
+        <CircularProgress />
+      </Grid>
+    )
+  }
+
   return (
     <Layout maxWidth="md" sx={{ paddingInline: 5 }}>
-      <CampaignApplicationForm />
+      {person && <CampaignApplicationForm person={person} />}
     </Layout>
   )
 }

--- a/src/components/client/campaign-application/CampaignApplicationPage.tsx
+++ b/src/components/client/campaign-application/CampaignApplicationPage.tsx
@@ -1,12 +1,11 @@
 import { CircularProgress, Grid } from '@mui/material'
-import { useSession } from 'next-auth/react'
-import { useViewPersonByKeylockId } from 'common/hooks/person'
+import { useCurrentPerson } from 'common/util/useCurrentPerson'
 import Layout from '../layout/Layout'
 import CampaignApplicationForm from './CampaignApplicationForm'
 
 export default function CampaignApplicationPage() {
-  const { data: session } = useSession()
-  const { data: person, isLoading } = useViewPersonByKeylockId(session?.user?.sub as string)
+  const { data: userData, isLoading } = useCurrentPerson()
+  const person = userData?.user || undefined
 
   if (isLoading) {
     return (
@@ -18,7 +17,7 @@ export default function CampaignApplicationPage() {
 
   return (
     <Layout maxWidth="md" sx={{ paddingInline: 5 }}>
-      {person && <CampaignApplicationForm person={person} />}
+      <CampaignApplicationForm person={person} />
     </Layout>
   )
 }


### PR DESCRIPTION
Prefill campaign application organizer form values from current user as requested in the following task https://github.com/users/gparlakov/projects/1/views/1?pane=issue&itemId=68583764

*Connected to [Epic #1842](https://github.com/podkrepi-bg/frontend/issues/1842)

## Screenshots:

![1](https://github.com/podkrepi-bg/frontend/assets/103574320/198495a3-cbb4-4ae4-8c46-0364b2dcc92b)

## Testing

### Steps to test

1. Login as normal user
2. Visit `http://localhost:3040/campaigns/application`