### PR TITLE
fix: ensure personId is available in subscription metadata

### DIFF
--- a/src/components/client/donation-flow/steps/authentication/InlineLoginForm.tsx
+++ b/src/components/client/donation-flow/steps/authentication/InlineLoginForm.tsx
@@ -4,9 +4,11 @@ import { useTranslation } from 'next-i18next'
 import { signIn } from 'next-auth/react'
 import { useFormikContext } from 'formik'
 import { Box, Button, CircularProgress, Grid } from '@mui/material'
+import { useQueryClient } from '@tanstack/react-query'
 
 import theme from 'common/theme'
 import Google from 'common/icons/Google'
+import { endpoints } from 'service/apiEndpoints'
 import PasswordField from 'components/common/form/PasswordField'
 import EmailField from 'components/common/form/EmailField'
 import { useDonationFlow } from 'components/client/donation-flow/contexts/DonationFlowProvider'
@@ -37,6 +39,7 @@ function InlineLoginForm() {
   const { t } = useTranslation('donation-flow')
   const [loading, setLoading] = useState(false)
   const { values, setFieldValue } = useFormikContext<DonationFormData>()
+  const queryClient = useQueryClient()
   const { campaign } = useDonationFlow()
   const onGoogleLogin = () => {
     signIn('google', { callbackUrl: routes.campaigns.oneTimeDonation(campaign.slug) })
@@ -55,6 +58,8 @@ function InlineLoginForm() {
         throw new Error(resp.error)
       }
       if (resp?.ok) {
+        // Refetch person data so personId is available for subscription metadata
+        await queryClient.invalidateQueries([endpoints.account.me.url])
         setLoading(false)
         setFieldValue('isAnonymous', false)
         AlertStore.show(t('auth:alerts.welcome'), 'success')

--- a/src/components/client/donation-flow/steps/authentication/InlineRegisterForm.tsx
+++ b/src/components/client/donation-flow/steps/authentication/InlineRegisterForm.tsx
@@ -4,9 +4,11 @@ import * as yup from 'yup'
 import { Button, CircularProgress, FormHelperText, Grid } from '@mui/material'
 import { signIn } from 'next-auth/react'
 import { useTranslation } from 'next-i18next'
+import { useQueryClient } from '@tanstack/react-query'
 
 import theme from 'common/theme'
 import { useRegister } from 'service/auth'
+import { endpoints } from 'service/apiEndpoints'
 import { AlertStore } from 'stores/AlertStore'
 import FormTextField from 'components/common/form/FormTextField'
 import PasswordField from 'components/common/form/PasswordField'
@@ -66,6 +68,7 @@ export default function InlineRegisterForm() {
   const { t } = useTranslation()
   const [loading, setLoading] = useState(false)
   const { mutateAsync: register } = useRegister()
+  const queryClient = useQueryClient()
   const formik = useFormikContext<DonationFormData>()
 
   const values: IndividualRegisterFormData = {
@@ -104,6 +107,8 @@ export default function InlineRegisterForm() {
         throw new Error(resp.error)
       }
       if (resp?.ok) {
+        // Refetch person data so personId is available for subscription metadata
+        await queryClient.invalidateQueries([endpoints.account.me.url])
         setLoading(false)
         AlertStore.show(t('auth:alerts.welcome'), 'success')
         formik.setFieldValue('authentication', DonationFormAuthState.AUTHENTICATED)


### PR DESCRIPTION
This pull request enhances the login and registration steps in the donation flow by ensuring that user account data is refreshed immediately after successful authentication. This guarantees that the latest person information (such as `personId`) is available for subsequent operations, like handling subscription metadata.

**Improvements to authentication data consistency:**

* After a successful login or registration in `InlineLoginForm.tsx` and `InlineRegisterForm.tsx`, the user account data is now refetched by invalidating the relevant React Query cache (`endpoints.account.me.url`). This ensures up-to-date person information is available for downstream processes. [[1]](diffhunk://#diff-244bdc5ee9c6a278f3eef5248056e1747d350a8d43ae1b8b42478fbc439e334cR61-R62) [[2]](diffhunk://#diff-93860dc2654c13229b89ddf8ccd7dc45a2a4f52a2d99a82246c879450506ce1fR110-R111)

**Dependency and hook updates:**

* Added imports for `useQueryClient` from `@tanstack/react-query` and `endpoints` from `service/apiEndpoints` in both authentication components to support cache invalidation. [[1]](diffhunk://#diff-244bdc5ee9c6a278f3eef5248056e1747d350a8d43ae1b8b42478fbc439e334cR7-R11) [[2]](diffhunk://#diff-93860dc2654c13229b89ddf8ccd7dc45a2a4f52a2d99a82246c879450506ce1fR7-R11)
* Initialized `queryClient` using `useQueryClient()` in both `InlineLoginForm` and `InlineRegisterForm` components. [[1]](diffhunk://#diff-244bdc5ee9c6a278f3eef5248056e1747d350a8d43ae1b8b42478fbc439e334cR42) [[2]](diffhunk://#diff-93860dc2654c13229b89ddf8ccd7dc45a2a4f52a2d99a82246c879450506ce1fR71)