### PR TITLE
Lint out console.log-s

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -52,5 +52,6 @@ module.exports = {
         message: 'Please use next-i18next',
       },
     ],
+    no-console: ["error", { allow: ["warn", "error"] }]
   },
 }


### PR DESCRIPTION
This eslint rule will help catch console.log-s and similar in the codd
