### PR TITLE
bugfix/1915-Profile-Birthdate-Validation-Message

### DIFF
--- a/src/common/theme.ts
+++ b/src/common/theme.ts
@@ -37,6 +37,9 @@ const colors = {
   white: {
     main: '#ffffff',
   },
+  red: {
+    error: '#ED1D1D',
+  },
 }
 
 const borders = {
@@ -66,6 +69,9 @@ export const themeOptions: ThemeOptions = {
       main: colors.blue.dark,
       light: colors.blue.mainDark,
       dark: darken(colors.blue.dark, 0.2),
+    },
+    error: {
+      main: colors.red.error,
     },
   },
   shape: {

--- a/src/components/client/auth/profile/UpdateBirthdateModal.tsx
+++ b/src/components/client/auth/profile/UpdateBirthdateModal.tsx
@@ -53,17 +53,6 @@ const parseDateString = (value: string, originalValue: string) => {
 
 const maxDate = new Date(new Date().setFullYear(new Date().getFullYear() - 18))
 
-const validationSchema: yup.SchemaOf<Pick<UpdateUserAccount, 'birthday'>> = yup
-  .object()
-  .defined()
-  .shape({
-    birthday: yup
-      .date()
-      .transform(parseDateString)
-      .max(maxDate, 'profile:birthdateModal.ageInvalid')
-      .required(),
-  })
-
 function UpdateBirthdateModal({
   isOpen,
   handleClose,
@@ -75,6 +64,17 @@ function UpdateBirthdateModal({
 }) {
   const { t } = useTranslation()
   const [loading, setLoading] = useState(false)
+
+  const validationSchema: yup.SchemaOf<Pick<UpdateUserAccount, 'birthday'>> = yup
+    .object()
+    .defined()
+    .shape({
+      birthday: yup
+        .date()
+        .transform(parseDateString)
+        .max(maxDate, t('profile:birthdateModal.ageInvalid'))
+        .required(),
+    })
 
   const dateBefore18Years = new Date(new Date().setFullYear(new Date().getFullYear() - 18))
 
@@ -119,7 +119,11 @@ function UpdateBirthdateModal({
           validationSchema={validationSchema}>
           <Grid container spacing={3}>
             <Grid item xs={12} sm={8}>
-              <FormDatePicker name="birthday" label={t('profile:birthdateModal.question')} />
+              <FormDatePicker
+                name="birthday"
+                label={t('profile:birthdateModal.question')}
+                maxDate={maxDate}
+              />
             </Grid>
             <Grid item xs={6}>
               <SubmitButton fullWidth label="auth:cta.send" loading={loading} />

--- a/src/components/common/form/FormDatePicker.tsx
+++ b/src/components/common/form/FormDatePicker.tsx
@@ -3,17 +3,27 @@ import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns'
 import { format } from 'date-fns'
 import { useField, useFormikContext } from 'formik'
 import { useTranslation } from 'next-i18next'
+import theme from 'common/theme'
 
 import { DATE_VALUE_FORMAT, getDateFormat } from 'common/util/date'
+
+interface FormDatePickerProps {
+  name: string
+  label: string
+  maxDate?: Date
+}
+
+const errorValidationColor = theme.palette.error as unknown as string
 
 /**
  * MUI date picker to be connected with Formik. Propagates updates to the passed Formik field name
  * @param name - name of the Formik field to bind
  * @param label - prompt text
+ * @param maxDate - optional maximal selectable date
  * @returns
  */
-export default function FormDatePicker({ name, label }: { name: string; label: string }) {
-  const [field] = useField(name)
+export default function FormDatePicker({ name, label, maxDate }: FormDatePickerProps) {
+  const [field, meta] = useField(name)
   const { setFieldValue } = useFormikContext()
   const { i18n } = useTranslation()
 
@@ -42,7 +52,19 @@ export default function FormDatePicker({ name, label }: { name: string; label: s
         label={label}
         value={new Date(field?.value)}
         onChange={(newValue) => updateValue(newValue)}
-        slotProps={{ textField: { size: 'small' } }}
+        slotProps={{ textField: { size: 'small', helperText: maxDate && meta.error } }}
+        sx={
+          maxDate && meta.error
+            ? {
+                '&.MuiOutlinedInput-root': {
+                  '& fieldset, &:hover fieldset, &.Mui-focused fieldset': {
+                    borderColor: errorValidationColor,
+                  },
+                },
+              }
+            : undefined
+        }
+        maxDate={maxDate}
       />
     </LocalizationProvider>
   )


### PR DESCRIPTION
Fixed no UI feedback on FormDatePicker when maxDate validation constraint is present

- Added maxDate optional prop to FormDatePicker component to be used in error state feedback
- maxDate validation applied to the calendar, so invalid dates cannot be selected from it, limiting issue to manual inputs
- Added error color from figma designs to theme color palette
- Left maxDate prop to be required when displaying the input error state to prevent issues in other places where component is used

Closes [#1915](https://github.com/podkrepi-bg/frontend/issues/1915)

## Screenshots:

Before|After
---|---
![image](https://github.com/user-attachments/assets/b5d9d430-d242-4978-bfea-2568cd0eb36f)|![image](https://github.com/user-attachments/assets/7b3175de-032a-4179-bd74-af05963a38d7)


<!-- List of pages that are affected by the changes -->

## Testing

### Steps to test

1. Open https://podkrepi.bg/en/profile/personal-information
2. Click edit on Birthday
3. Add date 03/10/2017 and observe error state of the input field
4. Click button
5. Add date that is 18+ years ago and observe error state of the input field
6. Click button

### Affected urls

<!--- Specify test requirements (environment, dependencies, design reviews) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include links to the related pages -->
<!--- Include details of your testing environment -->
<!--- Impact of your change to other areas of the code -->

## Environment

### New environment variables:

<!-- Mark with [x] when variable is added to `.env.local.example`  -->

- [ ] `NEW_ENV_VAR`: env var details

### New or updated dependencies:

<!-- including dev dependencies -->

Dependency name|Previous version|Updated version|Details
---|---|---|---
`dependency/name`|`v1.0.0`|`v2.0.0`|

