### PR TITLE
Fix typo in homepage section heading

### DIFF
--- a/public/locales/en/index.json
+++ b/public/locales/en/index.json
@@ -16,7 +16,7 @@
     "see-more": "See more"
   },
   "how-we-work": {
-    "heading": "How does Pordkprepi.bg work?",
+    "heading": "How does Podkrepi.bg work?",
     "text": "We have built a process of creating campaigns that ensures maximum security for donor funds and at the same time - attention and support to the needs of beneficiaries."
   },
   "platform-statistics": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fixed the typo in heading of "How does Podkrepi.bg work?" section.
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #1986

## Screenshots:

<!-- You can copy/paste screenshots directly in the editor -->

Before|After
---|---
<img width="1512" alt="image" src="https://github.com/user-attachments/assets/850b91c5-26d3-4fa3-a57a-3bbf108e0d46">|<img width="1510" alt="image" src="https://github.com/user-attachments/assets/148f971a-a524-4b62-8d0f-8d5b122529cc">