### PR TITLE
Adjust locale button style on hover

### DIFF
--- a/src/components/client/layout/LocaleButton.tsx
+++ b/src/components/client/layout/LocaleButton.tsx
@@ -30,7 +30,15 @@ export default function LocaleButton() {
       variant="text"
       color="inherit"
       size="small"
-      onClick={changeLang(router.locale === 'bg' ? 'en' : 'bg')}>
+      onClick={changeLang(router.locale === 'bg' ? 'en' : 'bg')}
+      sx={(theme) => ({
+        [theme.breakpoints.down('md')]: {
+          '&:hover': {
+            color: 'rgb(40, 135, 203)',
+            backgroundColor: 'transparent',
+          },
+        },
+      })}>
       {t(router.locale === 'bg' ? 'EN' : 'BG')}
     </Button>
   )


### PR DESCRIPTION
Closes #1909 

## Motivation and context

Styling of the Locale button in the navigation not adjusted for mobile version - it is the same as the desktop version, while the other tabs` styles differentiate.

Styles of all MobileNav list items must be unified.

To solve that, i added sx property on the Locale button to style it for breakpoints below 900px

## Screenshots:

Before|After
---|---
![image](https://github.com/user-attachments/assets/4e90d00c-306e-4c0b-882a-04f6c764fc02)|![image](https://github.com/user-attachments/assets/664c5de7-0d4d-463f-b679-81c0e22d258d)

## Testing

### Steps to test
1. Resize the window to width below 900px, which is the breakpoint where the navigation switches mobile/desktop.
2. Hover over the Locale button - it should have the blue color that appears on hovering register/login buttons and transparent background.
3. The new style shouldn't affect the button with breakpoints above 900px. 