### PR TITLE
Bugfix/new donation flow issues

### DIFF
--- a/public/locales/en/donation-flow.json
+++ b/public/locales/en/donation-flow.json
@@ -106,7 +106,7 @@
       },
       "noregister": {
         "label": "Continue without registration",
-        "description": "You will not be able to get a donation certificate or a list of your donations. If you still want to receive a receipt, please share your email - it will not be visible in the platform"
+        "description": "You will not be able to get a donation certificate or a list of your donations. If you still want to receive a receipt, please share your email - it will not be visible in the platform."
       },
       "field": {
         "password": "Password",

--- a/public/locales/en/donation-flow.json
+++ b/public/locales/en/donation-flow.json
@@ -128,7 +128,7 @@
       "donation": "Donation",
       "transaction": {
         "title": "Transaction",
-        "description": "The transaction is only to compensate the transfer and is calculated based on your method of payment. \"Podkrepi.bg\" works with 0% commission"
+        "description": "The transaction is only to compensate the transfer and is calculated based on your method of payment. \"Podkrepi.bg\" works with 0% commission."
       },
       "total": "Total",
       "field": {

--- a/src/components/client/donation-flow/DonationFlowForm.tsx
+++ b/src/components/client/donation-flow/DonationFlowForm.tsx
@@ -226,15 +226,15 @@ export function DonationFlowForm() {
               <ConfirmationDialog
                 isOpen={showCancelDialog}
                 handleCancel={() => {
-                  cancelSetupIntentMutation.mutate({ id: setupIntent.id })
-                  router.push(routes.campaigns.viewCampaignBySlug(campaign.slug))
+                  setShowCancelDialog(false)
                 }}
                 title={t('cancel-dialog.title')}
                 content={t('cancel-dialog.content')}
                 confirmButtonLabel={t('cancel-dialog.btn-continue')}
                 cancelButtonLabel={t('cancel-dialog.btn-cancel')}
                 handleConfirm={() => {
-                  setShowCancelDialog(false)
+                  cancelSetupIntentMutation.mutate({ id: setupIntent.id })
+                  router.push(routes.campaigns.viewCampaignBySlug(campaign.slug))
                 }}
               />
               <Button

--- a/src/components/client/donation-flow/DonationFlowForm.tsx
+++ b/src/components/client/donation-flow/DonationFlowForm.tsx
@@ -247,7 +247,10 @@ export function DonationFlowForm() {
               </Button>
               <Grid2 container size={{ xs: 12, md: 7 }} direction={'column'}>
                 <StepSplitter content="1" active={Boolean(values.amountChosen)} />
-                <Amount error={Boolean(errors.finalAmount) && Boolean(submitCount > 0)} />
+                <Amount
+                  disabled={values.payment === DonationFormPaymentMethod.BANK}
+                  error={Boolean(errors.finalAmount) && Boolean(submitCount > 0)}
+                />
               </Grid2>
               <Grid2 container size={{ xs: 12, md: 7 }} gap={2} direction={'column'}>
                 <StepSplitter content="2" active={Boolean(values.mode)} />

--- a/src/components/client/donation-flow/DonationFlowForm.tsx
+++ b/src/components/client/donation-flow/DonationFlowForm.tsx
@@ -247,10 +247,7 @@ export function DonationFlowForm() {
               </Button>
               <Grid2 container size={{ xs: 12, md: 7 }} direction={'column'}>
                 <StepSplitter content="1" active={Boolean(values.amountChosen)} />
-                <Amount
-                  disabled={values.payment === DonationFormPaymentMethod.BANK}
-                  error={Boolean(errors.finalAmount) && Boolean(submitCount > 0)}
-                />
+                <Amount error={Boolean(errors.finalAmount) && Boolean(submitCount > 0)} />
               </Grid2>
               <Grid2 container size={{ xs: 12, md: 7 }} gap={2} direction={'column'}>
                 <StepSplitter content="2" active={Boolean(values.mode)} />

--- a/src/components/client/donation-flow/DonationFlowStatusPage.tsx
+++ b/src/components/client/donation-flow/DonationFlowStatusPage.tsx
@@ -168,7 +168,7 @@ export default function DonationFlowStatusPage({ slug }: { slug: string }) {
             text={t('status.success.link.return')}
           />
         </Grid2>
-        <Grid2>
+        <Grid2 size={{ xs: 12, md: 6 }}>
           <LinkCard href={routes.campaigns.index} text={t('status.success.link.see')} />
         </Grid2>
         <Grid2 size={{ xs: 12, md: 6 }}>

--- a/src/components/client/donation-flow/steps/Amount.tsx
+++ b/src/components/client/donation-flow/steps/Amount.tsx
@@ -30,7 +30,7 @@ export const amountValidation = {
     then: yup.string().required(),
   }),
   finalAmount: yup.number().when('payment', {
-    is: (payment: string | null) => ['card', 'bank', null].includes(payment),
+    is: (payment: string | null) => ['card', null].includes(payment),
     then: () =>
       yup.number().min(1, 'donation-flow:step.amount.field.final-amount.error').required(),
   }),

--- a/src/components/client/donation-flow/steps/Amount.tsx
+++ b/src/components/client/donation-flow/steps/Amount.tsx
@@ -70,6 +70,9 @@ export default function Amount({ disabled, sectionRef, error }: SelectDonationAm
         ? toMoney(Number(formik.values.otherAmount))
         : Number(formik.values.amountChosen)
 
+    // Do not perform calculations if amount is not set
+    if (amountChosen === 0) return
+
     if (formik.values.cardIncludeFees) {
       formik.setFieldValue('amountWithoutFees', amountChosen)
       formik.setFieldValue(

--- a/src/components/client/donation-flow/steps/Amount.tsx
+++ b/src/components/client/donation-flow/steps/Amount.tsx
@@ -30,7 +30,7 @@ export const amountValidation = {
     then: yup.string().required(),
   }),
   finalAmount: yup.number().when('payment', {
-    is: 'card',
+    is: (payment: string | null) => ['card', 'bank', null].includes(payment),
     then: () =>
       yup.number().min(1, 'donation-flow:step.amount.field.final-amount.error').required(),
   }),

--- a/src/components/client/donation-flow/steps/authentication/InlineRegisterForm.tsx
+++ b/src/components/client/donation-flow/steps/authentication/InlineRegisterForm.tsx
@@ -166,10 +166,6 @@ export default function InlineRegisterForm() {
             </FormHelperText>
           )}
         </Grid>
-        <Grid item xs={12}>
-          <AcceptTermsField name="registerTerms" />
-          <AcceptPrivacyPolicyField name="registerGdpr" />
-        </Grid>
 
         <Grid item xs={12}>
           <Button

--- a/src/components/common/form/AcceptPrivacyPolicyField.tsx
+++ b/src/components/common/form/AcceptPrivacyPolicyField.tsx
@@ -1,5 +1,6 @@
 import { useTranslation } from 'next-i18next'
 import { Typography } from '@mui/material'
+import { useRouter } from 'next/router'
 
 import { routes } from 'common/routes'
 import ExternalLink from 'components/common/ExternalLink'
@@ -18,6 +19,8 @@ export default function AcceptPrivacyPolicyField({
   ...rest
 }: AcceptGDPRFieldProps) {
   const { t } = useTranslation()
+  const { locale } = useRouter()
+
   return (
     <CheckboxField
       name={name}
@@ -26,7 +29,9 @@ export default function AcceptPrivacyPolicyField({
       label={
         <Typography variant="body2">
           {t('validation:informed-agree-with')}{' '}
-          <ExternalLink href={routes.privacyPolicy}>{t('validation:gdpr')}</ExternalLink>
+          <ExternalLink href={`/${locale}${routes.privacyPolicy}`}>
+            {t('validation:gdpr')}
+          </ExternalLink>
         </Typography>
       }
       {...rest}


### PR DESCRIPTION
## Motivation and context
Fixes several issues from ticket #1960 related to the new donation flow, discovered during QA testing.

## Screenshots:

Issue #|Before|After
-|---|---
1|![image](https://github.com/user-attachments/assets/237a5a0d-2a9f-4a80-b540-78570b27f5bb)|![image](https://github.com/user-attachments/assets/886fc20f-4103-4425-8b0d-6b27b8f4a176)
2|![image](https://github.com/user-attachments/assets/dca86f16-e2f0-44af-bcd9-fb1fdd9845a6)|![image](https://github.com/user-attachments/assets/c6fc3d38-4293-4208-b405-21485c972196)
3|Cannot reproduce - message sent to QA for details| N/A
4|![image](https://github.com/user-attachments/assets/7ce94199-9c78-43cd-94c4-c4766a26d0ac)|![image](https://github.com/user-attachments/assets/adb48bcd-07dc-4424-b992-aad99eec9ef8)![image](https://github.com/user-attachments/assets/5dc30b2a-db4f-466f-aa9d-d0598a386903)
5|![image](https://github.com/user-attachments/assets/38e510c2-024f-4125-bf59-514fdcb37588)| Yes, it should work exactly the opposite way. Now when the user selects the `X` button or `Cancel` button, the user remains on the same page. If the user selects `Continue` button, then it will be redirected to the Campaign preview page.
10|![image](https://github.com/user-attachments/assets/c9e5d0e6-aad5-4c51-9868-0b9be1f5d915)|![image](https://github.com/user-attachments/assets/7d6eb40f-7456-4406-bf8c-92e38fb24615)
11|![image](https://github.com/user-attachments/assets/90c2da93-8186-476d-8e24-0e7e7318bab9)|![image](https://github.com/user-attachments/assets/fd94c3f3-ba4a-4761-b0b1-3db728f3ca34)
12|![image](https://github.com/user-attachments/assets/0f7bb51b-9afc-430a-ab61-eb346a0f0823)|![image](https://github.com/user-attachments/assets/cd314e2f-c1e2-4b11-bb00-b46ca583ffc7)






### Additional change:
IMO we should not disable the `Amount` field when bank payment option is selected as this creates several side effect. IMO we should either hide it completely when Bank options is chosen or leave it always available. This is because currently, if the user selects an amount and then selects bank payment type, the `Amount` field becomes disabled. This could create some confusion because the user cannot change the amount anymore and they cannot use the calculator for amount + fees at the bottom. Also if validation is triggered and the field, they cannot select an option to continue with the donation.
Here I removed the option for disabling in commit https://github.com/podkrepi-bg/frontend/commit/2ceeef55f2826e3ac9e43e81b25c8d28021b1d9e



