### PR TITLE
Admin campaign applications e2e tests part 3 file download or delete

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,9 @@ Watch releases of this repository to be notified about future updates:
 ## Contributors ✨
 
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
+
 [![All Contributors](https://img.shields.io/badge/all_contributors-84-orange.svg?style=flat-square)](#contributors-)
+
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 
 Please check [contributors guide](https://github.com/podkrepi-bg/frontend/blob/master/CONTRIBUTING.md) for:

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -52,3 +52,22 @@ Options:
 ```shell
 yarn test:e2e --headed --debug -x -g support
 ```
+
+### Tests with Authenticated user
+
+### Writing
+
+To auth a user we rely on the Storage where the session is stored. And the storage is filled in and accessed via a `test.extend` [fixture](https://playwright.dev/docs/auth#authenticate-with-api-request). It takes care to login and store the session and then use it in the tests. See the `e2e/utils/fixtures.ts` file
+
+This is the process for writing tests for auth user.
+
+- import the desired user `test` from the fixture 
+
+  ```import { expect, giverTest as test } from '../../../utils/fixtures'``` for the `giver` user
+- write your e2e tests ...
+
+>[Examples] `e2e/tests/regression/campaign-application/campaign-application-giver.spec.ts` and `e2e/tests/regression/campaign-application/campaign-application-admin.spec.ts`
+### Running
+
+- [Locally] run the 'docker compose -d keycloak pg-db', the api (`yarn dev` in the api repo folder), the app (`yarn dev` in the frontend repo folder),
+- in the `frontend/e2e` folder run `yarn e2e:tests --ui` to start the playwright visual testing tool 

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -61,13 +61,15 @@ To auth a user we rely on the Storage where the session is stored. And the stora
 
 This is the process for writing tests for auth user.
 
-- import the desired user `test` from the fixture 
+- import the desired user `test` from the fixture
 
-  ```import { expect, giverTest as test } from '../../../utils/fixtures'``` for the `giver` user
+  `import { expect, giverTest as test } from '../../../utils/fixtures'` for the `giver` user
+
 - write your e2e tests ...
 
->[Examples] `e2e/tests/regression/campaign-application/campaign-application-giver.spec.ts` and `e2e/tests/regression/campaign-application/campaign-application-admin.spec.ts`
+> [Examples] `e2e/tests/regression/campaign-application/campaign-application-giver.spec.ts` and `e2e/tests/regression/campaign-application/campaign-application-admin.spec.ts`
+
 ### Running
 
 - [Locally] run the 'docker compose -d keycloak pg-db', the api (`yarn dev` in the api repo folder), the app (`yarn dev` in the frontend repo folder),
-- in the `frontend/e2e` folder run `yarn e2e:tests --ui` to start the playwright visual testing tool 
+- in the `frontend/e2e` folder run `yarn e2e:tests --ui` to start the playwright visual testing tool

--- a/e2e/tests/regression/campaign-application/campaign-application-giver.spec.ts
+++ b/e2e/tests/regression/campaign-application/campaign-application-giver.spec.ts
@@ -1,8 +1,3 @@
-import {
-  CampaignApplicationResponse,
-  CampaignApplicationExisting,
-  CampaignApplicationAdminResponse,
-} from '../../../../src/gql/campaign-applications'
 import { Page } from 'playwright/test'
 import { expect, giverTest as test } from '../../../utils/fixtures'
 import { textLocalized } from '../../../utils/texts-localized'

--- a/e2e/utils/fixtures.ts
+++ b/e2e/utils/fixtures.ts
@@ -1,3 +1,7 @@
+/**
+ * This is logic for authenticating and storing the session to be used in the tests. See the e2e/Readme.md - the section about Authenticated user
+ */
+
 import { test, test as base } from '@playwright/test'
 import dotenv from 'dotenv'
 import fs from 'fs'

--- a/src/components/admin/campaign-applications/CampaignApplicationsGrid.tsx
+++ b/src/components/admin/campaign-applications/CampaignApplicationsGrid.tsx
@@ -115,7 +115,8 @@ export const useCampaignsList = () => {
   const { data, isLoading } = fetchMutation()
 
   return {
-    list: data?.sort((a, b) => b?.updatedAt?.localeCompare(a?.updatedAt ?? '') ?? 0),
+    // the data array is strict mode (sometimes) it throws a Readonly array error on the sort so create a shallow copy
+    list: [...(data ?? [])].sort((a, b) => b?.updatedAt?.localeCompare(a?.updatedAt ?? '') ?? 0),
     isLoading,
   }
 }


### PR DESCRIPTION
Commits 

- [chore: e2e test for organizer edit and delete a file](https://github.com/podkrepi-bg/frontend/commit/12a7a2aff2c77b88d4e339184bcefe3307a9b02f)
- [chore: add auth e2e test readme section](https://github.com/podkrepi-bg/frontend/commit/0112db6aa6951fe630708d428eee5c1f46535506)