### PR TITLE
fix: make subscribe dialog responsive 

### DIFF
--- a/src/components/client/campaigns/CampaignDetails.tsx
+++ b/src/components/client/campaigns/CampaignDetails.tsx
@@ -138,9 +138,6 @@ export default function CampaignDetails({ campaign }: Props) {
         showExpensesLink={(expensesList && expensesList?.length > 0) || canEditCampaign}
       />
       <Grid container spacing={8}>
-        {subscribeIsOpen && (
-          <RenderCampaignSubscribeModal setOpen={setSubscribeOpen} campaign={campaign} />
-        )}
         <Grid item xs={12} display="flex" sx={{ mt: 1.5 }}>
           <EmailIcon
             color="primary"

--- a/src/components/client/notifications/CampaignSubscribeModal.tsx
+++ b/src/components/client/notifications/CampaignSubscribeModal.tsx
@@ -33,7 +33,6 @@ const classes = {
 const StyledGrid = styled(Grid)(({ theme }) => ({
   [`& .${classes.subscribeBtn}`]: {
     fontSize: theme.typography.pxToRem(16),
-    background: `${theme.palette.primary}`,
   },
 }))
 
@@ -116,7 +115,12 @@ export default function RenderCampaignSubscribeModal({ campaign, setOpen }: Moda
             <EmailField
               label="common:notifications.email-descriptive"
               name="email"
-              sx={{ maxWidth: theme.spacing(50) }}
+              sx={{
+                width: '100%',
+                [theme.breakpoints.up('sm')]: {
+                  width: '70%',
+                },
+              }}
             />
           </Grid>
           <Grid item xs={12}>
@@ -124,7 +128,7 @@ export default function RenderCampaignSubscribeModal({ campaign, setOpen }: Moda
           </Grid>
           <Grid item xs={12} textAlign="center">
             <SubmitButton
-              sx={{ width: '40%' }}
+              sx={{ minWidth: theme.spacing(25) }}
               className={classes.subscribeBtn}
               label="common:notifications.cta.subscribe-button"
               loading={loading}
@@ -163,7 +167,7 @@ export default function RenderCampaignSubscribeModal({ campaign, setOpen }: Moda
           }}>
           <CloseModalButton onClose={handleClose} />
           <React.Fragment>
-            <EmailIcon color="primary" sx={{ fontSize: '64px' }} />
+            <EmailIcon color="primary" sx={{ fontSize: theme.typography.pxToRem(64) }} />
             <DialogTitle style={{ textAlign: 'center', width: '100%' }}>
               {t('common:notifications.subscribe-campaign-title')}
             </DialogTitle>
@@ -176,10 +180,23 @@ export default function RenderCampaignSubscribeModal({ campaign, setOpen }: Moda
                       : t('common:notifications.subscribe-text-loggedUser')}
                   </Typography>
                 </Grid>
-                <Grid item xs={12} display="flex" justifyContent="space-evenly">
+                <Grid
+                  item
+                  xs={12}
+                  sx={{
+                    display: 'flex',
+                    justifyContent: 'space-evenly',
+                    flexFlow: 'column',
+                    gap: theme.spacing(2),
+                    alignItems: 'center',
+
+                    [theme.breakpoints.up('sm')]: {
+                      flexFlow: 'row',
+                    },
+                  }}>
                   <SubmitButton
                     type="button"
-                    sx={{ width: '40%' }}
+                    sx={{ minWidth: theme.spacing(25) }}
                     className={classes.subscribeBtn}
                     label={
                       status !== 'authenticated'
@@ -191,7 +208,7 @@ export default function RenderCampaignSubscribeModal({ campaign, setOpen }: Moda
                   />
                   <SubmitButton
                     type="button"
-                    sx={{ width: '40%' }}
+                    sx={{ minWidth: theme.spacing(25) }}
                     variant="outlined"
                     className={classes.subscribeBtn}
                     label={

--- a/src/components/client/notifications/GeneralSubscribeModal.tsx
+++ b/src/components/client/notifications/GeneralSubscribeModal.tsx
@@ -120,7 +120,12 @@ export default function RenderSubscribeModal({ setOpen }: ModalProps) {
             <EmailField
               label={t('common:notifications.email-descriptive')}
               name="email"
-              sx={{ width: '70%' }}
+              sx={{
+                width: '100%',
+                [theme.breakpoints.up('sm')]: {
+                  width: '70%',
+                },
+              }}
             />
           </Grid>
           <Grid item xs={12}>
@@ -128,7 +133,7 @@ export default function RenderSubscribeModal({ setOpen }: ModalProps) {
           </Grid>
           <Grid item xs={12} textAlign="center">
             <SubmitButton
-              sx={{ width: '40%' }}
+              sx={{ minWidth: theme.spacing(25) }}
               className={classes.subscribeBtn}
               label="common:notifications.cta.subscribe-button"
               loading={loading}


### PR DESCRIPTION
Made necessary styling changes to make "Subscribe to campaign news" dialog and "general subscribe" dialog responsive.

Closes #{[1984](https://github.com/podkrepi-bg/frontend/issues/1984)}

## Screenshots:

<!-- You can copy/paste screenshots directly in the editor -->

Before|After
---|---
General Subscription:
![genold2](https://github.com/user-attachments/assets/96910755-661b-4496-9a3c-8e2c6f62f320)|![gennew2](https://github.com/user-attachments/assets/40d5e331-f5f1-4785-a403-a7f216d5bbcd)
Campaign Subscription:
![campold1](https://github.com/user-attachments/assets/67c29fa8-31aa-4871-a33f-0a222d308181)|![campnew1](https://github.com/user-attachments/assets/4ddd7fa1-9464-496d-9660-cdb435e4481b)
![campold2](https://github.com/user-attachments/assets/c594644c-674a-4276-ad92-cabfb2da3a9e)|![campnew2](https://github.com/user-attachments/assets/9daf9ff6-06aa-4689-8fed-b728bbae28df)

## Testing

### Steps to test
Go to https://podkrepi.bg/
Select a campaign.
Choose "Абонирайте се за email известия за кампанията.". Log in as a guest or with your credentials.
Go to mobile view.
Observe the dialog.
