### PR TITLE
fixed dots overlap on section

### DIFF
--- a/src/components/client/index/sections/CompletedCampaignsSection/CompletedCampaignsSection.styled.tsx
+++ b/src/components/client/index/sections/CompletedCampaignsSection/CompletedCampaignsSection.styled.tsx
@@ -16,7 +16,12 @@ export const CarouselWrapper = styled(Slider)(() => ({
   maxWidth: theme.spacing(162),
 
   '.slick-list': {
-    paddingBottom: theme.spacing(3),
+    paddingBottom: theme.spacing(7),
+  },
+
+  '.slick-dots': {
+    position: 'relative',
+    bottom: 'auto',
   },
 
   '.slick-dots li button::before': {

--- a/src/components/client/index/sections/PlatformStatisticsSection/PlatformStatisticsSection.styled.tsx
+++ b/src/components/client/index/sections/PlatformStatisticsSection/PlatformStatisticsSection.styled.tsx
@@ -6,7 +6,7 @@ import LinkButton from 'components/common/LinkButton'
 
 export const Root = styled('section')(() => ({
   backgroundColor: theme.palette.secondary.light,
-  marginTop: theme.spacing(14),
+  marginTop: theme.spacing(10),
 
   [theme.breakpoints.up('md')]: {
     padding: theme.spacing(0),


### PR DESCRIPTION
[screen-capture (2).webm](https://github.com/user-attachments/assets/055c4d01-4210-40b4-b486-16cdd5f76da5)

Slick dots are with relative position instead of absolute. This way we wont see overlaps between different elements.

https://github.com/podkrepi-bg/frontend/issues/2025