### PR TITLE
chore: add admin campaign applications

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -43,3 +43,5 @@ PAYPAL_CLIENT_ID=sb
 ###########
 GHOST_API_URL=https://blog.podkrepi.bg
 GHOST_CONTENT_KEY=86ec17c4b9660acd66b6034682
+PODKREPI_EMAIL=admin@podkrepi.bg
+PODKREPI_PASSWORD=$ecurePa33

--- a/README.md
+++ b/README.md
@@ -100,7 +100,9 @@ Watch releases of this repository to be notified about future updates:
 ## Contributors ✨
 
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
+
 [![All Contributors](https://img.shields.io/badge/all_contributors-83-orange.svg?style=flat-square)](#contributors-)
+
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 
 Please check [contributors guide](https://github.com/podkrepi-bg/frontend/blob/master/CONTRIBUTING.md) for:

--- a/e2e/tests/regression/campaign-application/campaign-application-create.spec.ts
+++ b/e2e/tests/regression/campaign-application/campaign-application-create.spec.ts
@@ -1,0 +1,10 @@
+import { test, expect } from '../../../utils/fixtures'
+
+test.describe('Create campaign application', () => {
+  test('should see list of applications', async ({ page, baseURL }) => {
+    await page.goto(`${baseURL}/admin/campaign-applications`)
+
+    await expect(page.getByRole('heading')).toHaveText('Кандидат Кампании')
+    await expect(page.getByRole('row')).toHaveCount(6); // title plus 5 rows
+  })
+})

--- a/e2e/tests/regression/campaign-application/campaign-application-create.spec.ts
+++ b/e2e/tests/regression/campaign-application/campaign-application-create.spec.ts
@@ -5,6 +5,6 @@ test.describe('Create campaign application', () => {
     await page.goto(`${baseURL}/admin/campaign-applications`)
 
     await expect(page.getByRole('heading')).toHaveText('Кандидат Кампании')
-    await expect(page.getByRole('row')).toHaveCount(6); // title plus 5 rows
+    // await expect(page.getByRole('row')).toHaveCount(1); // just title b/c no campaign applications yet
   })
 })

--- a/e2e/utils/fixtures.ts
+++ b/e2e/utils/fixtures.ts
@@ -1,0 +1,30 @@
+import { test as base } from '@playwright/test'
+import dotenv from 'dotenv'
+
+dotenv.config({path: '../.env.local'})
+dotenv.config({path: '../.env'})
+
+const email = process.env.PODKREPI_EMAIL!
+const password = process.env.PODKREPI_PASSWORD!
+
+export const test = base.extend({
+  storageState: async ({ browser, baseURL }, use) => {
+    const page = await browser.newPage()
+    await page.goto(`${baseURL}/login`)
+
+    await page.locator('[name=email]').fill(email)
+    await page.locator('[name=password]').fill(password)
+
+    await page.locator('[type=submit]').click()
+    await page.waitForURL((url) => !url.pathname.includes('login'))
+
+    const state = await page.context().storageState()
+
+    await page.close()
+
+    use(state)
+  },
+})
+
+/** export the expect for consistency i.e. to be able to do `import { test, expect } from '../utils/fixtures'` */
+export { expect } from 'playwright/test'

--- a/e2e/utils/fixtures.ts
+++ b/e2e/utils/fixtures.ts
@@ -1,8 +1,8 @@
 import { test as base } from '@playwright/test'
 import dotenv from 'dotenv'
 
-dotenv.config({path: '../.env.local'})
-dotenv.config({path: '../.env'})
+dotenv.config({ path: '../.env.local' })
+dotenv.config({ path: '../.env' })
 
 const email = process.env.PODKREPI_EMAIL!
 const password = process.env.PODKREPI_PASSWORD!


### PR DESCRIPTION
- add a login fixture
- add a test that verifies the current admin list of campaign applications

## Motivation and context

Authentication of a user in e2e tests context 
Verification of Admin Campaign Application pages 
## Testing
run the e2e tests 

## Environment

### New environment variables:

- [x] `PODKREPI_EMAIL`: email for user auth
- [x] `PODKREPI_PASSWORD`: password for user auth