### PR TITLE
fix(campaign-news): Remove center style for video and img

### DIFF
--- a/src/components/client/campaign-news/CampaignNewsPage.tsx
+++ b/src/components/client/campaign-news/CampaignNewsPage.tsx
@@ -37,11 +37,6 @@ const Root = styled(Layout)(({ theme }) => ({
     letterSpacing: theme.typography.pxToRem(-1.5),
     marginBottom: theme.spacing(1),
   },
-
-  '.ql-video, img': {
-    margin: '0 auto',
-    display: 'block',
-  },
 }))
 
 type Props = {


### PR DESCRIPTION
Their position will be set by the quill editor instead.