### PR TITLE
Update error message when creating new document (Admin)

### DIFF
--- a/src/components/admin/documents/Form.tsx
+++ b/src/components/admin/documents/Form.tsx
@@ -23,7 +23,13 @@ const validationSchema = yup
   .object()
   .defined()
   .shape({
-    type: yup.string().oneOf(validDocumentTypes, `Видът трябва да бъде една от следните стойности: ${validDocumentTypes.join(', ')}.`).required(),
+    type: yup
+      .string()
+      .oneOf(
+        validDocumentTypes,
+        `Видът трябва да бъде една от следните стойности: ${validDocumentTypes.join(', ')}.`,
+      )
+      .required(),
     name: yup.string().trim().min(2).max(20).required(),
     filename: yup.string().trim().min(2).max(20).required(),
     filetype: yup.string().trim().max(3),

--- a/src/components/admin/documents/Form.tsx
+++ b/src/components/admin/documents/Form.tsx
@@ -23,7 +23,7 @@ const validationSchema = yup
   .object()
   .defined()
   .shape({
-    type: yup.string().oneOf(validDocumentTypes, `Видът трябва да бъде една от следните стойности: ${validDocumentTypes.join(', ')}.s`).required(),
+    type: yup.string().oneOf(validDocumentTypes, `Видът трябва да бъде една от следните стойности: ${validDocumentTypes.join(', ')}.`).required(),
     name: yup.string().trim().min(2).max(20).required(),
     filename: yup.string().trim().min(2).max(20).required(),
     filetype: yup.string().trim().max(3),

--- a/src/components/admin/documents/Form.tsx
+++ b/src/components/admin/documents/Form.tsx
@@ -23,7 +23,7 @@ const validationSchema = yup
   .object()
   .defined()
   .shape({
-    type: yup.string().oneOf(validDocumentTypes).required(),
+    type: yup.string().oneOf(validDocumentTypes, `Видът трябва да бъде една от следните стойности: ${validDocumentTypes.join(', ')}.s`).required(),
     name: yup.string().trim().min(2).max(20).required(),
     filename: yup.string().trim().min(2).max(20).required(),
     filetype: yup.string().trim().max(3),


### PR DESCRIPTION
Updated the error message below type field on 'Create new document' form on Admin panel:

<img width="928" alt="Screenshot 2024-07-21 210456" src="https://github.com/user-attachments/assets/7bb73793-039c-4f42-95b1-f8c347963bb7">

We do not need English translation for the text since it is present only on the Admin panel.