### PR TITLE
chore(blog): Show published_at date instead of created_at

### DIFF
--- a/src/components/client/blog/BlogPage.tsx
+++ b/src/components/client/blog/BlogPage.tsx
@@ -32,7 +32,7 @@ export default function BlogPage({ page }: Props) {
             </Typography>
           </Grid2>
           <Grid2 xs={10} xsOffset={1} textAlign="center">
-            <DateCreated showLabel createdAt={page.created_at} />
+            <DateCreated showLabel createdAt={page.published_at as string} />
             <ReadingTime showLabel readingTime={page.reading_time} />
           </Grid2>
           <Grid2 xs={10} xsOffset={1}>

--- a/src/components/client/blog/BlogPostPage.tsx
+++ b/src/components/client/blog/BlogPostPage.tsx
@@ -33,7 +33,7 @@ export default function BlogPostPage({ post, referer }: Props) {
             </Typography>
           </Grid2>
           <Grid2 xs={10} xsOffset={1} textAlign="center">
-            <DateCreated showLabel createdAt={post.created_at} />
+            <DateCreated showLabel createdAt={post.published_at as string} />
             <ReadingTime showLabel readingTime={post.reading_time} />
           </Grid2>
           <Grid2 xs={10} xsOffset={1}>


### PR DESCRIPTION
Only published blogs are shown in our site, thus it is more appropriate to show the published_at date.

