### PR TITLE
fix: Retry three times if /me endpoint responds with 401

### DIFF
--- a/src/common/util/useCurrentPerson.ts
+++ b/src/common/util/useCurrentPerson.ts
@@ -44,7 +44,7 @@ export function useCurrentPerson() {
     authQueryFnFactory<CurrentPerson>(session?.accessToken),
     {
       retry: (count, err) => {
-        if (err.isAxiosError && err.response?.status === 401) {
+        if (err.isAxiosError && err.response?.status === 401 && count > 3) {
           return false
         }
         return true


### PR DESCRIPTION
There are edge-cases where the accessToken is expired, before getting refreshed.