### PR TITLE
Card holder name restriction

### DIFF
--- a/src/components/client/donation-flow/steps/payment-method/PaymentDetailsStripeForm.tsx
+++ b/src/components/client/donation-flow/steps/payment-method/PaymentDetailsStripeForm.tsx
@@ -81,9 +81,9 @@ export default function PaymentDetailsStripeForm({
           placeholder={t('donation-flow:step.payment-method.field.card-data.name-label')}
           onInput={(e) => {
             const input = e.target as HTMLInputElement
-            if (!/^[a-zA-Z\s]+$/.test(input.value)) {
-              input.value = input.value.replace(/[^a-zA-Z\s]/g, '')
-            }
+            input.value = input.value
+              .replace(/[^a-zA-Z\s-]/g, '')
+              .replace(/[-\s]{2,}/g, (match) => match[0])
           }}
         />
       </Box>

--- a/src/components/client/donation-flow/steps/payment-method/PaymentDetailsStripeForm.tsx
+++ b/src/components/client/donation-flow/steps/payment-method/PaymentDetailsStripeForm.tsx
@@ -79,6 +79,12 @@ export default function PaymentDetailsStripeForm({
           id="billingName"
           variant="outlined"
           placeholder={t('donation-flow:step.payment-method.field.card-data.name-label')}
+          onInput={(e) => {
+            const input = e.target as HTMLInputElement
+            if (!/^[a-zA-Z\s]+$/.test(input.value)) {
+              input.value = input.value.replace(/[^a-zA-Z\s]/g, '')
+            }
+          }}
         />
       </Box>
       <PaymentElement


### PR DESCRIPTION
Closes #1761

## Motivation and context

Enhance the component's usability for individuals with varying levels of technical expertise by adding an onInput handler that removes non-letters, non-spaces, and non-hyphens, and replaces consecutive hyphens/spaces with a single character.

## Screenshots:

Before|After
---|---
![image](https://github.com/user-attachments/assets/498f1f36-cf76-4135-91da-c411ac08cc73)|![image](https://github.com/user-attachments/assets/01019791-bc1c-44b5-a300-6d9fd0f8363e)

## Testing

### Steps to test
1. Go to a donation page 
2. Choose card payment
3. Try adding numeric/other symbols in the name input field. Only Letters, spacing and hyphens should be allowed

Tested with different name combinations in regex 101 tool.

