### PR TITLE
fix(ci): fix permissions for reusable workflow calls

### DIFF
--- a/.github/workflows/build-frontend-docker.yml
+++ b/.github/workflows/build-frontend-docker.yml
@@ -38,8 +38,6 @@ jobs:
   build:
     name: Build (${{ inputs.environment }})
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,10 @@ on:
     paths-ignore:
       - '**/*.md'
 
+permissions:
+  contents: write
+  packages: write
+
 jobs:
   build-maintenance-image:
     name: Build maintenance container image


### PR DESCRIPTION
The refactor in #2081 moved Docker builds into a reusable workflow
but didn't account for how permissions propagate to nested workflow
calls. This caused the fork PR workflow to fail silently and the
release workflow to fail pushing images to GHCR.

- Remove job-level permissions from build-frontend-docker.yml so it
  inherits from the caller
- Add top-level permissions to release.yml for GHCR push
- Switch check-pr and check-pr-fork to secrets: inherit for nested
  workflow compatibility
- Move validate-env out of tests.yml into check-pr.yml so fork PRs
  get env validation without needing the run tests label