### PR TITLE
Fix id after choosing a campaign (Admin panel)

### DIFF
--- a/src/components/admin/recurring-donation/Form.tsx
+++ b/src/components/admin/recurring-donation/Form.tsx
@@ -74,7 +74,7 @@ export default function EditForm() {
       extCustomerId: data?.extCustomerId,
       money: fromMoney(data?.amount || 0),
       currency: data?.currency,
-      sourceVault: data?.sourceVault.id,
+      sourceVault: '',
       campaign: data?.sourceVault.campaign.id,
     }
   }


### PR DESCRIPTION
Fixed id after choosing a campain in recurring donations in Admin panel:

Before|After
---|---
![image](https://github.com/user-attachments/assets/0a1b68f4-4e29-41d6-b2a4-84565cbda9a8)|![image](https://github.com/user-attachments/assets/730d0d97-ad99-43d1-8d40-79a2e739c075)

The id is set in handleCampaignSelected function when the user chooses a campaign. The issue was caused by setting an initail value on sourceVault when the id is already present, so I reset it to '' in the object.